### PR TITLE
Update Durable Functions dependency to v1.8.2

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -17,7 +17,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.1"
+        "version": "1.8.2"
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid",


### PR DESCRIPTION
We recently released Durable Functions [v1.8.2](https://github.com/Azure/azure-functions-durable-extension/releases/tag/v1.8.2). Bundles need to be updated to point to this version.