### PR TITLE
Update Durable Functions extension to 1.8.3

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -17,7 +17,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.2"
+        "version": "1.8.3"
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid",


### PR DESCRIPTION
This PR updates the Azure Functions bundles to the latest version of the Durable Functions nuget extension:
https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.DurableTask/1.8.3

Release notes:
https://github.com/Azure/azure-functions-durable-extension/releases