### PR TITLE
Update DurableTask extension to 1.8.5

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -38,7 +38,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "1.8.3",
+        "version": "1.8.5",
         "name": "DurableTask",
         "bindings": [
             "activitytrigger",


### PR DESCRIPTION
This version contains several fixes for non-C# languages, which still largely use bundles.