### PR TITLE
Upgrade CosmosDB extension to 3.0.7

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -58,7 +58,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
-        "version": "3.0.6",
+        "version": "3.0.7",
         "name": "CosmosDB",
         "bindings": [
             "cosmosdbtrigger",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -58,7 +58,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
-        "version": "3.0.5",
+        "version": "3.0.6",
         "name": "CosmosDB",
         "bindings": [
             "cosmosdbtrigger",


### PR DESCRIPTION
https://github.com/Azure/azure-webjobs-sdk-extensions/releases/tag/cosmos-v3.0.6
https://github.com/Azure/azure-webjobs-sdk-extensions/releases/tag/cosmos-v3.0.7

Introduces support for OFFSET LIMIT queries.