### PR TITLE
Add orchestrationclient for backwards compatibility

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -45,7 +45,8 @@
             "activitytrigger",
             "orchestrationtrigger",
             "entitytrigger",
-            "durableclient"
+            "durableclient",
+            "orchestrationclient"
         ]
     },
     {


### PR DESCRIPTION
Backwards compat for `orchestrationClient` added in 2.2.1 here: https://github.com/Azure/azure-functions-durable-extension/issues/1290

/cc @cgillum @ConnorMcMahon @davidmrdavid 