### PR TITLE
Updating DurableTask version from 2.3.0 to 2.3.1

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -39,7 +39,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "2.3.0",
+        "version": "2.3.1",
         "name": "DurableTask",
         "bindings": [
             "activitytrigger",


### PR DESCRIPTION
Updated `Microsoft.Azure.WebJobs.Extensions.DurableTask` version from `2.3.0` to `2.3.1` in `extensions.json`.