### PR TITLE
[v3.x] Kafka Extension Bundle 

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -61,7 +61,7 @@ namespace Build
 
         public static string ExtensionBundleBuildVersion = "3.1.0";
 
-        public static string TemplatesVersion = "2.0.1642";
+        public static string TemplatesVersion = "2.0.1695";
 
         public static readonly string RUPackagePath = Path.Combine(RootBinDirectory, $"{ExtensionBundleId}.{ExtensionBundleBuildVersion}_RU_package", ExtensionBundleBuildVersion);
 

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -110,5 +110,14 @@
         "rabbitmqtrigger",
         "rabbitmq"
     ]
+  },
+  {
+    "id": "Microsoft.Azure.WebJobs.Extensions.Kafka",
+    "version": "3.2.1",
+    "name": "Kafka",
+    "bindings": [
+        "kafkatrigger",
+        "kafka"
+    ]
   }
 ]


### PR DESCRIPTION
# What is this feature? 

Include [Kafka Extension](https://github.com/Azure/azure-functions-kafka-extension) to this extension bundle. 
Currently no support. 

https://functionscdn.azureedge.net/public/ExtensionBundleTemplates/ExtensionBundle.v2.Templates.2.0.1695.zip


# Question

I talked with Narren and decide the Release of Bundle. 
https://github.com/Azure/azure-functions-templates/releases/tag/bundle-3.1.0

However, the 3.1.0 is already used on this Settings.cs. Is this ok? or should we update it?