### PR TITLE
Updating bundle version (v3.x)

### DIFF
--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -59,7 +59,7 @@ namespace Build
 
         public static string ExtensionBundleVersionRange = "[3.*, 4.0.0)";
 
-        public static string ExtensionBundleBuildVersion = "3.1.0";
+        public static string ExtensionBundleBuildVersion = "3.2.0";
 
         public static string TemplatesVersion = "2.0.1701";
 


### PR DESCRIPTION
Updated bundle version.

No update to template version (still on 2.0.1701.)