### PR TITLE
Update DurableTask version to 2.4.3

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -39,7 +39,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "2.4.2",
+        "version": "2.4.3",
         "name": "DurableTask",
         "bindings": [
             "activitytrigger",


### PR DESCRIPTION
Updated `Microsoft.Azure.WebJobs.Extensions.DurableTask` version from 2.4.2 to 2.4.3 in extensions.json.