### PR TITLE
Update DurableTask version to 2.4.3 in v3 extension bundles

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -56,7 +56,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "name": "DurableTask",
     "bindings": [
       "activitytrigger",


### PR DESCRIPTION
Updated `Microsoft.Azure.WebJobs.Extensions.DurableTask` version from 2.4.2 to 2.4.3 in extensions.json.