### PR TITLE
Update SignalR version to 1.4.2 in v2

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -77,12 +77,14 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
-        "version": "1.2.2",
+        "version": "1.4.0",
         "name": "SignalR",
         "bindings": [
             "signalr",
             "signalrconnectioninfo",
-            "signalrtrigger"
+            "signalrtrigger",
+            "signalrendpoints",
+            "signalrnegotiation"
         ]
     },
     {

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -77,7 +77,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
-        "version": "1.4.1",
+        "version": "1.4.2",
         "name": "SignalR",
         "bindings": [
             "signalr",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -77,7 +77,7 @@
     },
     {
         "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "name": "SignalR",
         "bindings": [
             "signalr",


### PR DESCRIPTION
And I have a little more questions.  The target framework of `Microsoft.Azure.WebJobs.Extensions.SignalRService` have changed from netstandard2.0 to netcoreapp2.1 and netcoreapp3.1 as it has different dependencies on netcoreapp2.1 and netcoreapp3.1.  My question is what is v3.x extension bundles used for and whether SignalR extension should update in v3.x.