### PR TITLE
Update DurableTask version to 2.5.1 in v3 extension bundles

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -56,7 +56,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "name": "DurableTask",
     "bindings": [
       "activitytrigger",


### PR DESCRIPTION
Updated `Microsoft.Azure.WebJobs.Extensions.DurableTask` version from 2.5.0 to 2.5.1 in extensions.json.