### PR TITLE
Add support for new Durable Functions backends

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        },
+        {
+            "name": "Launch Build",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": ["run", "skip:PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux,PackageNetCoreV2Bundle,BundlePackageNetCoreV2Any"],
+            "cwd": "${workspaceFolder}/build",
+            "stopAtEntry": true,
+            "console": "internalConsole"
+        }
+
+    ]
+}

--- a/build/BuildConfiguration.cs
+++ b/build/BuildConfiguration.cs
@@ -18,6 +18,8 @@ namespace Build
         public string PublishBinDirectoryPath => Path.Combine(PublishDirectoryPath, PublishBinDirectorySubPath);
 
         public string PublishBinDirectorySubPath { get; set; }
+
+        public double DotNetVersion { get; set; }
     }
 
 }

--- a/build/Extension.cs
+++ b/build/Extension.cs
@@ -18,5 +18,8 @@ namespace Build
 
         [JsonProperty(PropertyName = "bindings")]
         public List<string> Bindings { get; set; }
+
+        [JsonProperty(PropertyName = "minDotNetVersion")]
+        public double? MinDotNetVersion { get; set; }
     }
 }

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -83,8 +83,8 @@ namespace Build
                 SourceProjectFileName = "extensions.csproj",
                 RuntimeIdentifier = "any",
                 PublishReadyToRun = false,
-                PublishBinDirectorySubPath = "bin"
-
+                PublishBinDirectorySubPath = "bin",
+                DotNetVersion = 2.2,
             },
             new BuildConfiguration()
             {
@@ -92,7 +92,8 @@ namespace Build
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "win-x86",
                 PublishReadyToRun = true,
-                PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x86")
+                PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x86"),
+                DotNetVersion = 3.1,
             },
             new BuildConfiguration()
             {
@@ -100,7 +101,8 @@ namespace Build
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "win-x64",
                 PublishReadyToRun = true,
-                PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x64")
+                PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x64"),
+                DotNetVersion = 3.1,
             },
             new BuildConfiguration()
             {
@@ -108,7 +110,8 @@ namespace Build
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "any",
                 PublishReadyToRun = false,
-                PublishBinDirectorySubPath = "bin"
+                PublishBinDirectorySubPath = Path.Combine("bin_v3", "any"),
+                DotNetVersion = 3.1,
             }
         };
 
@@ -120,7 +123,8 @@ namespace Build
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "linux-x64",
                 PublishReadyToRun = true,
-                PublishBinDirectorySubPath = Path.Combine("bin_v3", "linux-x64")
+                PublishBinDirectorySubPath = Path.Combine("bin_v3", "linux-x64"),
+                DotNetVersion = 3,
             },
             new BuildConfiguration()
             {
@@ -128,7 +132,8 @@ namespace Build
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "any",
                 PublishReadyToRun = false,
-                PublishBinDirectorySubPath = "bin"
+                PublishBinDirectorySubPath = "bin",
+                DotNetVersion = 3,
             }
         };
 
@@ -143,7 +148,7 @@ namespace Build
 
         public static BundlePackageConfiguration BundlePackageNetCoreV2Any = new BundlePackageConfiguration()
         {
-            PackageIdentifier = string.Empty,
+            PackageIdentifier = "v2-any",
             ConfigBinariesToInclude = new List<ConfigId>() {
                 ConfigId.NetCoreApp2_any_any
             },
@@ -152,7 +157,7 @@ namespace Build
 
         public static BundlePackageConfiguration BundlePackageNetCoreV3Any = new BundlePackageConfiguration()
         {
-            PackageIdentifier = "any-any",
+            PackageIdentifier = "v3-any",
             ConfigBinariesToInclude = new List<ConfigId>() {
                 ConfigId.NetCoreApp3_any_any
             },
@@ -164,6 +169,7 @@ namespace Build
             PackageIdentifier = "win-any",
             ConfigBinariesToInclude = new List<ConfigId>() {
                 ConfigId.NetCoreApp2_any_any,
+                ConfigId.NetCoreApp3_any_any,
                 ConfigId.NetCoreApp3_win_x86,
                 ConfigId.NetCoreApp3_win_x64
             },

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -67,6 +67,32 @@
     ]
   },
   {
+    "id": "Microsoft.DurableTask.SqlServer.AzureFunctions",
+    "version": "0.10.1-beta",
+    "name": "SqlDurabilityProviderStartup",
+    "bindings": [
+      "activitytrigger",
+      "orchestrationtrigger",
+      "entitytrigger",
+      "durableclient",
+      "orchestrationclient"
+    ],
+    "minDotNetVersion": 3.1
+  },
+  {
+    "id": "Microsoft.Azure.DurableTask.Netherite",
+    "version": "0.5.0-alpha",
+    "name": "NetheriteProviderStartup",
+    "bindings": [
+      "activitytrigger",
+      "orchestrationtrigger",
+      "entitytrigger",
+      "durableclient",
+      "orchestrationclient"
+    ],
+    "minDotNetVersion": 3.1
+  },
+  {
     "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
     "version": "3.0.0-beta.3",
     "name": "EventGrid",


### PR DESCRIPTION
Adds new backends for Durable Functions to v3 bundles. In order to
support this, additional changes were made to ensure that the new
extensions were only built in .NET Core 3.1 or greater, as the
extensions rely on .NET Standard 2.1. Therefore, we can not build them
in the v2 bits, so additional metadata was added to reflect this.

Changes will also need to be made to Functions Host to properly load
v3_any bits for the local dev experience.

Once the extensions are more stable, they should also be added to v2
bundles as well.