### PR TITLE
Add Netherite backend to V2

### DIFF
--- a/build/BuildConfiguration.cs
+++ b/build/BuildConfiguration.cs
@@ -13,6 +13,8 @@ namespace Build
 
         public bool PublishReadyToRun { get; set; }
 
+        public bool SuppressTfmSupportBuildWarnings { get; set; }
+
         public string PublishDirectoryPath => Path.Combine(Settings.RootBinDirectory, $"{ConfigId}");
 
         public string PublishBinDirectoryPath => Path.Combine(PublishDirectoryPath, PublishBinDirectorySubPath);

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -137,6 +137,11 @@ namespace Build
                 publishCommandArguments += $" /p:PublishReadyToRun=true";
             }
 
+            if (buildConfig.SuppressTfmSupportBuildWarnings)
+            {
+                publishCommandArguments += " /p:SuppressTfmSupportBuildWarnings=true";
+            }
+
             Shell.Run("dotnet", publishCommandArguments);
 
             if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -63,6 +63,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp2_any_any,
                 SourceProjectFileName = "extensions.csproj",
                 RuntimeIdentifier = "any",
+                SuppressTfmSupportBuildWarnings = true,
                 PublishReadyToRun = false,
                 PublishBinDirectorySubPath = "bin"
 
@@ -72,6 +73,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_win_x86,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "win-x86",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = true,
                 PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x86")
             },
@@ -80,6 +82,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_win_x64,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "win-x64",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = true,
                 PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x64")
             },
@@ -88,6 +91,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_any_any,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "any",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = false,
                 PublishBinDirectorySubPath = "bin"
             }
@@ -100,6 +104,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_linux_x64,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "linux-x64",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = true,
                 PublishBinDirectorySubPath = Path.Combine("bin_v3", "linux-x64")
             },
@@ -108,6 +113,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_any_any,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "any",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = false,
                 PublishBinDirectorySubPath = "bin"
             }

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -50,6 +50,18 @@
         ]
     },
     {
+        "id": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
+        "majorVersion": "1",
+        "name": "NetheriteProviderStartup",
+        "bindings": [
+          "activitytrigger",
+          "orchestrationtrigger",
+          "entitytrigger",
+          "durableclient",
+          "orchestrationclient"
+        ]
+    },
+    {
         "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
         "majorVersion": "2",
         "name": "EventGrid",


### PR DESCRIPTION
Adds a reference to the new Netherite backend for Durable Functions.
Supercedes https://github.com/Azure/azure-functions-extension-bundles/pull/121

A GA-ready build of Netherite is being pushed to Nuget right now. By the time this PR is merged, and bundles is released, the GA Netherite package should be on Nuget