### PR TITLE
Add Netherite backend to V3

### DIFF
--- a/build/BuildConfiguration.cs
+++ b/build/BuildConfiguration.cs
@@ -13,6 +13,8 @@ namespace Build
 
         public bool PublishReadyToRun { get; set; }
 
+        public bool SuppressTfmSupportBuildWarnings { get; set; }
+
         public string PublishDirectoryPath => Path.Combine(Settings.RootBinDirectory, $"{ConfigId}");
 
         public string PublishBinDirectoryPath => Path.Combine(PublishDirectoryPath, PublishBinDirectorySubPath);

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -154,6 +154,11 @@ namespace Build
                 publishCommandArguments += $" /p:PublishReadyToRun=true";
             }
 
+            if (buildConfig.SuppressTfmSupportBuildWarnings)
+            {
+                publishCommandArguments += " /p:SuppressTfmSupportBuildWarnings=true";
+            }
+
             Shell.Run("dotnet", publishCommandArguments);
 
             if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -74,6 +74,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp2_any_any,
                 SourceProjectFileName = "extensions.csproj",
                 RuntimeIdentifier = "any",
+                SuppressTfmSupportBuildWarnings = true,
                 PublishReadyToRun = false,
                 PublishBinDirectorySubPath = "bin"
 
@@ -83,6 +84,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_win_x86,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "win-x86",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = true,
                 PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x86")
             },
@@ -91,6 +93,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_win_x64,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "win-x64",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = true,
                 PublishBinDirectorySubPath = Path.Combine("bin_v3", "win-x64")
             },
@@ -99,6 +102,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_any_any,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "any",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = false,
                 PublishBinDirectorySubPath = "bin"
             }
@@ -111,6 +115,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_linux_x64,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "linux-x64",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = true,
                 PublishBinDirectorySubPath = Path.Combine("bin_v3", "linux-x64")
             },
@@ -119,6 +124,7 @@ namespace Build
                 ConfigId = ConfigId.NetCoreApp3_any_any,
                 SourceProjectFileName = "extensions_netcoreapp3.csproj",
                 RuntimeIdentifier = "any",
+                SuppressTfmSupportBuildWarnings = false,
                 PublishReadyToRun = false,
                 PublishBinDirectorySubPath = "bin"
             }

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -67,6 +67,18 @@
     ]
   },
   {
+    "id": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
+    "majorVersion": "1",
+    "name": "NetheriteProviderStartup",
+    "bindings": [
+      "activitytrigger",
+      "orchestrationtrigger",
+      "entitytrigger",
+      "durableclient",
+      "orchestrationclient"
+    ]
+  },
+  {
     "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
     "majorVersion": "3",
     "name": "EventGrid",


### PR DESCRIPTION
Adds a reference to the new Netherite backend for Durable Functions.
Supercedes https://github.com/Azure/azure-functions-extension-bundles/pull/121

A GA-ready build of Netherite is being pushed to Nuget right now. By the time this PR is merged, and bundles is released, the GA Netherite package should be on Nuget