### PR TITLE
adding new Tables extension to V3 bundle

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -29,6 +29,14 @@
     ]
   },
   {
+    "id": "Microsoft.Azure.WebJobs.Extensions.Tables",
+    "majorVersion": "1",
+    "name": "AzureTables",
+    "bindings": [
+      "table"
+    ]
+  },
+  {
     "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
     "majorVersion": "5",
     "name": "ServiceBus",


### PR DESCRIPTION
Adding Tables package to V3 bundle per recent GA package release: https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Tables/1.0.0