### PR TITLE
Add new Tables extension to V3

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -11,6 +11,14 @@
     ]
   },
   {
+    "id": "Microsoft.Azure.WebJobs.Extensions.Tables",
+    "majorVersion": "1",
+    "name": "AzureTables",
+    "bindings": [
+      "table"
+    ]
+  },
+  {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
     "majorVersion": "5",
     "name": "AzureStorageQueues",


### PR DESCRIPTION
Supercedes: https://github.com/Azure/azure-functions-extension-bundles/pull/151

Adding Tables package to V3 bundle per recent GA package release: https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Tables/1.0.0