### PR TITLE
Add clear to nuget.config (v3.x-preview)

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="azureSdk" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>  


### PR DESCRIPTION
Without clear the nuget config will pick up whatever other sources a user may have configured, which could cause conflicts or authentication issues. Clearing the sources before adding the ones ensures that people building will always get the packages from the correct sources.