### PR TITLE
Add Durable Functions MSSQL backend extension

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -62,6 +62,18 @@
         ]
     },
     {
+        "id": "Microsoft.DurableTask.SqlServer.AzureFunctions",
+        "majorVersion": "1",
+        "name": "SqlDurabilityProvider",
+        "bindings": [
+          "activitytrigger",
+          "orchestrationtrigger",
+          "entitytrigger",
+          "durableclient",
+          "orchestrationclient"
+        ]
+    },
+    {
         "id": "Microsoft.Azure.WebJobs.Extensions.EventGrid",
         "majorVersion": "2",
         "name": "EventGrid",


### PR DESCRIPTION
Now that the Durable Task MSSQL backend has reached v1.0.0 (GA), it should be safe to add to GA extension bundles.