### PR TITLE
[4.x] Add additional assemblies

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -179,8 +179,6 @@ namespace Build
 
             Shell.Run("dotnet", publishCommandArguments);
 
-            // Temporary fix to copy assembly needed for cosmosDb extension
-            var additionalAssembliesPath = Path.Combine(Directory.GetParent(projectFilePath).FullName, "bin" , "Release", "netcoreapp3.1", buildConfig.RuntimeIdentifier == "any" ? String.Empty : buildConfig.RuntimeIdentifier, "System.Configuration.ConfigurationManager.dll");
             if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)
             {
                 FileUtility.EnsureDirectoryExists(Directory.GetParent(buildConfig.PublishBinDirectoryPath).FullName);
@@ -188,7 +186,13 @@ namespace Build
             }
 
             // Temporary fix to copy assembly needed for cosmosDb extension
-            File.Copy(additionalAssembliesPath, Path.Combine(buildConfig.PublishBinDirectoryPath, "System.Configuration.ConfigurationManager.dll"));
+            var additionalAssembliesPath = Path.Combine(Directory.GetParent(projectFilePath).FullName, "bin", "Release", "netcoreapp3.1", buildConfig.RuntimeIdentifier == "any" ? String.Empty : buildConfig.RuntimeIdentifier);
+
+            var configAssembly = "System.Configuration.ConfigurationManager.dll";
+            File.Copy(Path.Combine(additionalAssembliesPath, configAssembly), Path.Combine(buildConfig.PublishBinDirectoryPath, configAssembly));
+
+            var permissionsAssembly = "System.Security.Permissions.dll";
+            File.Copy(Path.Combine(additionalAssembliesPath, permissionsAssembly), Path.Combine(buildConfig.PublishBinDirectoryPath, permissionsAssembly));
         }
 
         public static void AddBindingInfoToExtensionsJson(string extensionsJson)


### PR DESCRIPTION
Porting fix from 4.x-preview done in https://github.com/Azure/azure-functions-extension-bundles/pull/234/files