### PR TITLE
Adding .NET 3.1 dependency

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,10 @@ jobs:
     - ImageOverride -equals MMS2019TLS
 
   steps:
+  - task: SetupDotNet@v1
+    inputs:
+      packageType: 'sdk'
+      version: '3.1.100'
   - task: UseDotNet@2
     inputs:
       packageType: 'sdk'


### PR DESCRIPTION
Pipelines deprecated .NET 3.1 but we still need it for testing.