### PR TITLE
Hotfix: DF Extension version explicitly to 2.12.0

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -64,7 +64,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-    "Version": "2.10.0",
+    "Version": "2.12.0",
     "name": "DurableTask",
     "bindings": [
       "activitytrigger",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -38,7 +38,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.ServiceBus",
-    "majorVersion": "5",
+    "Version": "5.12.0",
     "name": "ServiceBus",
     "bindings": [
       "servicebustrigger",
@@ -109,7 +109,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
-    "majorVersion": "4",
+    "Version": "4.4.0",
     "name": "CosmosDB",
     "bindings": [
       "cosmosdbtrigger",
@@ -175,7 +175,7 @@
   },
   {
     "id": "Azure.Storage.Queues",
-    "majorVersion": "12",
+    "Version": "12.16.0",
     "name": "AzureStorageQueues",
     "bindings": []
   },

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -64,7 +64,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-    "majorVersion": "2",
+    "Version": "2.10.0",
     "name": "DurableTask",
     "bindings": [
       "activitytrigger",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -88,7 +88,7 @@
   },
   {
     "id": "Microsoft.Azure.DurableTask.Netherite.AzureFunctions",
-    "majorVersion": "1",
+    "Version": "1.4.0",
     "name": "NetheriteProvider",
     "bindings": [
       "activitytrigger",


### PR DESCRIPTION
~As in title, since version 2.11.x has known regressions when interacting with the Netherite backend.~
Update: please see this: https://github.com/Azure/azure-functions-extension-bundles/pull/315#issuecomment-1796290708