### PR TITLE
unpin DF packages (v3.x)

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -64,7 +64,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-    "Version": "2.12.0",
+    "majorVersion": "2",
     "name": "DurableTask",
     "bindings": [
       "activitytrigger",
@@ -88,7 +88,7 @@
   },
   {
     "id": "Microsoft.DurableTask.SqlServer.AzureFunctions",
-    "Version": "1.2.1",
+    "majorVersion": "1",
     "name": "SqlDurabilityProvider",
     "bindings": [
       "activitytrigger",


### PR DESCRIPTION
We recently pinned the DF packages due to a bug that we did not want customers to pick up on (https://github.com/Azure/azure-functions-extension-bundles/pull/354). The bug was fixed in the most recent DF release, so we can now unpin these versions.

