### PR TITLE
Pin Microsoft.Identity.Client to 4.60.3 (v4.x)

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -181,6 +181,12 @@
     "bindings": []
   },
   {
+    "id": "Microsoft.Identity.Client",
+    "Version": "4.60.3",
+    "name": "AzureIdentityClient",
+    "bindings": []
+  },
+  {
     "id": "Azure.Storage.Queues",
     "majorVersion": "12",
     "name": "AzureStorageQueues",


### PR DESCRIPTION
Pin `Microsoft.Identity.Client` to 4.60.3