### PR TITLE
Pin Microsoft.Identity.Client to 4.60.3 (v2.x) 

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -166,6 +166,12 @@
     "bindings": []
   },
   {
+    "id": "Microsoft.Identity.Client",
+    "Version": "4.60.3",
+    "name": "AzureIdentityClient",
+    "bindings": []
+  },
+  {
     "id": "Microsoft.Data.SqlClient",
     "Version": "3.1.5",
     "name": "MicrosoftDataSqlClient",


### PR DESCRIPTION
Pin `Microsoft.Identity.Client` to 4.60.3