### PR TITLE
Updating build dependencies to address the dependency check failure and the vulnerability check

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -158,5 +158,29 @@
     "Version": "4.3.2",
     "name": "SystemPrivateUri",
     "bindings": []
+  },
+  {
+    "id": "Azure.Identity",
+    "Version": "1.11.4",
+    "name": "AzureIdentity",
+    "bindings": []
+  },
+  {
+    "id": "Microsoft.Data.SqlClient",
+    "Version": "3.1.5",
+    "name": "MicrosoftDataSqlClient",
+    "bindings": []
+  },
+  {
+    "id": "Microsoft.IdentityModel.JsonWebTokens",
+    "Version": "6.34.0",
+    "name": "SystemIdentityModelTokensJwt",
+    "bindings": []
+  },
+  {
+    "id": "System.IdentityModel.Tokens.Jwt",
+    "Version": "6.34.0",
+    "name": "SystemIdentityModelTokensJwt",
+    "bindings": []
   }
 ]

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -158,35 +158,5 @@
     "Version": "4.3.2",
     "name": "SystemPrivateUri",
     "bindings": []
-  },
-  {
-    "id": "Azure.Identity",
-    "Version": "1.11.0",
-    "name": "AzureIdentity",
-    "bindings": []
-  },
-  {
-    "id": "Microsoft.Identity.Client",
-    "Version": "4.60.3",
-    "name": "AzureIdentityClient",
-    "bindings": []
-  },
-  {
-    "id": "Microsoft.Data.SqlClient",
-    "Version": "3.1.5",
-    "name": "MicrosoftDataSqlClient",
-    "bindings": []
-  },
-  {
-    "id": "Microsoft.IdentityModel.JsonWebTokens",
-    "Version": "6.34.0",
-    "name": "SystemIdentityModelTokensJwt",
-    "bindings": []
-  },
-  {
-    "id": "System.IdentityModel.Tokens.Jwt",
-    "Version": "6.34.0",
-    "name": "SystemIdentityModelTokensJwt",
-    "bindings": []
   }
 ]


### PR DESCRIPTION
- Updating Azure.Identity from 1.11.0 to 1.11.4 to address CVE vulnerability https://github.com/advisories/GHSA-m5vv-6r4h-3vj9
- Removing explicit reference to Microsoft.Identity.Client - 4.60.3 as it updated to version 4.61.3 as a transitive dependency by Azure.Identity