### PR TITLE
Adding Fabric Host Extension To Preview Branch

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -237,5 +237,14 @@
       "SemanticSearch",
       "EmbeddingsStore"
     ]
+  },
+  {
+    "id": "Microsoft.Azure.WebJobs.Extensions.Fabric",
+    "majorVersion": "0",
+    "name": "Startup",
+    "bindings": [
+      "fabricItem",
+      "udfProperty"
+    ]
   }
 ]


### PR DESCRIPTION
This PR adds the Microsoft Fabric UDF Functions host extension to the list of extensions available in the preview extension bundle for Azure Functions. 