### PR TITLE
Fix v4.x tests and dapr major version bump

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 #
 
-* @azure-functions-extensions-bundle-admins
+* @azure/azure-functions-extensions-bundle-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 #
 
-* @azure/azure-functions-core
+* @azure/azure-functions-extensions-bundle-admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 #
 
-* @azure/azure-functions-extensions-bundle-admins
+* @azure-functions-extensions-bundle-admins

--- a/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -1057,8 +1057,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -1271,8 +1271,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -2574,8 +2574,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+            "assemblyVersion": "6.0.0.0",
+            "fileVersion": "6.0.21.52210"
           }
         }
       },

--- a/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
@@ -911,8 +911,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -1125,8 +1125,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -2479,8 +2479,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+            "assemblyVersion": "6.0.0.0",
+            "fileVersion": "6.0.21.52210"
           }
         }
       },

--- a/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -937,8 +937,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -1151,8 +1151,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -2499,8 +2499,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+            "assemblyVersion": "6.0.0.0",
+            "fileVersion": "6.0.21.52210"
           }
         }
       },

--- a/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -926,8 +926,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -1140,8 +1140,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
-            "assemblyVersion": "99.99.99.0",
-            "fileVersion": "99.99.99.0"
+            "assemblyVersion": "0.0.0.0",
+            "fileVersion": "0.0.0.0"
           }
         }
       },
@@ -2488,8 +2488,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+            "assemblyVersion": "6.0.0.0",
+            "fileVersion": "6.0.21.52210"
           }
         }
       },

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -34,7 +34,7 @@ jobs:
       command: 'run'
       workingDirectory: '.\build'
       ${{ if eq(parameters.official, false) }}:
-        arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
+        arguments: 'skip:DownloadTemplates,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
 
   - ${{ if eq(parameters.official, true) }}:
     - task: CopyFiles@2

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.csproj
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.csproj
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.csproj
@@ -5,6 +5,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
-    <PackageReference Include="MessagePack" Version="2.5.187" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
 Changed:
    - Microsoft.Azure.Functions.Extensions.Dapr.Core.dll: 99.99.99.0/99.99.99.0 -> 0.0.0.0/0.0.0.0
    - Microsoft.Azure.WebJobs.Extensions.Dapr.dll: 99.99.99.0/99.99.99.0 -> 0.0.0.0/0.0.0.0
    - System.Memory.Data.dll: 1.0.2.0/1.0.221.20802 -> 6.0.0.0/6.0.21.52210

https://azfunc.visualstudio.com/internal/_TestManagement/Runs?_a=resultSummary&runId=1446268&resultId=100002