### PR TITLE
codeql: remove dead code to resolve code ql issue

### DIFF
--- a/build/Extension.cs
+++ b/build/Extension.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Build
 {

--- a/build/FileUtility.cs
+++ b/build/FileUtility.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
-using System.IO.Compression;
-using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Build
 {
@@ -20,118 +16,12 @@ namespace Build
             set { _instance = value; }
         }
 
-        public static void RecursiveCopy(string sourcePath, string destinationPath)
-        {
-            // Get the subdirectories for the specified directory.
-            var dir = new DirectoryInfo(sourcePath);
-
-            if (!dir.Exists)
-            {
-                throw new DirectoryNotFoundException(
-                    "Source directory does not exist or could not be found: "
-                    + sourcePath);
-            }
-
-            var dirs = dir.GetDirectories();
-            // If the destination directory doesn't exist, create it.
-            if (!Directory.Exists(destinationPath))
-            {
-                Directory.CreateDirectory(destinationPath);
-            }
-
-            // Get the files in the directory and copy them to the new location.
-            var files = dir.GetFiles();
-            foreach (var file in files)
-            {
-                var temppath = Path.Combine(destinationPath, file.Name);
-                file.CopyTo(temppath, false);
-            }
-
-            // If copying subdirectories, copy them and their contents to new location.
-            foreach (var subdir in dirs)
-            {
-                var temppath = Path.Combine(destinationPath, subdir.Name);
-                RecursiveCopy(subdir.FullName, temppath);
-            }
-        }
-
-        public static void ExtractZipFileForce(string zipFile, string to)
-        {
-            using var archive = ZipFile.OpenRead(zipFile);
-            foreach (ZipArchiveEntry file in archive.Entries)
-            {
-                string destinationPath = Path.GetFullPath(Path.Combine(to, file.FullName));
-
-                // Ensure the destination path is within the target directory
-                if (!destinationPath.StartsWith(Path.GetFullPath(to), StringComparison.Ordinal))
-                {
-                    throw new UnauthorizedAccessException($"Entry '{file.FullName}' is outside the target directory.");
-                }
-
-                file.ExtractToFile(destinationPath, overwrite: true);
-            }
-        }
-
-        public static void CreateZipFile(IEnumerable<string> files, string baseDir, string zipFilePath)
-        {
-            using (var zipfile = ZipFile.Open(zipFilePath, ZipArchiveMode.Create))
-            {
-                foreach (var file in files)
-                {
-                    zipfile.CreateEntryFromFile(file, Path.GetRelativePath(baseDir, file), CompressionLevel.NoCompression);
-                }
-            }
-        }
-
-        public static string ReadResourceString(string resourcePath, Assembly assembly = null)
-        {
-            assembly = assembly ?? Assembly.GetCallingAssembly();
-            using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourcePath)))
-            {
-                return reader.ReadToEnd();
-            }
-        }
-
         public static void EnsureDirectoryExists(string path)
         {
             if (!Instance.Directory.Exists(path))
             {
                 Instance.Directory.CreateDirectory(path);
             }
-        }
-
-        public static Task DeleteDirectoryAsync(string path, bool recursive)
-        {
-            return Task.Run(() =>
-            {
-                if (Instance.Directory.Exists(path))
-                {
-                    Instance.Directory.Delete(path, recursive);
-                }
-            });
-        }
-
-        public static void DeleteDirectory(string path, bool recursive)
-        {
-            if (Instance.Directory.Exists(path))
-            {
-                Instance.Directory.Delete(path, recursive);
-                System.Threading.Thread.Sleep(1000);
-            }
-
-        }
-
-        public static Task<bool> DeleteIfExistsAsync(string path)
-        {
-            return Task.Run(() =>
-            {
-                if (Instance.File.Exists(path))
-                {
-                    Instance.File.Delete(path);
-                    return true;
-                }
-                return false;
-            });
         }
 
         public static void Write(string path, string contents, Encoding encoding = null)
@@ -157,89 +47,11 @@ namespace Build
             fileStream.Close();
         }
 
-        public static async Task<string> ReadAsync(string path, Encoding encoding = null)
-        {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            encoding = encoding ?? Encoding.UTF8;
-            using (var fileStream = OpenFile(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
-            using (var reader = new StreamReader(fileStream, encoding, true, 4096))
-            {
-                return await reader.ReadToEndAsync();
-            }
-        }
-
         public static string ReadAllText(string path) => Instance.File.ReadAllText(path);
 
         public static Stream OpenFile(string path, FileMode mode, FileAccess access = FileAccess.ReadWrite, FileShare share = FileShare.None)
         {
             return Instance.File.Open(path, mode, access, share);
-        }
-
-        public static string GetRelativePath(string path1, string path2)
-        {
-            if (path1 == null)
-            {
-                throw new ArgumentNullException(nameof(path1));
-            }
-
-            if (path2 == null)
-            {
-                throw new ArgumentNullException(nameof(path2));
-            }
-
-            string EnsureTrailingSeparator(string path)
-            {
-                if (!Path.HasExtension(path) && !path.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                {
-                    path = path + Path.DirectorySeparatorChar;
-                }
-
-                return path;
-            }
-
-            path1 = EnsureTrailingSeparator(path1);
-            path2 = EnsureTrailingSeparator(path2);
-
-            var uri1 = new Uri(path1);
-            var uri2 = new Uri(path2);
-
-            Uri relativeUri = uri1.MakeRelativeUri(uri2);
-            string relativePath = Uri.UnescapeDataString(relativeUri.ToString())
-                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-
-            return relativePath;
-        }
-
-        public static Task<string[]> GetFilesAsync(string path, string prefix)
-        {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
-            return Task.Run(() =>
-            {
-                return Instance.Directory.GetFiles(path, prefix);
-            });
-        }
-
-        public static string[] GetFiles(string path)
-        {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            return Instance.Directory.GetFiles(path);
         }
 
         public static void CopyFile(string sourcePath, string targetPath)
@@ -268,12 +80,6 @@ namespace Build
         public static bool FileExists(string path) => Instance.File.Exists(path);
 
         public static bool DirectoryExists(string path) => Instance.Directory.Exists(path);
-
-        public static DirectoryInfoBase DirectoryInfoFromDirectoryName(string localSiteRootPath) => Instance.DirectoryInfo.FromDirectoryName(localSiteRootPath);
-
-        public static FileInfoBase FileInfoFromFileName(string localFilePath) => Instance.FileInfo.FromFileName(localFilePath);
-
-        public static string GetFullPath(string path) => Instance.Path.GetFullPath(path);
 
         private static void DeleteDirectoryContentsSafe(DirectoryInfoBase directoryInfo, bool ignoreErrors)
         {
@@ -314,38 +120,6 @@ namespace Build
 
             DoSafeAction(fileSystemInfo.Delete, ignoreErrors);
         }
-
-        public static void DeleteDirectoryContentsSafe(string path, bool ignoreErrors = true)
-        {
-            try
-            {
-                var directoryInfo = DirectoryInfoFromDirectoryName(path);
-                if (directoryInfo.Exists)
-                {
-                    foreach (var fsi in directoryInfo.GetFileSystemInfos())
-                    {
-                        DeleteFileSystemInfo(fsi, ignoreErrors);
-                    }
-                }
-            }
-            catch when (ignoreErrors)
-            {
-            }
-        }
-
-        public static void DeleteFileSafe(string path)
-        {
-            try
-            {
-                var info = FileInfoFromFileName(path);
-                DeleteFileSystemInfo(info, ignoreErrors: true);
-            }
-            catch
-            {
-            }
-        }
-
-        public static IEnumerable<string> EnumerateDirectories(string path) => Instance.Directory.EnumerateDirectories(path);
 
         private static void DoSafeAction(Action action, bool ignoreErrors)
         {

--- a/build/FileUtility.cs
+++ b/build/FileUtility.cs
@@ -65,7 +65,7 @@ namespace Build
                 // Ensure the destination path is within the target directory
                 if (!destinationPath.StartsWith(Path.GetFullPath(to), StringComparison.Ordinal))
                 {
-                    throw new UnauthorizedAccessException("Entry is outside the target directory.");
+                    throw new UnauthorizedAccessException($"Entry '{file.FullName}' is outside the target directory.");
                 }
 
                 file.ExtractToFile(destinationPath, overwrite: true);

--- a/build/FileUtility.cs
+++ b/build/FileUtility.cs
@@ -57,12 +57,18 @@ namespace Build
 
         public static void ExtractZipFileForce(string zipFile, string to)
         {
-            using (var archive = ZipFile.OpenRead(zipFile))
+            using var archive = ZipFile.OpenRead(zipFile);
+            foreach (ZipArchiveEntry file in archive.Entries)
             {
-                foreach (ZipArchiveEntry file in archive.Entries)
+                string destinationPath = Path.GetFullPath(Path.Combine(to, file.FullName));
+
+                // Ensure the destination path is within the target directory
+                if (!destinationPath.StartsWith(Path.GetFullPath(to), StringComparison.Ordinal))
                 {
-                    file.ExtractToFile(Path.Combine(to, file.FullName), overwrite: true);
+                    throw new UnauthorizedAccessException("Entry is outside the target directory.");
                 }
+
+                file.ExtractToFile(destinationPath, overwrite: true);
             }
         }
 

--- a/build/IndexV2.cs
+++ b/build/IndexV2.cs
@@ -1,15 +1,9 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Build
 {
     public class IndexV2
     {
-        public string DefaultVersionRange { get; set; } = "[3.*, 4.0.0)";
-
         public Dictionary<string, Dictionary<string, string>> BundleVersions { get; set; } = new Dictionary<string, Dictionary<string, string>>();
 
         public Template Templates { get; set; } = new Template();

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Net;
-using static Build.BuildSteps;
+﻿using static Build.BuildSteps;
 
 namespace Build
 {

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using static Build.BasePath;
 
 namespace Build


### PR DESCRIPTION
Addressing CodeQL issue to ensure that the file is being placed inside the target directory - the method has no reference, removing it and also using this opportunity to remove more dead code.

Removed unused using statements too