### PR TITLE
Merge release/v4.x-preview-hotfix into release/v4.x-preview

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,6 +1,6 @@
 ﻿{
     "bundleId":  "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-    "bundleVersion":  "4.26.1",
+    "bundleVersion":  "4.26.2",
     "templateVersion":  "4.0.3043",
     "isPreviewBundle":  true
 }

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,6 +1,6 @@
 ﻿{
     "bundleId":  "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-    "bundleVersion":  "4.26.0",
+    "bundleVersion":  "4.26.1",
     "templateVersion":  "4.0.3043",
     "isPreviewBundle":  true
 }

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -118,7 +118,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
-    "majorVersion": "1",
+    "Version": "1.14.0",
     "name": "SignalR",
     "bindings": [
       "signalr",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -213,7 +213,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.MySql",
-    "majorVersion": "1",
+    "Version": "1.0.3-preview",
     "name": "MySqlBinding",
     "bindings": [
       "MySql",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage",
-    "majorVersion": "5",
+    "Version": "5.3.2",
     "name": "AzureStorage",
     "bindings": [
       "blobtrigger",
@@ -12,7 +12,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
-    "majorVersion": "5",
+    "Version": "5.3.2",
     "name": "AzureStorageQueues",
     "bindings": [
       "queue",
@@ -21,7 +21,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
-    "majorVersion": "5",
+    "Version": "5.3.2",
     "name": "AzureStorageBlobs",
     "bindings": [
       "blobtrigger",


### PR DESCRIPTION
Merge release/v4.x-preview-hotfix into release/v4.x-preview, includes:
- preview bundle version updated to 4.26.2
- pinning of versions for Microsoft.Azure.WebJobs.Extensions.Storage and Microsoft.Azure.WebJobs.Extensions.Storage.Queues and Microsoft.Azure.WebJobs.Extensions.Storage.Blobs to 5.3.2
- Microsoft.Azure.WebJobs.Extensions.SignalRService to 1.14.0
- Microsoft.Azure.WebJobs.Extensions.MySQL to 1.0.3-preview