### PR TITLE
Pin DurableTask.SqlServer to 1.4.0

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -76,7 +76,7 @@
   },
   {
     "id": "Microsoft.DurableTask.SqlServer.AzureFunctions",
-    "majorVersion": "1",
+    "version": "1.4.0",
     "name": "SqlDurabilityProvider",
     "bindings": [
       "activitytrigger",


### PR DESCRIPTION
Resolving issue - 
```
D:\a\_work\1\s\build_temp\win_x86\extensions.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Azure.WebJobs.Extensions.DurableTask from 3.0.0 to 2.13.7. Reference the package directly from the project to select a different version.
D:\a\_work\1\s\build_temp\win_x86\extensions.csproj : error NU1605:  extensions -> Microsoft.DurableTask.SqlServer.AzureFunctions 1.5.0 -> Microsoft.Azure.WebJobs.Extensions.DurableTask (>= 3.0.0)
D:\a\_work\1\s\build_temp\win_x86\extensions.csproj : error NU1605:  extensions -> Microsoft.Azure.WebJobs.Extensions.DurableTask (>= 2.13.7)
```

by pinning DurableTask.SqlServer to 1.4.0 as DurableTask and DurableTask Netherite are not ready to upgrade in the bundles yet