### PR TITLE
merge hotfix release 4.26.2 changes to pin MySQL version

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -213,7 +213,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.MySql",
-    "majorVersion": "1.0.3-preview",
+    "version": "1.0.3-preview",
     "name": "MySqlBinding",
     "bindings": [
       "MySql",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -213,7 +213,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.MySql",
-    "majorVersion": "1",
+    "majorVersion": "1.0.3-preview",
     "name": "MySqlBinding",
     "bindings": [
       "MySql",


### PR DESCRIPTION
Discarding https://github.com/Azure/azure-functions-extension-bundles/pull/458 and merging just the pinning of MySQL as we don't want to keep others pinned anymore