### PR TITLE
Update SqlClient to 5.2.2

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -200,7 +200,7 @@
   },
   {
     "id": "Microsoft.Data.SqlClient",
-    "majorVersion": "5",
+    "Version": "5.2.2",
     "name": "MicrosoftDataSqlClient",
     "bindings": []
   },

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -200,7 +200,7 @@
   },
   {
     "id": "Microsoft.Data.SqlClient",
-    "Version": "5.1.3",
+    "majorVersion": "5",
     "name": "MicrosoftDataSqlClient",
     "bindings": []
   },


### PR DESCRIPTION
SQL extension is bumping to 5.2.2, updating this to match.

https://github.com/Azure/azure-functions-sql-extension/pull/1160