### PR TITLE
main-preview: Bumping the major version of SignalR extensions to 2

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -130,7 +130,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
-    "majorVersion": "1",
+    "majorVersion": "2",
     "name": "SignalR",
     "bindings": [
       "signalr",


### PR DESCRIPTION
Signal R major version bumped to 2.
[ChangeLog](https://github.com/Azure/azure-sdk-for-net/blob/Microsoft.Azure.WebJobs.Extensions.SignalRService_2.0.0/sdk/signalr/Microsoft.Azure.WebJobs.Extensions.SignalRService/CHANGELOG.md#200-2025-03-11)