### PR TITLE
Unpin versions for storage extensions and update test deps

### DIFF
--- a/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -8,28 +8,28 @@
     ".NETCoreApp,Version=v6.0": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.1",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.0.3",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.284",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.NET.Sdk.Functions": "4.4.0",
           "System.Formats.Asn1": "6.0.1",
@@ -58,13 +58,13 @@
       },
       "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
@@ -78,7 +78,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -90,7 +90,7 @@
       "Azure.Data.Tables/12.9.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
@@ -99,28 +99,27 @@
           }
         }
       },
-      "Azure.Identity/1.12.1": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Identity.Client": "4.65.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.1.0",
-            "fileVersion": "1.1200.124.47602"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -134,9 +133,9 @@
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
@@ -151,9 +150,9 @@
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
@@ -166,25 +165,25 @@
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.ServiceBus/7.18.2": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.Memory.Data": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
       "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
@@ -193,40 +192,39 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.22.1": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.22.1.0",
-            "fileVersion": "12.2200.124.47502"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.22.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.22.0.0",
-            "fileVersion": "12.2200.24.56203"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
-      "Azure.Storage.Queues/12.21.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.56203"
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
@@ -255,7 +253,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -264,58 +262,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "Google.Protobuf": "3.24.3",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -336,7 +334,7 @@
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.AspNetCore.Server.dll": {
@@ -359,7 +357,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.49.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -396,32 +394,32 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
+      "Grpc.Core.Api/2.49.0": {
         "dependencies": {
           "System.Memory": "4.5.5"
         },
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
+          "Grpc.Net.Common": "2.49.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
+          "Grpc.Net.Client": "2.49.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
@@ -431,19 +429,19 @@
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.49.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "librdkafka.redist/2.4.0": {
         "runtimeTargets": {
           "runtimes/linux-arm64/native/librdkafka.so": {
             "rid": "linux-arm64",
@@ -470,20 +468,25 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
+          "runtimes/osx-arm64/native/librdkafka.dylib": {
+            "rid": "osx-arm64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
           "runtimes/osx-x64/native/librdkafka.dylib": {
             "rid": "osx-x64",
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/libcrypto-1_1-x64.dll": {
+          "runtimes/win-x64/native/libcrypto-3-x64.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/libcurl.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x64/native/librdkafka.dll": {
             "rid": "win-x64",
@@ -495,30 +498,30 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/libssl-1_1-x64.dll": {
+          "runtimes/win-x64/native/libssl-3-x64.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/zlib1.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x64/native/zstd.dll": {
             "rid": "win-x64",
             "assetType": "native",
             "fileVersion": "1.5.2.0"
           },
-          "runtimes/win-x86/native/libcrypto-1_1.dll": {
+          "runtimes/win-x86/native/libcrypto-3.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/libcurl.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x86/native/librdkafka.dll": {
             "rid": "win-x86",
@@ -530,10 +533,10 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x86/native/libssl-1_1.dll": {
+          "runtimes/win-x86/native/libssl-3.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/msvcp140.dll": {
             "rid": "win-x86",
@@ -548,7 +551,7 @@
           "runtimes/win-x86/native/zlib1.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x86/native/zstd.dll": {
             "rid": "win-x86",
@@ -557,18 +560,23 @@
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -679,7 +687,7 @@
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
+          "Microsoft.AspNetCore.WebSockets": "2.1.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
         }
@@ -706,7 +714,7 @@
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -835,27 +843,7 @@
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
+      "Microsoft.AspNetCore.WebSockets/2.1.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.Extensions.Options": "6.0.0",
@@ -876,46 +864,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "1.7.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
+          "System.Configuration.ConfigurationManager": "6.0.2",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -936,17 +926,17 @@
           "runtimes/win-x64/native/msvcp140.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140_1.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           }
         }
       },
@@ -954,7 +944,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -967,10 +957,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -996,13 +986,13 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
@@ -1010,39 +1000,27 @@
         "runtime": {
           "lib/netstandard2.0/DurableTask.Netherite.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Azure.DurableTask.Netherite": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2"
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
-      "Microsoft.Azure.Functions.Extensions/1.0.0": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.0.0"
-          }
-        }
-      },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
         "dependencies": {
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -1051,63 +1029,51 @@
           }
         }
       },
-      "Microsoft.Azure.SignalR/1.25.2": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
           "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net6.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -1125,8 +1091,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1148,7 +1114,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
@@ -1162,7 +1128,7 @@
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
@@ -1184,17 +1150,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.CSharp": "4.7.0",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.1.0",
-            "fileVersion": "4.8.1.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1216,9 +1183,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
@@ -1227,37 +1194,36 @@
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.DurableTask.Grpc": "1.3.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.2.0"
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.21.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.3.0",
-            "fileVersion": "3.400.324.56904"
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1282,20 +1248,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
@@ -1317,7 +1283,7 @@
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1340,116 +1306,115 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Sendgrid": "9.10.0"
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
+          "Azure.Messaging.ServiceBus": "7.18.2",
           "Google.Protobuf": "3.24.3",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
+          "MessagePack": "2.5.192",
           "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "System.IdentityModel.Tokens.Jwt": "6.35.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "6.0.0",
+          "System.Runtime.Caching": "6.0.1",
           "morelinq": "3.4.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.284.0",
-            "fileVersion": "3.1.284.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
         "dependencies": {
           "Azure.Data.Tables": "12.9.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Tables.dll": {
-            "assemblyVersion": "1.3.2.0",
-            "fileVersion": "1.300.224.31302"
+            "assemblyVersion": "1.3.3.0",
+            "fileVersion": "1.300.325.16403"
           }
         }
       },
@@ -1509,9 +1474,9 @@
       },
       "Microsoft.Azure.WebPubSub.Common/1.3.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
@@ -1520,11 +1485,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -1536,17 +1501,17 @@
           }
         }
       },
-      "Microsoft.CSharp/4.5.0": {},
+      "Microsoft.CSharp/4.7.0": {},
       "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
-          "System.Runtime.Caching": "6.0.0"
+          "System.Configuration.ConfigurationManager": "6.0.2",
+          "System.Runtime.Caching": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Data.SqlClient.dll": {
@@ -1643,58 +1608,51 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
-        },
-        "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.51037"
-          }
-        }
-      },
-      "Microsoft.DurableTask.SqlServer/1.5.0": {
-        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "6.0.0"
+          "System.IdentityModel.Tokens.Jwt": "6.35.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.DurableTask.SqlServer": "1.5.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
           "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.6": {
+      "Microsoft.Extensions.Azure/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.6.0",
-            "fileVersion": "1.700.624.50402"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.1000.25.10602"
           }
         }
       },
@@ -1733,11 +1691,18 @@
       },
       "Microsoft.Extensions.DependencyInjection/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net6.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -1777,14 +1742,14 @@
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         }
       },
       "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
@@ -1793,7 +1758,7 @@
       "Microsoft.Extensions.Logging/6.0.0": {
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -1816,7 +1781,7 @@
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
       "Microsoft.Extensions.Options/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
@@ -1824,7 +1789,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
@@ -1846,27 +1811,27 @@
           }
         }
       },
-      "Microsoft.Identity.Client/4.65.0": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
@@ -1883,7 +1848,7 @@
           "Microsoft.IdentityModel.Tokens": "6.35.0",
           "System.Text.Encoding": "4.3.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
@@ -1929,7 +1894,7 @@
       },
       "Microsoft.IdentityModel.Tokens/6.35.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Microsoft.IdentityModel.Logging": "6.35.0",
           "System.Security.Cryptography.Cng": "4.5.0"
         },
@@ -1957,6 +1922,18 @@
           "System.Net.Http": "4.3.4",
           "System.Text.Encodings.Web": "6.0.0",
           "System.Text.RegularExpressions": "4.3.1"
+        }
+      },
+      "Microsoft.NET.StringTools/17.6.3": {
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
         }
       },
       "Microsoft.NETCore.Platforms/1.1.1": {},
@@ -2212,15 +2189,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2236,6 +2213,14 @@
           }
         }
       },
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
       "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -2244,8 +2229,8 @@
       "System.Buffers/4.5.1": {},
       "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
@@ -2306,15 +2291,15 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Configuration.ConfigurationManager/6.0.1": {
+      "System.Configuration.ConfigurationManager/6.0.2": {
         "dependencies": {
           "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
+          "System.Security.Permissions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.922.41905"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2559,7 +2544,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -2590,14 +2575,11 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/6.0.0": {
-        "dependencies": {
-          "System.Text.Json": "6.0.10"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
           "lib/net6.0/System.Memory.Data.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2826,14 +2808,14 @@
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "System.Runtime.Caching/6.0.0": {
+      "System.Runtime.Caching/6.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "6.0.1"
+          "System.Configuration.ConfigurationManager": "6.0.2"
         },
         "runtime": {
           "lib/net6.0/System.Runtime.Caching.dll": {
             "assemblyVersion": "4.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         },
         "runtimeTargets": {
@@ -2841,7 +2823,7 @@
             "rid": "win",
             "assetType": "runtime",
             "assemblyVersion": "4.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2896,13 +2878,6 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Security.AccessControl/6.0.0": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -3039,15 +3014,14 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
-      "System.Security.Permissions/6.0.0": {
+      "System.Security.Permissions/6.0.1": {
         "dependencies": {
-          "System.Security.AccessControl": "6.0.0",
           "System.Windows.Extensions": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Security.Permissions.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3094,15 +3068,11 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Text.Json/6.0.10": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.0"
-        },
+      "System.Text.Json/6.0.11": {
         "runtime": {
           "lib/net6.0/System.Text.Json.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3524.45918"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3261,12 +3231,12 @@
       "path": "azure.data.tables/12.9.1",
       "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.1": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7j7ksn+1X2swW2DDDEEywK5wxuYImzMIXnunZTB83E3mwzBbyHOob1hO1wOG5fMZYTGe/+9gyc/qurcozaSm1A==",
-      "path": "azure.identity/1.12.1",
-      "hashPath": "azure.identity.1.12.1.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -3289,12 +3259,12 @@
       "path": "azure.messaging.eventhubs.processor/5.11.5",
       "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
     "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
@@ -3303,26 +3273,26 @@
       "path": "azure.messaging.webpubsub/1.4.0",
       "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.22.1": {
+    "Azure.Storage.Blobs/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-x0TZRhkLQwVf+BYjFJybRu0G8OdIXm0mYZJUgUX2I27DHxHmW6+qR4q3VsbOKYT1r/CFwDKBt7wDVohr14k4bQ==",
-      "path": "azure.storage.blobs/12.22.1",
-      "hashPath": "azure.storage.blobs.12.22.1.nupkg.sha512"
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.22.0": {
+    "Azure.Storage.Common/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0Vm30bRpQ0fcswB0xQMhKAOSXnRygnF2f/029uPaIDLaj1/yfX4jmU0fFjJe9ojGEj/vlAmsApCEOyL9if6zHg==",
-      "path": "azure.storage.common/12.22.0",
-      "hashPath": "azure.storage.common.12.22.0.nupkg.sha512"
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.21.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4Ql71evO/iosdzZD8KFKBByVyvCXvVeC979w8JOdT7UdStncBg4BbnZREq3B56ud4paUgKdPv45qEasTYUsH2w==",
-      "path": "azure.storage.queues/12.21.0",
-      "hashPath": "azure.storage.queues.12.21.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -3345,33 +3315,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "Google.Protobuf/3.24.3": {
       "type": "package",
@@ -3408,19 +3378,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-6OTcSQ8iML+xzmELhH4anUZlNM3dHDKPFBsMLSdiT80LJaaZKxwZml/K9ZdfLIjSR/EzdMZzzU2Avbedz4N7BA==",
+      "path": "grpc.core.api/2.49.0",
+      "hashPath": "grpc.core.api.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-mLXxEJzqnRHseVzRCzSQznA7y8pcSStVbstLTUuQRulN7kREovh82ctNkGpkfwONi/DHoWscX9mJLiAmh0gjOQ==",
+      "path": "grpc.net.client/2.49.0",
+      "hashPath": "grpc.net.client.2.49.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -3429,12 +3399,12 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-G0TVTS8fjCk8b7td/E7C8/ssJPm3JnGVBKsveoj/89PIwIee72qkXG+tVn5c1gwTanEFPdyPoydna/bmU/NAaw==",
+      "path": "grpc.net.common/2.49.0",
+      "hashPath": "grpc.net.common.2.49.0.nupkg.sha512"
     },
     "Grpc.Tools/2.49.0": {
       "type": "package",
@@ -3443,19 +3413,26 @@
       "path": "grpc.tools/2.49.0",
       "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "librdkafka.redist/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "MessagePack/2.5.192": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -3660,26 +3637,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
+    "Microsoft.AspNetCore.WebSockets/2.1.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-wvp85LiIDuFAtbn5FiD4dpAXUBI203yBEtKeNE1I1ipSrUugY2lJVpZAP+C5F5AJ1RZtWvBl+AP1mhkuDNWpag==",
+      "path": "microsoft.aspnetcore.websockets/2.1.1",
+      "hashPath": "microsoft.aspnetcore.websockets.2.1.1.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -3695,19 +3658,19 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
@@ -3730,19 +3693,19 @@
       "path": "microsoft.azure.durabletask.core/3.0.0",
       "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hxhQPd8Ft8n/aETkTzPdA0wTBBOMpF012yCPJMoRzVnRYTkO9OfUADa6gVyLv4HvNRlvYET3MvdNg7dDFp6CJA==",
-      "path": "microsoft.azure.durabletask.netherite/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.3.0.0.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sWVSLuz2TfGzQINIoYCu30ASslyQYhzINhIg8VYL8J3QFlGfrMxXkifJZ5VIt04ZTRihuoUD8/RAZie0DWtvXQ==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.0.0.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -3751,13 +3714,6 @@
       "path": "microsoft.azure.functions.analyzers/1.0.0",
       "hashPath": "microsoft.azure.functions.analyzers.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-rIiuBZyN1lhDkF3oXzaKjyvcDjo9SFtND4+ny6Pyl+qVUHERGk2VmG2BRwep/V6IFE0HseOH/dJhx7lrjbE+BA==",
-      "path": "microsoft.azure.functions.extensions/1.0.0",
-      "hashPath": "microsoft.azure.functions.extensions.1.0.0.nupkg.sha512"
-    },
     "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
       "type": "package",
       "serviceable": true,
@@ -3765,26 +3721,26 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -3821,12 +3777,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XDiqLlFJyhhlqUWNQT4F7ZGSCUbWbsNJ3r/sPAJ+rxnaCwzPS/mspgfF4HX6ABhnOYkZBvMNueXrPPVH6MHGnQ==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.1.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -3835,12 +3791,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bxgSeDk2RbsQzfuuBYLuvWmdGqfUN/R2q9ondIgysWPFvMPGZXrEMvUSyGO6hJshuPpuPdwSz91u/jc8Sq+/3g==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.2.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3849,12 +3805,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DgK/yKI2xodSRwfzThXYjFXtQDfppJjuxhNNYah2Ch6VyasGllOzi8hqvIWeqUopVHEuU0hjM2RhTlDEzpuUJA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.3.nupkg.sha512"
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -3870,12 +3826,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/2.0.3": {
       "type": "package",
@@ -3898,61 +3854,61 @@
       "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
       "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-En6cNhWmEt1eBDg4kvnxSPcw4sQdEwpvW04K7Su+9usbsetZe0EEbYLYMkdxqY6PlHpWfZYH8LsTDBNoC6d8rg==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.284",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.284.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dl+PoO8su2Ho2/QhODq9tIthR2cdBkjbhYvDYkHaF0Fo7hK5QXHO7FgZzRkQlknEnrdxkq0G8uV4R8IZdbSxzw==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bFEzPY420QkiGvlTLXQItYkplklRWSQWigCqt9ZhTNV08uVswd/wgwhdYKP53FP3OugBVTSOsq4e897nnFwKxQ==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RwRZ0OQ2w18YoslTYBhL/JAjExIvAhbADkuS1b6XTh1cmqNqIJiHfshyglwWkctrsqnBgI69UkvuuQKKgvgy9Q==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.3.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7djdtFJFTbDwDIrFgZAQ6MRiBAPFOYdHX9OZ/g9f1D81mBrZwQHZGJOw44bSBC2DvqZLeG+Uwutp8rwEr3fYfQ==",
-      "path": "microsoft.azure.webjobs.extensions.tables/1.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.2.nupkg.sha512"
+      "sha512": "sha512-0MknEtohJx9bGMKHH5tfAFVx/YMV59SUVbfdzif05mELjAUa7DC/3TGyQhXcGn7ZYYDGd2HC0AL+VnXV/KDD+g==",
+      "path": "microsoft.azure.webjobs.extensions.tables/1.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -3996,12 +3952,12 @@
       "path": "microsoft.azure.webpubsub.common/1.3.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.3.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
-      "path": "microsoft.bcl.asyncinterfaces/6.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
+      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
+      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4010,12 +3966,12 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CSharp/4.5.0": {
+    "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ==",
-      "path": "microsoft.csharp/4.5.0",
-      "hashPath": "microsoft.csharp.4.5.0.nupkg.sha512"
+      "sha512": "sha512-pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA==",
+      "path": "microsoft.csharp/4.7.0",
+      "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
@@ -4038,33 +3994,26 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U0Q+EiOpPoaX1zUPDZSlwXdnKeEoqbaLuJgtqWXwwMqlqPJw14LSc8U6V3+moEZYtcDJgxrxaq7NsGXemyZ2pg==",
-      "path": "microsoft.durabletask.grpc/1.3.0",
-      "hashPath": "microsoft.durabletask.grpc.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.5.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5M726SSosFoh1Aji4HuqbsG58ZwmFJSTaNVycY4Mvrpd4ZpEaeOcQmv8/fJ8Ch2LQlRq2V9RcZXFYm4F5aot4Q==",
-      "path": "microsoft.durabletask.sqlserver/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.5.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+    "Microsoft.Extensions.Azure/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rgNokoVmfnlVJ7vvDKhYaO7BKZqz3nZcGtOdG3obKXzvMQ7x8Nxg4F9WHV6GZTXt2kG2qHekQZBHQlzHsGU1Bg==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.0.nupkg.sha512"
-    },
-    "Microsoft.Extensions.Azure/1.7.6": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-o2dLnQ8cMw5p7KAtxAPukkk4Mhs4tu96nUyFee4lvfLZEkuyTLhLGT2D5o5bagCwHVxqzt+w4Eb4YOl/pLq6Cw==",
-      "path": "microsoft.extensions.azure/1.7.6",
-      "hashPath": "microsoft.extensions.azure.1.7.6.nupkg.sha512"
+      "sha512": "sha512-hKYPTmD2NS/DVxS1vSqO24cAjBO3yFioAiXAzs/9UDjHVJZc2CEowtpPMtNMvhoXknFTyu3nlGTpFlj/ofDUtg==",
+      "path": "microsoft.extensions.azure/1.10.0",
+      "hashPath": "microsoft.extensions.azure.1.10.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/2.2.0": {
       "type": "package",
@@ -4115,12 +4064,12 @@
       "path": "microsoft.extensions.dependencyinjection/6.0.0",
       "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -4227,19 +4176,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.65.0": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RV35ZcJ5/P7n+Zu6J3wmtiDdK6MW5h6EpZ0ojjB9sMwNhGHEJCv829cb3kZ4PZ664llYFv8sbUITWWGvBTqv0Q==",
-      "path": "microsoft.identity.client/4.65.0",
-      "hashPath": "microsoft.identity.client.4.65.0.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JIOBFMAyVSqGWP4dNoST+A9BRJMGC8m73BNbR1oKA8nUjGyR8Fd4eOOME/VDrd26I5JWU4RtmWqpt20lpp2r5w==",
-      "path": "microsoft.identity.client.extensions.msal/4.65.0",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.65.0.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/6.35.0": {
       "type": "package",
@@ -4296,6 +4245,13 @@
       "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
       "path": "microsoft.net.sdk.functions/4.4.0",
       "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+    },
+    "Microsoft.NET.StringTools/17.6.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
     },
     "Microsoft.NETCore.Platforms/1.1.1": {
       "type": "package",
@@ -4507,12 +4463,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "StackExchange.Redis/2.7.4": {
       "type": "package",
@@ -4520,6 +4476,13 @@
       "sha512": "sha512-lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
+    },
+    "starkbank-ecdsa/1.3.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
     },
     "System.AppContext/4.3.0": {
       "type": "package",
@@ -4591,12 +4554,12 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Configuration.ConfigurationManager/6.0.1": {
+    "System.Configuration.ConfigurationManager/6.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jXw9MlUu/kRfEU0WyTptAVueupqIeE3/rl0EZDMlf8pcvJnitQ8HeVEp69rZdaStXwTV72boi/Bhw8lOeO+U2w==",
-      "path": "system.configuration.configurationmanager/6.0.1",
-      "hashPath": "system.configuration.configurationmanager.6.0.1.nupkg.sha512"
+      "sha512": "sha512-LtqgY79MRntWIM0AeQf4uj1mGyqpVhR7O9N1+UODQu/EGQwRTERqMqpYTeedE7VTK2ngoCtxzAaTn9gRDa+6Qw==",
+      "path": "system.configuration.configurationmanager/6.0.2",
+      "hashPath": "system.configuration.configurationmanager.6.0.2.nupkg.sha512"
     },
     "System.Console/4.3.0": {
       "type": "package",
@@ -4787,12 +4750,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/6.0.0": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
-      "path": "system.memory.data/6.0.0",
-      "hashPath": "system.memory.data.6.0.0.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -4969,12 +4932,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/6.0.0": {
+    "System.Runtime.Caching/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-E0e03kUp5X2k+UAoVl6efmI7uU7JRBWi5EIdlQ7cr0NpBGjHG4fWII35PgsBY9T4fJQ8E4QPsL0rKksU9gcL5A==",
-      "path": "system.runtime.caching/6.0.0",
-      "hashPath": "system.runtime.caching.6.0.0.nupkg.sha512"
+      "sha512": "sha512-LemwNEizWlwWOAVqKDj6HM42d2eRiujS6Dkom13YqQFE8XzojGMXciUWN2d7Njv5uLbbvG9d5P3gpUJdUZiOcQ==",
+      "path": "system.runtime.caching/6.0.1",
+      "hashPath": "system.runtime.caching.6.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -5024,20 +4987,6 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
-    "System.Security.AccessControl/6.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ==",
-      "path": "system.security.accesscontrol/6.0.0",
-      "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",
@@ -5102,12 +5051,12 @@
       "path": "system.security.cryptography.x509certificates/4.3.0",
       "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
     },
-    "System.Security.Permissions/6.0.0": {
+    "System.Security.Permissions/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
-      "path": "system.security.permissions/6.0.0",
-      "hashPath": "system.security.permissions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-QufGNXopGXxdXbkDn87hta4ajdNKNI3a1+HoJbKkmBbMtYPhEgEJKSiPZHGjI0zQpgZ7gi5L0gSV3PeewKRtew==",
+      "path": "system.security.permissions/6.0.1",
+      "hashPath": "system.security.permissions.6.0.1.nupkg.sha512"
     },
     "System.Security.Principal/4.3.0": {
       "type": "package",
@@ -5144,12 +5093,12 @@
       "path": "system.text.encodings.web/6.0.0",
       "hashPath": "system.text.encodings.web.6.0.0.nupkg.sha512"
     },
-    "System.Text.Json/6.0.10": {
+    "System.Text.Json/6.0.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
-      "path": "system.text.json/6.0.10",
-      "hashPath": "system.text.json.6.0.10.nupkg.sha512"
+      "sha512": "sha512-xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+      "path": "system.text.json/6.0.11",
+      "hashPath": "system.text.json.6.0.11.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
@@ -9,28 +9,28 @@
     ".NETCoreApp,Version=v6.0/linux-x64": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.1",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.0.3",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.284",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.NET.Sdk.Functions": "4.4.0",
           "System.Formats.Asn1": "6.0.1",
@@ -59,13 +59,13 @@
       },
       "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
@@ -79,7 +79,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -91,7 +91,7 @@
       "Azure.Data.Tables/12.9.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
@@ -100,28 +100,27 @@
           }
         }
       },
-      "Azure.Identity/1.12.1": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Identity.Client": "4.65.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.1.0",
-            "fileVersion": "1.1200.124.47602"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -135,9 +134,9 @@
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
@@ -152,9 +151,9 @@
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
@@ -167,25 +166,25 @@
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.ServiceBus/7.18.2": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.Memory.Data": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
       "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
@@ -194,40 +193,39 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.22.1": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.22.1.0",
-            "fileVersion": "12.2200.124.47502"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.22.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.22.0.0",
-            "fileVersion": "12.2200.24.56203"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
-      "Azure.Storage.Queues/12.21.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.56203"
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
@@ -256,7 +254,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -265,58 +263,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "Google.Protobuf": "3.24.3",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -337,7 +335,7 @@
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.AspNetCore.Server.dll": {
@@ -360,7 +358,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.49.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -375,32 +373,32 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
+      "Grpc.Core.Api/2.49.0": {
         "dependencies": {
           "System.Memory": "4.5.5"
         },
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
+          "Grpc.Net.Common": "2.49.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
+          "Grpc.Net.Client": "2.49.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
@@ -410,19 +408,19 @@
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.49.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "librdkafka.redist/2.4.0": {
         "native": {
           "runtimes/linux-x64/native/alpine-librdkafka.so": {
             "fileVersion": "0.0.0.0"
@@ -438,18 +436,23 @@
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -560,7 +563,7 @@
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
+          "Microsoft.AspNetCore.WebSockets": "2.1.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
         }
@@ -587,7 +590,7 @@
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -716,27 +719,7 @@
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
+      "Microsoft.AspNetCore.WebSockets/2.1.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.Extensions.Options": "6.0.0",
@@ -757,46 +740,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "1.7.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
+          "System.Configuration.ConfigurationManager": "6.0.2",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -808,7 +793,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -821,10 +806,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -850,13 +835,13 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
@@ -864,39 +849,27 @@
         "runtime": {
           "lib/netstandard2.0/DurableTask.Netherite.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Azure.DurableTask.Netherite": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2"
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
-      "Microsoft.Azure.Functions.Extensions/1.0.0": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.0.0"
-          }
-        }
-      },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
         "dependencies": {
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -905,63 +878,51 @@
           }
         }
       },
-      "Microsoft.Azure.SignalR/1.25.2": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
           "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net6.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -979,8 +940,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1002,7 +963,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
@@ -1016,7 +977,7 @@
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
@@ -1038,17 +999,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.CSharp": "4.7.0",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.1.0",
-            "fileVersion": "4.8.1.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1070,9 +1032,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
@@ -1081,37 +1043,36 @@
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.DurableTask.Grpc": "1.3.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.2.0"
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.21.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.3.0",
-            "fileVersion": "3.400.324.56904"
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1136,20 +1097,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
@@ -1171,7 +1132,7 @@
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1194,116 +1155,115 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Sendgrid": "9.10.0"
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
+          "Azure.Messaging.ServiceBus": "7.18.2",
           "Google.Protobuf": "3.24.3",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
+          "MessagePack": "2.5.192",
           "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "System.IdentityModel.Tokens.Jwt": "6.35.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "6.0.0",
+          "System.Runtime.Caching": "6.0.1",
           "morelinq": "3.4.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.284.0",
-            "fileVersion": "3.1.284.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
         "dependencies": {
           "Azure.Data.Tables": "12.9.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Tables.dll": {
-            "assemblyVersion": "1.3.2.0",
-            "fileVersion": "1.300.224.31302"
+            "assemblyVersion": "1.3.3.0",
+            "fileVersion": "1.300.325.16403"
           }
         }
       },
@@ -1363,9 +1323,9 @@
       },
       "Microsoft.Azure.WebPubSub.Common/1.3.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
@@ -1374,11 +1334,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -1390,17 +1350,17 @@
           }
         }
       },
-      "Microsoft.CSharp/4.5.0": {},
+      "Microsoft.CSharp/4.7.0": {},
       "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
-          "System.Runtime.Caching": "6.0.0"
+          "System.Configuration.ConfigurationManager": "6.0.2",
+          "System.Runtime.Caching": "6.0.1"
         },
         "runtime": {
           "runtimes/unix/lib/net6.0/Microsoft.Data.SqlClient.dll": {
@@ -1460,58 +1420,51 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
-        },
-        "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.51037"
-          }
-        }
-      },
-      "Microsoft.DurableTask.SqlServer/1.5.0": {
-        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "6.0.0"
+          "System.IdentityModel.Tokens.Jwt": "6.35.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.DurableTask.SqlServer": "1.5.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
           "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.6": {
+      "Microsoft.Extensions.Azure/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.6.0",
-            "fileVersion": "1.700.624.50402"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.1000.25.10602"
           }
         }
       },
@@ -1550,11 +1503,18 @@
       },
       "Microsoft.Extensions.DependencyInjection/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net6.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -1594,14 +1554,14 @@
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         }
       },
       "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
@@ -1610,7 +1570,7 @@
       "Microsoft.Extensions.Logging/6.0.0": {
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -1633,7 +1593,7 @@
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
       "Microsoft.Extensions.Options/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
@@ -1641,7 +1601,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
@@ -1663,27 +1623,27 @@
           }
         }
       },
-      "Microsoft.Identity.Client/4.65.0": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
@@ -1700,7 +1660,7 @@
           "Microsoft.IdentityModel.Tokens": "6.35.0",
           "System.Text.Encoding": "4.3.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
@@ -1746,7 +1706,7 @@
       },
       "Microsoft.IdentityModel.Tokens/6.35.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Microsoft.IdentityModel.Logging": "6.35.0",
           "System.Security.Cryptography.Cng": "4.5.0"
         },
@@ -1774,6 +1734,18 @@
           "System.Net.Http": "4.3.4",
           "System.Text.Encodings.Web": "6.0.0",
           "System.Text.RegularExpressions": "4.3.1"
+        }
+      },
+      "Microsoft.NET.StringTools/17.6.3": {
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
         }
       },
       "Microsoft.NETCore.Platforms/1.1.1": {},
@@ -2143,15 +2115,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2167,6 +2139,14 @@
           }
         }
       },
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
       "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -2175,8 +2155,8 @@
       "System.Buffers/4.5.1": {},
       "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
@@ -2238,15 +2218,15 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Configuration.ConfigurationManager/6.0.1": {
+      "System.Configuration.ConfigurationManager/6.0.2": {
         "dependencies": {
           "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
+          "System.Security.Permissions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.922.41905"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2485,7 +2465,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -2516,14 +2496,11 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/6.0.0": {
-        "dependencies": {
-          "System.Text.Json": "6.0.10"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
           "lib/net6.0/System.Memory.Data.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2760,14 +2737,14 @@
           "runtime.any.System.Runtime": "4.3.0"
         }
       },
-      "System.Runtime.Caching/6.0.0": {
+      "System.Runtime.Caching/6.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "6.0.1"
+          "System.Configuration.ConfigurationManager": "6.0.2"
         },
         "runtime": {
           "lib/net6.0/System.Runtime.Caching.dll": {
             "assemblyVersion": "4.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2825,13 +2802,6 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Security.AccessControl/6.0.0": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -2960,15 +2930,14 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
-      "System.Security.Permissions/6.0.0": {
+      "System.Security.Permissions/6.0.1": {
         "dependencies": {
-          "System.Security.AccessControl": "6.0.0",
           "System.Windows.Extensions": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Security.Permissions.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3017,15 +2986,11 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Text.Json/6.0.10": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.0"
-        },
+      "System.Text.Json/6.0.11": {
         "runtime": {
           "lib/net6.0/System.Text.Json.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3524.45918"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3184,12 +3149,12 @@
       "path": "azure.data.tables/12.9.1",
       "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.1": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7j7ksn+1X2swW2DDDEEywK5wxuYImzMIXnunZTB83E3mwzBbyHOob1hO1wOG5fMZYTGe/+9gyc/qurcozaSm1A==",
-      "path": "azure.identity/1.12.1",
-      "hashPath": "azure.identity.1.12.1.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -3212,12 +3177,12 @@
       "path": "azure.messaging.eventhubs.processor/5.11.5",
       "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
     "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
@@ -3226,26 +3191,26 @@
       "path": "azure.messaging.webpubsub/1.4.0",
       "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.22.1": {
+    "Azure.Storage.Blobs/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-x0TZRhkLQwVf+BYjFJybRu0G8OdIXm0mYZJUgUX2I27DHxHmW6+qR4q3VsbOKYT1r/CFwDKBt7wDVohr14k4bQ==",
-      "path": "azure.storage.blobs/12.22.1",
-      "hashPath": "azure.storage.blobs.12.22.1.nupkg.sha512"
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.22.0": {
+    "Azure.Storage.Common/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0Vm30bRpQ0fcswB0xQMhKAOSXnRygnF2f/029uPaIDLaj1/yfX4jmU0fFjJe9ojGEj/vlAmsApCEOyL9if6zHg==",
-      "path": "azure.storage.common/12.22.0",
-      "hashPath": "azure.storage.common.12.22.0.nupkg.sha512"
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.21.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4Ql71evO/iosdzZD8KFKBByVyvCXvVeC979w8JOdT7UdStncBg4BbnZREq3B56ud4paUgKdPv45qEasTYUsH2w==",
-      "path": "azure.storage.queues/12.21.0",
-      "hashPath": "azure.storage.queues.12.21.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -3268,33 +3233,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "Google.Protobuf/3.24.3": {
       "type": "package",
@@ -3331,19 +3296,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-6OTcSQ8iML+xzmELhH4anUZlNM3dHDKPFBsMLSdiT80LJaaZKxwZml/K9ZdfLIjSR/EzdMZzzU2Avbedz4N7BA==",
+      "path": "grpc.core.api/2.49.0",
+      "hashPath": "grpc.core.api.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-mLXxEJzqnRHseVzRCzSQznA7y8pcSStVbstLTUuQRulN7kREovh82ctNkGpkfwONi/DHoWscX9mJLiAmh0gjOQ==",
+      "path": "grpc.net.client/2.49.0",
+      "hashPath": "grpc.net.client.2.49.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -3352,12 +3317,12 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-G0TVTS8fjCk8b7td/E7C8/ssJPm3JnGVBKsveoj/89PIwIee72qkXG+tVn5c1gwTanEFPdyPoydna/bmU/NAaw==",
+      "path": "grpc.net.common/2.49.0",
+      "hashPath": "grpc.net.common.2.49.0.nupkg.sha512"
     },
     "Grpc.Tools/2.49.0": {
       "type": "package",
@@ -3366,19 +3331,26 @@
       "path": "grpc.tools/2.49.0",
       "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "librdkafka.redist/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "MessagePack/2.5.192": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -3583,26 +3555,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
+    "Microsoft.AspNetCore.WebSockets/2.1.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-wvp85LiIDuFAtbn5FiD4dpAXUBI203yBEtKeNE1I1ipSrUugY2lJVpZAP+C5F5AJ1RZtWvBl+AP1mhkuDNWpag==",
+      "path": "microsoft.aspnetcore.websockets/2.1.1",
+      "hashPath": "microsoft.aspnetcore.websockets.2.1.1.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -3618,19 +3576,19 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
@@ -3653,19 +3611,19 @@
       "path": "microsoft.azure.durabletask.core/3.0.0",
       "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hxhQPd8Ft8n/aETkTzPdA0wTBBOMpF012yCPJMoRzVnRYTkO9OfUADa6gVyLv4HvNRlvYET3MvdNg7dDFp6CJA==",
-      "path": "microsoft.azure.durabletask.netherite/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.3.0.0.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sWVSLuz2TfGzQINIoYCu30ASslyQYhzINhIg8VYL8J3QFlGfrMxXkifJZ5VIt04ZTRihuoUD8/RAZie0DWtvXQ==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.0.0.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -3674,13 +3632,6 @@
       "path": "microsoft.azure.functions.analyzers/1.0.0",
       "hashPath": "microsoft.azure.functions.analyzers.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-rIiuBZyN1lhDkF3oXzaKjyvcDjo9SFtND4+ny6Pyl+qVUHERGk2VmG2BRwep/V6IFE0HseOH/dJhx7lrjbE+BA==",
-      "path": "microsoft.azure.functions.extensions/1.0.0",
-      "hashPath": "microsoft.azure.functions.extensions.1.0.0.nupkg.sha512"
-    },
     "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
       "type": "package",
       "serviceable": true,
@@ -3688,26 +3639,26 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -3744,12 +3695,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XDiqLlFJyhhlqUWNQT4F7ZGSCUbWbsNJ3r/sPAJ+rxnaCwzPS/mspgfF4HX6ABhnOYkZBvMNueXrPPVH6MHGnQ==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.1.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -3758,12 +3709,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bxgSeDk2RbsQzfuuBYLuvWmdGqfUN/R2q9ondIgysWPFvMPGZXrEMvUSyGO6hJshuPpuPdwSz91u/jc8Sq+/3g==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.2.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3772,12 +3723,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DgK/yKI2xodSRwfzThXYjFXtQDfppJjuxhNNYah2Ch6VyasGllOzi8hqvIWeqUopVHEuU0hjM2RhTlDEzpuUJA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.3.nupkg.sha512"
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -3793,12 +3744,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/2.0.3": {
       "type": "package",
@@ -3821,61 +3772,61 @@
       "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
       "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-En6cNhWmEt1eBDg4kvnxSPcw4sQdEwpvW04K7Su+9usbsetZe0EEbYLYMkdxqY6PlHpWfZYH8LsTDBNoC6d8rg==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.284",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.284.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dl+PoO8su2Ho2/QhODq9tIthR2cdBkjbhYvDYkHaF0Fo7hK5QXHO7FgZzRkQlknEnrdxkq0G8uV4R8IZdbSxzw==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bFEzPY420QkiGvlTLXQItYkplklRWSQWigCqt9ZhTNV08uVswd/wgwhdYKP53FP3OugBVTSOsq4e897nnFwKxQ==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RwRZ0OQ2w18YoslTYBhL/JAjExIvAhbADkuS1b6XTh1cmqNqIJiHfshyglwWkctrsqnBgI69UkvuuQKKgvgy9Q==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.3.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7djdtFJFTbDwDIrFgZAQ6MRiBAPFOYdHX9OZ/g9f1D81mBrZwQHZGJOw44bSBC2DvqZLeG+Uwutp8rwEr3fYfQ==",
-      "path": "microsoft.azure.webjobs.extensions.tables/1.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.2.nupkg.sha512"
+      "sha512": "sha512-0MknEtohJx9bGMKHH5tfAFVx/YMV59SUVbfdzif05mELjAUa7DC/3TGyQhXcGn7ZYYDGd2HC0AL+VnXV/KDD+g==",
+      "path": "microsoft.azure.webjobs.extensions.tables/1.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -3919,12 +3870,12 @@
       "path": "microsoft.azure.webpubsub.common/1.3.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.3.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
-      "path": "microsoft.bcl.asyncinterfaces/6.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
+      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
+      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -3933,12 +3884,12 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CSharp/4.5.0": {
+    "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ==",
-      "path": "microsoft.csharp/4.5.0",
-      "hashPath": "microsoft.csharp.4.5.0.nupkg.sha512"
+      "sha512": "sha512-pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA==",
+      "path": "microsoft.csharp/4.7.0",
+      "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
@@ -3961,33 +3912,26 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U0Q+EiOpPoaX1zUPDZSlwXdnKeEoqbaLuJgtqWXwwMqlqPJw14LSc8U6V3+moEZYtcDJgxrxaq7NsGXemyZ2pg==",
-      "path": "microsoft.durabletask.grpc/1.3.0",
-      "hashPath": "microsoft.durabletask.grpc.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.5.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5M726SSosFoh1Aji4HuqbsG58ZwmFJSTaNVycY4Mvrpd4ZpEaeOcQmv8/fJ8Ch2LQlRq2V9RcZXFYm4F5aot4Q==",
-      "path": "microsoft.durabletask.sqlserver/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.5.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+    "Microsoft.Extensions.Azure/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rgNokoVmfnlVJ7vvDKhYaO7BKZqz3nZcGtOdG3obKXzvMQ7x8Nxg4F9WHV6GZTXt2kG2qHekQZBHQlzHsGU1Bg==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.0.nupkg.sha512"
-    },
-    "Microsoft.Extensions.Azure/1.7.6": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-o2dLnQ8cMw5p7KAtxAPukkk4Mhs4tu96nUyFee4lvfLZEkuyTLhLGT2D5o5bagCwHVxqzt+w4Eb4YOl/pLq6Cw==",
-      "path": "microsoft.extensions.azure/1.7.6",
-      "hashPath": "microsoft.extensions.azure.1.7.6.nupkg.sha512"
+      "sha512": "sha512-hKYPTmD2NS/DVxS1vSqO24cAjBO3yFioAiXAzs/9UDjHVJZc2CEowtpPMtNMvhoXknFTyu3nlGTpFlj/ofDUtg==",
+      "path": "microsoft.extensions.azure/1.10.0",
+      "hashPath": "microsoft.extensions.azure.1.10.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/2.2.0": {
       "type": "package",
@@ -4038,12 +3982,12 @@
       "path": "microsoft.extensions.dependencyinjection/6.0.0",
       "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -4150,19 +4094,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.65.0": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RV35ZcJ5/P7n+Zu6J3wmtiDdK6MW5h6EpZ0ojjB9sMwNhGHEJCv829cb3kZ4PZ664llYFv8sbUITWWGvBTqv0Q==",
-      "path": "microsoft.identity.client/4.65.0",
-      "hashPath": "microsoft.identity.client.4.65.0.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JIOBFMAyVSqGWP4dNoST+A9BRJMGC8m73BNbR1oKA8nUjGyR8Fd4eOOME/VDrd26I5JWU4RtmWqpt20lpp2r5w==",
-      "path": "microsoft.identity.client.extensions.msal/4.65.0",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.65.0.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/6.35.0": {
       "type": "package",
@@ -4219,6 +4163,13 @@
       "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
       "path": "microsoft.net.sdk.functions/4.4.0",
       "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+    },
+    "Microsoft.NET.StringTools/17.6.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
     },
     "Microsoft.NETCore.Platforms/1.1.1": {
       "type": "package",
@@ -4605,12 +4556,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "StackExchange.Redis/2.7.4": {
       "type": "package",
@@ -4618,6 +4569,13 @@
       "sha512": "sha512-lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
+    },
+    "starkbank-ecdsa/1.3.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
     },
     "System.AppContext/4.3.0": {
       "type": "package",
@@ -4689,12 +4647,12 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Configuration.ConfigurationManager/6.0.1": {
+    "System.Configuration.ConfigurationManager/6.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jXw9MlUu/kRfEU0WyTptAVueupqIeE3/rl0EZDMlf8pcvJnitQ8HeVEp69rZdaStXwTV72boi/Bhw8lOeO+U2w==",
-      "path": "system.configuration.configurationmanager/6.0.1",
-      "hashPath": "system.configuration.configurationmanager.6.0.1.nupkg.sha512"
+      "sha512": "sha512-LtqgY79MRntWIM0AeQf4uj1mGyqpVhR7O9N1+UODQu/EGQwRTERqMqpYTeedE7VTK2ngoCtxzAaTn9gRDa+6Qw==",
+      "path": "system.configuration.configurationmanager/6.0.2",
+      "hashPath": "system.configuration.configurationmanager.6.0.2.nupkg.sha512"
     },
     "System.Console/4.3.0": {
       "type": "package",
@@ -4885,12 +4843,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/6.0.0": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
-      "path": "system.memory.data/6.0.0",
-      "hashPath": "system.memory.data.6.0.0.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5067,12 +5025,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/6.0.0": {
+    "System.Runtime.Caching/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-E0e03kUp5X2k+UAoVl6efmI7uU7JRBWi5EIdlQ7cr0NpBGjHG4fWII35PgsBY9T4fJQ8E4QPsL0rKksU9gcL5A==",
-      "path": "system.runtime.caching/6.0.0",
-      "hashPath": "system.runtime.caching.6.0.0.nupkg.sha512"
+      "sha512": "sha512-LemwNEizWlwWOAVqKDj6HM42d2eRiujS6Dkom13YqQFE8XzojGMXciUWN2d7Njv5uLbbvG9d5P3gpUJdUZiOcQ==",
+      "path": "system.runtime.caching/6.0.1",
+      "hashPath": "system.runtime.caching.6.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -5122,20 +5080,6 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
-    "System.Security.AccessControl/6.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ==",
-      "path": "system.security.accesscontrol/6.0.0",
-      "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",
@@ -5200,12 +5144,12 @@
       "path": "system.security.cryptography.x509certificates/4.3.0",
       "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
     },
-    "System.Security.Permissions/6.0.0": {
+    "System.Security.Permissions/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
-      "path": "system.security.permissions/6.0.0",
-      "hashPath": "system.security.permissions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-QufGNXopGXxdXbkDn87hta4ajdNKNI3a1+HoJbKkmBbMtYPhEgEJKSiPZHGjI0zQpgZ7gi5L0gSV3PeewKRtew==",
+      "path": "system.security.permissions/6.0.1",
+      "hashPath": "system.security.permissions.6.0.1.nupkg.sha512"
     },
     "System.Security.Principal/4.3.0": {
       "type": "package",
@@ -5242,12 +5186,12 @@
       "path": "system.text.encodings.web/6.0.0",
       "hashPath": "system.text.encodings.web.6.0.0.nupkg.sha512"
     },
-    "System.Text.Json/6.0.10": {
+    "System.Text.Json/6.0.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
-      "path": "system.text.json/6.0.10",
-      "hashPath": "system.text.json.6.0.10.nupkg.sha512"
+      "sha512": "sha512-xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+      "path": "system.text.json/6.0.11",
+      "hashPath": "system.text.json.6.0.11.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -9,28 +9,28 @@
     ".NETCoreApp,Version=v6.0/win-x64": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.1",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.0.3",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.284",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.NET.Sdk.Functions": "4.4.0",
           "System.Formats.Asn1": "6.0.1",
@@ -59,13 +59,13 @@
       },
       "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
@@ -79,7 +79,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -91,7 +91,7 @@
       "Azure.Data.Tables/12.9.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
@@ -100,28 +100,27 @@
           }
         }
       },
-      "Azure.Identity/1.12.1": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Identity.Client": "4.65.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.1.0",
-            "fileVersion": "1.1200.124.47602"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -135,9 +134,9 @@
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
@@ -152,9 +151,9 @@
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
@@ -167,25 +166,25 @@
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.ServiceBus/7.18.2": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.Memory.Data": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
       "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
@@ -194,40 +193,39 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.22.1": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.22.1.0",
-            "fileVersion": "12.2200.124.47502"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.22.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.22.0.0",
-            "fileVersion": "12.2200.24.56203"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
-      "Azure.Storage.Queues/12.21.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.56203"
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
@@ -256,7 +254,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -265,58 +263,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "Google.Protobuf": "3.24.3",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -337,7 +335,7 @@
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.AspNetCore.Server.dll": {
@@ -360,7 +358,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.49.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -375,32 +373,32 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
+      "Grpc.Core.Api/2.49.0": {
         "dependencies": {
           "System.Memory": "4.5.5"
         },
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
+          "Grpc.Net.Common": "2.49.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
+          "Grpc.Net.Client": "2.49.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
@@ -410,25 +408,25 @@
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.49.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "librdkafka.redist/2.4.0": {
         "native": {
-          "runtimes/win-x64/native/libcrypto-1_1-x64.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x64/native/libcrypto-3-x64.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/libcurl.dll": {
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x64/native/librdkafka.dll": {
             "fileVersion": "0.0.0.0"
@@ -436,29 +434,34 @@
           "runtimes/win-x64/native/librdkafkacpp.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/libssl-1_1-x64.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x64/native/libssl-3-x64.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/zlib1.dll": {
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x64/native/zstd.dll": {
             "fileVersion": "1.5.2.0"
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -569,7 +572,7 @@
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
+          "Microsoft.AspNetCore.WebSockets": "2.1.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
         }
@@ -596,7 +599,7 @@
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -725,27 +728,7 @@
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
+      "Microsoft.AspNetCore.WebSockets/2.1.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.Extensions.Options": "6.0.0",
@@ -766,46 +749,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "1.7.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
+          "System.Configuration.ConfigurationManager": "6.0.2",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -820,13 +805,13 @@
             "fileVersion": "2.14.0.0"
           },
           "runtimes/win-x64/native/msvcp140.dll": {
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140.dll": {
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140_1.dll": {
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           }
         }
       },
@@ -834,7 +819,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -847,10 +832,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -876,13 +861,13 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
@@ -890,39 +875,27 @@
         "runtime": {
           "lib/netstandard2.0/DurableTask.Netherite.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Azure.DurableTask.Netherite": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2"
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
-      "Microsoft.Azure.Functions.Extensions/1.0.0": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.0.0"
-          }
-        }
-      },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
         "dependencies": {
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -931,63 +904,51 @@
           }
         }
       },
-      "Microsoft.Azure.SignalR/1.25.2": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
           "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net6.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -1005,8 +966,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1028,7 +989,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
@@ -1042,7 +1003,7 @@
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
@@ -1064,17 +1025,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.CSharp": "4.7.0",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.1.0",
-            "fileVersion": "4.8.1.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1096,9 +1058,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
@@ -1107,37 +1069,36 @@
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.DurableTask.Grpc": "1.3.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.2.0"
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.21.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.3.0",
-            "fileVersion": "3.400.324.56904"
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1162,20 +1123,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
@@ -1197,7 +1158,7 @@
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1220,116 +1181,115 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Sendgrid": "9.10.0"
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
+          "Azure.Messaging.ServiceBus": "7.18.2",
           "Google.Protobuf": "3.24.3",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
+          "MessagePack": "2.5.192",
           "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "System.IdentityModel.Tokens.Jwt": "6.35.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "6.0.0",
+          "System.Runtime.Caching": "6.0.1",
           "morelinq": "3.4.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.284.0",
-            "fileVersion": "3.1.284.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
         "dependencies": {
           "Azure.Data.Tables": "12.9.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Tables.dll": {
-            "assemblyVersion": "1.3.2.0",
-            "fileVersion": "1.300.224.31302"
+            "assemblyVersion": "1.3.3.0",
+            "fileVersion": "1.300.325.16403"
           }
         }
       },
@@ -1389,9 +1349,9 @@
       },
       "Microsoft.Azure.WebPubSub.Common/1.3.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
@@ -1400,11 +1360,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -1416,17 +1376,17 @@
           }
         }
       },
-      "Microsoft.CSharp/4.5.0": {},
+      "Microsoft.CSharp/4.7.0": {},
       "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
-          "System.Runtime.Caching": "6.0.0"
+          "System.Configuration.ConfigurationManager": "6.0.2",
+          "System.Runtime.Caching": "6.0.1"
         },
         "runtime": {
           "runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll": {
@@ -1492,58 +1452,51 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
-        },
-        "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.51037"
-          }
-        }
-      },
-      "Microsoft.DurableTask.SqlServer/1.5.0": {
-        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "6.0.0"
+          "System.IdentityModel.Tokens.Jwt": "6.35.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.DurableTask.SqlServer": "1.5.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
           "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.6": {
+      "Microsoft.Extensions.Azure/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.6.0",
-            "fileVersion": "1.700.624.50402"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.1000.25.10602"
           }
         }
       },
@@ -1582,11 +1535,18 @@
       },
       "Microsoft.Extensions.DependencyInjection/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net6.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -1626,14 +1586,14 @@
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         }
       },
       "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
@@ -1642,7 +1602,7 @@
       "Microsoft.Extensions.Logging/6.0.0": {
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -1665,7 +1625,7 @@
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
       "Microsoft.Extensions.Options/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
@@ -1673,7 +1633,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
@@ -1695,27 +1655,27 @@
           }
         }
       },
-      "Microsoft.Identity.Client/4.65.0": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
@@ -1732,7 +1692,7 @@
           "Microsoft.IdentityModel.Tokens": "6.35.0",
           "System.Text.Encoding": "4.3.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
@@ -1778,7 +1738,7 @@
       },
       "Microsoft.IdentityModel.Tokens/6.35.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Microsoft.IdentityModel.Logging": "6.35.0",
           "System.Security.Cryptography.Cng": "4.5.0"
         },
@@ -1806,6 +1766,18 @@
           "System.Net.Http": "4.3.4",
           "System.Text.Encodings.Web": "6.0.0",
           "System.Text.RegularExpressions": "4.3.1"
+        }
+      },
+      "Microsoft.NET.StringTools/17.6.3": {
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
         }
       },
       "Microsoft.NETCore.Platforms/1.1.1": {},
@@ -2159,15 +2131,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2183,6 +2155,14 @@
           }
         }
       },
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
       "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -2191,8 +2171,8 @@
       "System.Buffers/4.5.1": {},
       "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
@@ -2254,15 +2234,15 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Configuration.ConfigurationManager/6.0.1": {
+      "System.Configuration.ConfigurationManager/6.0.2": {
         "dependencies": {
           "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
+          "System.Security.Permissions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.922.41905"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2501,7 +2481,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -2532,14 +2512,11 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/6.0.0": {
-        "dependencies": {
-          "System.Text.Json": "6.0.10"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
           "lib/net6.0/System.Memory.Data.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2775,14 +2752,14 @@
           "runtime.any.System.Runtime": "4.3.0"
         }
       },
-      "System.Runtime.Caching/6.0.0": {
+      "System.Runtime.Caching/6.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "6.0.1"
+          "System.Configuration.ConfigurationManager": "6.0.2"
         },
         "runtime": {
           "runtimes/win/lib/net6.0/System.Runtime.Caching.dll": {
             "assemblyVersion": "4.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2840,13 +2817,6 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Security.AccessControl/6.0.0": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -2975,15 +2945,14 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
-      "System.Security.Permissions/6.0.0": {
+      "System.Security.Permissions/6.0.1": {
         "dependencies": {
-          "System.Security.AccessControl": "6.0.0",
           "System.Windows.Extensions": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Security.Permissions.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3032,15 +3001,11 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Text.Json/6.0.10": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.0"
-        },
+      "System.Text.Json/6.0.11": {
         "runtime": {
           "lib/net6.0/System.Text.Json.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3524.45918"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3201,12 +3166,12 @@
       "path": "azure.data.tables/12.9.1",
       "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.1": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7j7ksn+1X2swW2DDDEEywK5wxuYImzMIXnunZTB83E3mwzBbyHOob1hO1wOG5fMZYTGe/+9gyc/qurcozaSm1A==",
-      "path": "azure.identity/1.12.1",
-      "hashPath": "azure.identity.1.12.1.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -3229,12 +3194,12 @@
       "path": "azure.messaging.eventhubs.processor/5.11.5",
       "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
     "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
@@ -3243,26 +3208,26 @@
       "path": "azure.messaging.webpubsub/1.4.0",
       "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.22.1": {
+    "Azure.Storage.Blobs/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-x0TZRhkLQwVf+BYjFJybRu0G8OdIXm0mYZJUgUX2I27DHxHmW6+qR4q3VsbOKYT1r/CFwDKBt7wDVohr14k4bQ==",
-      "path": "azure.storage.blobs/12.22.1",
-      "hashPath": "azure.storage.blobs.12.22.1.nupkg.sha512"
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.22.0": {
+    "Azure.Storage.Common/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0Vm30bRpQ0fcswB0xQMhKAOSXnRygnF2f/029uPaIDLaj1/yfX4jmU0fFjJe9ojGEj/vlAmsApCEOyL9if6zHg==",
-      "path": "azure.storage.common/12.22.0",
-      "hashPath": "azure.storage.common.12.22.0.nupkg.sha512"
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.21.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4Ql71evO/iosdzZD8KFKBByVyvCXvVeC979w8JOdT7UdStncBg4BbnZREq3B56ud4paUgKdPv45qEasTYUsH2w==",
-      "path": "azure.storage.queues/12.21.0",
-      "hashPath": "azure.storage.queues.12.21.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -3285,33 +3250,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "Google.Protobuf/3.24.3": {
       "type": "package",
@@ -3348,19 +3313,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-6OTcSQ8iML+xzmELhH4anUZlNM3dHDKPFBsMLSdiT80LJaaZKxwZml/K9ZdfLIjSR/EzdMZzzU2Avbedz4N7BA==",
+      "path": "grpc.core.api/2.49.0",
+      "hashPath": "grpc.core.api.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-mLXxEJzqnRHseVzRCzSQznA7y8pcSStVbstLTUuQRulN7kREovh82ctNkGpkfwONi/DHoWscX9mJLiAmh0gjOQ==",
+      "path": "grpc.net.client/2.49.0",
+      "hashPath": "grpc.net.client.2.49.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -3369,12 +3334,12 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-G0TVTS8fjCk8b7td/E7C8/ssJPm3JnGVBKsveoj/89PIwIee72qkXG+tVn5c1gwTanEFPdyPoydna/bmU/NAaw==",
+      "path": "grpc.net.common/2.49.0",
+      "hashPath": "grpc.net.common.2.49.0.nupkg.sha512"
     },
     "Grpc.Tools/2.49.0": {
       "type": "package",
@@ -3383,19 +3348,26 @@
       "path": "grpc.tools/2.49.0",
       "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "librdkafka.redist/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "MessagePack/2.5.192": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -3600,26 +3572,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
+    "Microsoft.AspNetCore.WebSockets/2.1.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-wvp85LiIDuFAtbn5FiD4dpAXUBI203yBEtKeNE1I1ipSrUugY2lJVpZAP+C5F5AJ1RZtWvBl+AP1mhkuDNWpag==",
+      "path": "microsoft.aspnetcore.websockets/2.1.1",
+      "hashPath": "microsoft.aspnetcore.websockets.2.1.1.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -3635,19 +3593,19 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
@@ -3670,19 +3628,19 @@
       "path": "microsoft.azure.durabletask.core/3.0.0",
       "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hxhQPd8Ft8n/aETkTzPdA0wTBBOMpF012yCPJMoRzVnRYTkO9OfUADa6gVyLv4HvNRlvYET3MvdNg7dDFp6CJA==",
-      "path": "microsoft.azure.durabletask.netherite/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.3.0.0.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sWVSLuz2TfGzQINIoYCu30ASslyQYhzINhIg8VYL8J3QFlGfrMxXkifJZ5VIt04ZTRihuoUD8/RAZie0DWtvXQ==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.0.0.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -3691,13 +3649,6 @@
       "path": "microsoft.azure.functions.analyzers/1.0.0",
       "hashPath": "microsoft.azure.functions.analyzers.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-rIiuBZyN1lhDkF3oXzaKjyvcDjo9SFtND4+ny6Pyl+qVUHERGk2VmG2BRwep/V6IFE0HseOH/dJhx7lrjbE+BA==",
-      "path": "microsoft.azure.functions.extensions/1.0.0",
-      "hashPath": "microsoft.azure.functions.extensions.1.0.0.nupkg.sha512"
-    },
     "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
       "type": "package",
       "serviceable": true,
@@ -3705,26 +3656,26 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -3761,12 +3712,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XDiqLlFJyhhlqUWNQT4F7ZGSCUbWbsNJ3r/sPAJ+rxnaCwzPS/mspgfF4HX6ABhnOYkZBvMNueXrPPVH6MHGnQ==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.1.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -3775,12 +3726,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bxgSeDk2RbsQzfuuBYLuvWmdGqfUN/R2q9ondIgysWPFvMPGZXrEMvUSyGO6hJshuPpuPdwSz91u/jc8Sq+/3g==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.2.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3789,12 +3740,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DgK/yKI2xodSRwfzThXYjFXtQDfppJjuxhNNYah2Ch6VyasGllOzi8hqvIWeqUopVHEuU0hjM2RhTlDEzpuUJA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.3.nupkg.sha512"
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -3810,12 +3761,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/2.0.3": {
       "type": "package",
@@ -3838,61 +3789,61 @@
       "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
       "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-En6cNhWmEt1eBDg4kvnxSPcw4sQdEwpvW04K7Su+9usbsetZe0EEbYLYMkdxqY6PlHpWfZYH8LsTDBNoC6d8rg==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.284",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.284.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dl+PoO8su2Ho2/QhODq9tIthR2cdBkjbhYvDYkHaF0Fo7hK5QXHO7FgZzRkQlknEnrdxkq0G8uV4R8IZdbSxzw==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bFEzPY420QkiGvlTLXQItYkplklRWSQWigCqt9ZhTNV08uVswd/wgwhdYKP53FP3OugBVTSOsq4e897nnFwKxQ==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RwRZ0OQ2w18YoslTYBhL/JAjExIvAhbADkuS1b6XTh1cmqNqIJiHfshyglwWkctrsqnBgI69UkvuuQKKgvgy9Q==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.3.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7djdtFJFTbDwDIrFgZAQ6MRiBAPFOYdHX9OZ/g9f1D81mBrZwQHZGJOw44bSBC2DvqZLeG+Uwutp8rwEr3fYfQ==",
-      "path": "microsoft.azure.webjobs.extensions.tables/1.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.2.nupkg.sha512"
+      "sha512": "sha512-0MknEtohJx9bGMKHH5tfAFVx/YMV59SUVbfdzif05mELjAUa7DC/3TGyQhXcGn7ZYYDGd2HC0AL+VnXV/KDD+g==",
+      "path": "microsoft.azure.webjobs.extensions.tables/1.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -3936,12 +3887,12 @@
       "path": "microsoft.azure.webpubsub.common/1.3.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.3.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
-      "path": "microsoft.bcl.asyncinterfaces/6.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
+      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
+      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -3950,12 +3901,12 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CSharp/4.5.0": {
+    "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ==",
-      "path": "microsoft.csharp/4.5.0",
-      "hashPath": "microsoft.csharp.4.5.0.nupkg.sha512"
+      "sha512": "sha512-pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA==",
+      "path": "microsoft.csharp/4.7.0",
+      "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
@@ -3978,33 +3929,26 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U0Q+EiOpPoaX1zUPDZSlwXdnKeEoqbaLuJgtqWXwwMqlqPJw14LSc8U6V3+moEZYtcDJgxrxaq7NsGXemyZ2pg==",
-      "path": "microsoft.durabletask.grpc/1.3.0",
-      "hashPath": "microsoft.durabletask.grpc.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.5.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5M726SSosFoh1Aji4HuqbsG58ZwmFJSTaNVycY4Mvrpd4ZpEaeOcQmv8/fJ8Ch2LQlRq2V9RcZXFYm4F5aot4Q==",
-      "path": "microsoft.durabletask.sqlserver/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.5.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+    "Microsoft.Extensions.Azure/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rgNokoVmfnlVJ7vvDKhYaO7BKZqz3nZcGtOdG3obKXzvMQ7x8Nxg4F9WHV6GZTXt2kG2qHekQZBHQlzHsGU1Bg==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.0.nupkg.sha512"
-    },
-    "Microsoft.Extensions.Azure/1.7.6": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-o2dLnQ8cMw5p7KAtxAPukkk4Mhs4tu96nUyFee4lvfLZEkuyTLhLGT2D5o5bagCwHVxqzt+w4Eb4YOl/pLq6Cw==",
-      "path": "microsoft.extensions.azure/1.7.6",
-      "hashPath": "microsoft.extensions.azure.1.7.6.nupkg.sha512"
+      "sha512": "sha512-hKYPTmD2NS/DVxS1vSqO24cAjBO3yFioAiXAzs/9UDjHVJZc2CEowtpPMtNMvhoXknFTyu3nlGTpFlj/ofDUtg==",
+      "path": "microsoft.extensions.azure/1.10.0",
+      "hashPath": "microsoft.extensions.azure.1.10.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/2.2.0": {
       "type": "package",
@@ -4055,12 +3999,12 @@
       "path": "microsoft.extensions.dependencyinjection/6.0.0",
       "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -4167,19 +4111,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.65.0": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RV35ZcJ5/P7n+Zu6J3wmtiDdK6MW5h6EpZ0ojjB9sMwNhGHEJCv829cb3kZ4PZ664llYFv8sbUITWWGvBTqv0Q==",
-      "path": "microsoft.identity.client/4.65.0",
-      "hashPath": "microsoft.identity.client.4.65.0.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JIOBFMAyVSqGWP4dNoST+A9BRJMGC8m73BNbR1oKA8nUjGyR8Fd4eOOME/VDrd26I5JWU4RtmWqpt20lpp2r5w==",
-      "path": "microsoft.identity.client.extensions.msal/4.65.0",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.65.0.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/6.35.0": {
       "type": "package",
@@ -4236,6 +4180,13 @@
       "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
       "path": "microsoft.net.sdk.functions/4.4.0",
       "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+    },
+    "Microsoft.NET.StringTools/17.6.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
     },
     "Microsoft.NETCore.Platforms/1.1.1": {
       "type": "package",
@@ -4615,12 +4566,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "StackExchange.Redis/2.7.4": {
       "type": "package",
@@ -4628,6 +4579,13 @@
       "sha512": "sha512-lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
+    },
+    "starkbank-ecdsa/1.3.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
     },
     "System.AppContext/4.3.0": {
       "type": "package",
@@ -4699,12 +4657,12 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Configuration.ConfigurationManager/6.0.1": {
+    "System.Configuration.ConfigurationManager/6.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jXw9MlUu/kRfEU0WyTptAVueupqIeE3/rl0EZDMlf8pcvJnitQ8HeVEp69rZdaStXwTV72boi/Bhw8lOeO+U2w==",
-      "path": "system.configuration.configurationmanager/6.0.1",
-      "hashPath": "system.configuration.configurationmanager.6.0.1.nupkg.sha512"
+      "sha512": "sha512-LtqgY79MRntWIM0AeQf4uj1mGyqpVhR7O9N1+UODQu/EGQwRTERqMqpYTeedE7VTK2ngoCtxzAaTn9gRDa+6Qw==",
+      "path": "system.configuration.configurationmanager/6.0.2",
+      "hashPath": "system.configuration.configurationmanager.6.0.2.nupkg.sha512"
     },
     "System.Console/4.3.0": {
       "type": "package",
@@ -4895,12 +4853,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/6.0.0": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
-      "path": "system.memory.data/6.0.0",
-      "hashPath": "system.memory.data.6.0.0.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5077,12 +5035,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/6.0.0": {
+    "System.Runtime.Caching/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-E0e03kUp5X2k+UAoVl6efmI7uU7JRBWi5EIdlQ7cr0NpBGjHG4fWII35PgsBY9T4fJQ8E4QPsL0rKksU9gcL5A==",
-      "path": "system.runtime.caching/6.0.0",
-      "hashPath": "system.runtime.caching.6.0.0.nupkg.sha512"
+      "sha512": "sha512-LemwNEizWlwWOAVqKDj6HM42d2eRiujS6Dkom13YqQFE8XzojGMXciUWN2d7Njv5uLbbvG9d5P3gpUJdUZiOcQ==",
+      "path": "system.runtime.caching/6.0.1",
+      "hashPath": "system.runtime.caching.6.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -5132,20 +5090,6 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
-    "System.Security.AccessControl/6.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ==",
-      "path": "system.security.accesscontrol/6.0.0",
-      "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",
@@ -5210,12 +5154,12 @@
       "path": "system.security.cryptography.x509certificates/4.3.0",
       "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
     },
-    "System.Security.Permissions/6.0.0": {
+    "System.Security.Permissions/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
-      "path": "system.security.permissions/6.0.0",
-      "hashPath": "system.security.permissions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-QufGNXopGXxdXbkDn87hta4ajdNKNI3a1+HoJbKkmBbMtYPhEgEJKSiPZHGjI0zQpgZ7gi5L0gSV3PeewKRtew==",
+      "path": "system.security.permissions/6.0.1",
+      "hashPath": "system.security.permissions.6.0.1.nupkg.sha512"
     },
     "System.Security.Principal/4.3.0": {
       "type": "package",
@@ -5252,12 +5196,12 @@
       "path": "system.text.encodings.web/6.0.0",
       "hashPath": "system.text.encodings.web.6.0.0.nupkg.sha512"
     },
-    "System.Text.Json/6.0.10": {
+    "System.Text.Json/6.0.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
-      "path": "system.text.json/6.0.10",
-      "hashPath": "system.text.json.6.0.10.nupkg.sha512"
+      "sha512": "sha512-xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+      "path": "system.text.json/6.0.11",
+      "hashPath": "system.text.json.6.0.11.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -9,28 +9,28 @@
     ".NETCoreApp,Version=v6.0/win-x86": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.1",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.0.3",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.284",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Tables": "1.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.NET.Sdk.Functions": "4.4.0",
           "System.Formats.Asn1": "6.0.1",
@@ -59,13 +59,13 @@
       },
       "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
@@ -79,7 +79,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -91,7 +91,7 @@
       "Azure.Data.Tables/12.9.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
@@ -100,28 +100,27 @@
           }
         }
       },
-      "Azure.Identity/1.12.1": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Identity.Client": "4.65.0",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Text.Json": "6.0.10",
+          "System.Text.Json": "6.0.11",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.1.0",
-            "fileVersion": "1.1200.124.47602"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -135,9 +134,9 @@
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
@@ -152,9 +151,9 @@
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "6.0.0",
@@ -167,25 +166,25 @@
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.ServiceBus/7.18.2": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "System.Memory.Data": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
       "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
@@ -194,40 +193,39 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.22.1": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.22.1.0",
-            "fileVersion": "12.2200.124.47502"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.22.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.22.0.0",
-            "fileVersion": "12.2200.24.56203"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
-      "Azure.Storage.Queues/12.21.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.22.0",
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.56203"
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
@@ -256,7 +254,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -265,58 +263,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "Google.Protobuf": "3.24.3",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -337,7 +335,7 @@
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.AspNetCore.Server.dll": {
@@ -360,7 +358,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.49.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -375,32 +373,32 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
+      "Grpc.Core.Api/2.49.0": {
         "dependencies": {
           "System.Memory": "4.5.5"
         },
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
+          "Grpc.Net.Common": "2.49.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
+          "Grpc.Net.Client": "2.49.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
@@ -410,25 +408,25 @@
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.49.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.49.0"
         },
         "runtime": {
           "lib/net6.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.49.0.0"
           }
         }
       },
       "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "librdkafka.redist/2.4.0": {
         "native": {
-          "runtimes/win-x86/native/libcrypto-1_1.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x86/native/libcrypto-3.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/libcurl.dll": {
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x86/native/librdkafka.dll": {
             "fileVersion": "0.0.0.0"
@@ -436,8 +434,8 @@
           "runtimes/win-x86/native/librdkafkacpp.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x86/native/libssl-1_1.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x86/native/libssl-3.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/msvcp140.dll": {
             "fileVersion": "14.29.30040.0"
@@ -446,25 +444,30 @@
             "fileVersion": "14.29.30040.0"
           },
           "runtimes/win-x86/native/zlib1.dll": {
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x86/native/zstd.dll": {
             "fileVersion": "1.5.2.0"
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -575,7 +578,7 @@
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
+          "Microsoft.AspNetCore.WebSockets": "2.1.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
         }
@@ -602,7 +605,7 @@
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -731,27 +734,7 @@
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
+      "Microsoft.AspNetCore.WebSockets/2.1.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.Extensions.Options": "6.0.0",
@@ -772,46 +755,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "1.7.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
+          "System.Configuration.ConfigurationManager": "6.0.2",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -823,7 +808,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -836,10 +821,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -865,13 +850,13 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
@@ -879,39 +864,27 @@
         "runtime": {
           "lib/netstandard2.0/DurableTask.Netherite.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
-          "Microsoft.Azure.DurableTask.Netherite": "3.0.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2"
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.0.2146"
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
-      "Microsoft.Azure.Functions.Extensions/1.0.0": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.0.0"
-          }
-        }
-      },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
         "dependencies": {
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -920,63 +893,51 @@
           }
         }
       },
-      "Microsoft.Azure.SignalR/1.25.2": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
           "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net6.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -994,8 +955,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1017,7 +978,7 @@
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
@@ -1031,7 +992,7 @@
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "6.0.0"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
@@ -1053,17 +1014,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.CSharp": "4.5.0",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.CSharp": "4.7.0",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.1.0",
-            "fileVersion": "4.8.1.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1085,9 +1047,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
@@ -1096,37 +1058,36 @@
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.DurableTask.Grpc": "1.3.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.2.0"
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
         "dependencies": {
           "Azure.Messaging.EventGrid": "4.21.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.3.0",
-            "fileVersion": "3.400.324.56904"
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
           "Azure.Messaging.EventHubs": "5.11.5",
-          "Azure.Storage.Blobs": "12.22.1",
+          "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1151,20 +1112,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "6.0.1",
           "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
@@ -1186,7 +1147,7 @@
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1209,116 +1170,115 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Sendgrid": "9.10.0"
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
+          "Azure.Messaging.ServiceBus": "7.18.2",
           "Google.Protobuf": "3.24.3",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
+          "MessagePack": "2.5.192",
           "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.Extensions.Azure": "1.7.6",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "System.IdentityModel.Tokens.Jwt": "6.35.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "6.0.0",
+          "System.Runtime.Caching": "6.0.1",
           "morelinq": "3.4.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.284.0",
-            "fileVersion": "3.1.284.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.3",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.3"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.22.1",
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.21.0",
+          "Azure.Storage.Queues": "12.22.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.3.0",
-            "fileVersion": "5.300.324.51001"
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
         "dependencies": {
           "Azure.Data.Tables": "12.9.1",
           "Microsoft.Azure.WebJobs": "3.0.41",
-          "Microsoft.Extensions.Azure": "1.7.6"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Tables.dll": {
-            "assemblyVersion": "1.3.2.0",
-            "fileVersion": "1.300.224.31302"
+            "assemblyVersion": "1.3.3.0",
+            "fileVersion": "1.300.325.16403"
           }
         }
       },
@@ -1378,9 +1338,9 @@
       },
       "Microsoft.Azure.WebPubSub.Common/1.3.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
+          "System.Memory.Data": "6.0.1",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
@@ -1389,11 +1349,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -1405,17 +1365,17 @@
           }
         }
       },
-      "Microsoft.CSharp/4.5.0": {},
+      "Microsoft.CSharp/4.7.0": {},
       "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "6.0.1",
-          "System.Runtime.Caching": "6.0.0"
+          "System.Configuration.ConfigurationManager": "6.0.2",
+          "System.Runtime.Caching": "6.0.1"
         },
         "runtime": {
           "runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll": {
@@ -1481,58 +1441,51 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
-        },
-        "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.51037"
-          }
-        }
-      },
-      "Microsoft.DurableTask.SqlServer/1.5.0": {
-        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "6.0.0"
+          "System.IdentityModel.Tokens.Jwt": "6.35.0",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.2",
-          "Microsoft.DurableTask.SqlServer": "1.5.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
           "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
             "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.61594"
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.6": {
+      "Microsoft.Extensions.Azure/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
-          "Azure.Identity": "1.12.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.6.0",
-            "fileVersion": "1.700.624.50402"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.1000.25.10602"
           }
         }
       },
@@ -1571,11 +1524,18 @@
       },
       "Microsoft.Extensions.DependencyInjection/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net6.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -1615,14 +1575,14 @@
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1"
         }
       },
       "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0"
@@ -1631,7 +1591,7 @@
       "Microsoft.Extensions.Logging/6.0.0": {
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.1",
           "Microsoft.Extensions.Options": "6.0.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
@@ -1654,7 +1614,7 @@
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
       "Microsoft.Extensions.Options/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Primitives": "6.0.0"
         }
       },
@@ -1662,7 +1622,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.Options": "6.0.0"
         }
       },
@@ -1684,27 +1644,27 @@
           }
         }
       },
-      "Microsoft.Identity.Client/4.65.0": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "6.35.0",
           "System.Diagnostics.DiagnosticSource": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.65.0",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.65.0.0",
-            "fileVersion": "4.65.0.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
@@ -1721,7 +1681,7 @@
           "Microsoft.IdentityModel.Tokens": "6.35.0",
           "System.Text.Encoding": "4.3.0",
           "System.Text.Encodings.Web": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
@@ -1767,7 +1727,7 @@
       },
       "Microsoft.IdentityModel.Tokens/6.35.0": {
         "dependencies": {
-          "Microsoft.CSharp": "4.5.0",
+          "Microsoft.CSharp": "4.7.0",
           "Microsoft.IdentityModel.Logging": "6.35.0",
           "System.Security.Cryptography.Cng": "4.5.0"
         },
@@ -1795,6 +1755,18 @@
           "System.Net.Http": "4.3.4",
           "System.Text.Encodings.Web": "6.0.0",
           "System.Text.RegularExpressions": "4.3.1"
+        }
+      },
+      "Microsoft.NET.StringTools/17.6.3": {
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
         }
       },
       "Microsoft.NETCore.Platforms/1.1.1": {},
@@ -2148,15 +2120,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2172,6 +2144,14 @@
           }
         }
       },
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
       "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -2180,8 +2160,8 @@
       "System.Buffers/4.5.1": {},
       "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "6.0.0",
-          "System.Text.Json": "6.0.10"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "6.0.11"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
@@ -2243,15 +2223,15 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Configuration.ConfigurationManager/6.0.1": {
+      "System.Configuration.ConfigurationManager/6.0.2": {
         "dependencies": {
           "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
+          "System.Security.Permissions": "6.0.1"
         },
         "runtime": {
           "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.922.41905"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2490,7 +2470,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -2521,14 +2501,11 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/6.0.0": {
-        "dependencies": {
-          "System.Text.Json": "6.0.10"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
           "lib/net6.0/System.Memory.Data.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2764,14 +2741,14 @@
           "runtime.any.System.Runtime": "4.3.0"
         }
       },
-      "System.Runtime.Caching/6.0.0": {
+      "System.Runtime.Caching/6.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "6.0.1"
+          "System.Configuration.ConfigurationManager": "6.0.2"
         },
         "runtime": {
           "runtimes/win/lib/net6.0/System.Runtime.Caching.dll": {
             "assemblyVersion": "4.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -2829,13 +2806,6 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Security.AccessControl/6.0.0": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -2964,15 +2934,14 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
-      "System.Security.Permissions/6.0.0": {
+      "System.Security.Permissions/6.0.1": {
         "dependencies": {
-          "System.Security.AccessControl": "6.0.0",
           "System.Windows.Extensions": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/System.Security.Permissions.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.21.52210"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3021,15 +2990,11 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
-      "System.Text.Json/6.0.10": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.0"
-        },
+      "System.Text.Json/6.0.11": {
         "runtime": {
           "lib/net6.0/System.Text.Json.dll": {
             "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3524.45918"
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
@@ -3190,12 +3155,12 @@
       "path": "azure.data.tables/12.9.1",
       "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.1": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7j7ksn+1X2swW2DDDEEywK5wxuYImzMIXnunZTB83E3mwzBbyHOob1hO1wOG5fMZYTGe/+9gyc/qurcozaSm1A==",
-      "path": "azure.identity/1.12.1",
-      "hashPath": "azure.identity.1.12.1.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -3218,12 +3183,12 @@
       "path": "azure.messaging.eventhubs.processor/5.11.5",
       "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
     "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
@@ -3232,26 +3197,26 @@
       "path": "azure.messaging.webpubsub/1.4.0",
       "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.22.1": {
+    "Azure.Storage.Blobs/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-x0TZRhkLQwVf+BYjFJybRu0G8OdIXm0mYZJUgUX2I27DHxHmW6+qR4q3VsbOKYT1r/CFwDKBt7wDVohr14k4bQ==",
-      "path": "azure.storage.blobs/12.22.1",
-      "hashPath": "azure.storage.blobs.12.22.1.nupkg.sha512"
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.22.0": {
+    "Azure.Storage.Common/12.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0Vm30bRpQ0fcswB0xQMhKAOSXnRygnF2f/029uPaIDLaj1/yfX4jmU0fFjJe9ojGEj/vlAmsApCEOyL9if6zHg==",
-      "path": "azure.storage.common/12.22.0",
-      "hashPath": "azure.storage.common.12.22.0.nupkg.sha512"
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.21.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4Ql71evO/iosdzZD8KFKBByVyvCXvVeC979w8JOdT7UdStncBg4BbnZREq3B56ud4paUgKdPv45qEasTYUsH2w==",
-      "path": "azure.storage.queues/12.21.0",
-      "hashPath": "azure.storage.queues.12.21.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -3274,33 +3239,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "Google.Protobuf/3.24.3": {
       "type": "package",
@@ -3337,19 +3302,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-6OTcSQ8iML+xzmELhH4anUZlNM3dHDKPFBsMLSdiT80LJaaZKxwZml/K9ZdfLIjSR/EzdMZzzU2Avbedz4N7BA==",
+      "path": "grpc.core.api/2.49.0",
+      "hashPath": "grpc.core.api.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-mLXxEJzqnRHseVzRCzSQznA7y8pcSStVbstLTUuQRulN7kREovh82ctNkGpkfwONi/DHoWscX9mJLiAmh0gjOQ==",
+      "path": "grpc.net.client/2.49.0",
+      "hashPath": "grpc.net.client.2.49.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -3358,12 +3323,12 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.49.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-G0TVTS8fjCk8b7td/E7C8/ssJPm3JnGVBKsveoj/89PIwIee72qkXG+tVn5c1gwTanEFPdyPoydna/bmU/NAaw==",
+      "path": "grpc.net.common/2.49.0",
+      "hashPath": "grpc.net.common.2.49.0.nupkg.sha512"
     },
     "Grpc.Tools/2.49.0": {
       "type": "package",
@@ -3372,19 +3337,26 @@
       "path": "grpc.tools/2.49.0",
       "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "librdkafka.redist/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "MessagePack/2.5.192": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -3589,26 +3561,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
+    "Microsoft.AspNetCore.WebSockets/2.1.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-wvp85LiIDuFAtbn5FiD4dpAXUBI203yBEtKeNE1I1ipSrUugY2lJVpZAP+C5F5AJ1RZtWvBl+AP1mhkuDNWpag==",
+      "path": "microsoft.aspnetcore.websockets/2.1.1",
+      "hashPath": "microsoft.aspnetcore.websockets.2.1.1.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -3624,19 +3582,19 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
@@ -3659,19 +3617,19 @@
       "path": "microsoft.azure.durabletask.core/3.0.0",
       "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hxhQPd8Ft8n/aETkTzPdA0wTBBOMpF012yCPJMoRzVnRYTkO9OfUADa6gVyLv4HvNRlvYET3MvdNg7dDFp6CJA==",
-      "path": "microsoft.azure.durabletask.netherite/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.3.0.0.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.0.0": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sWVSLuz2TfGzQINIoYCu30ASslyQYhzINhIg8VYL8J3QFlGfrMxXkifJZ5VIt04ZTRihuoUD8/RAZie0DWtvXQ==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.0.0",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.0.0.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -3680,13 +3638,6 @@
       "path": "microsoft.azure.functions.analyzers/1.0.0",
       "hashPath": "microsoft.azure.functions.analyzers.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-rIiuBZyN1lhDkF3oXzaKjyvcDjo9SFtND4+ny6Pyl+qVUHERGk2VmG2BRwep/V6IFE0HseOH/dJhx7lrjbE+BA==",
-      "path": "microsoft.azure.functions.extensions/1.0.0",
-      "hashPath": "microsoft.azure.functions.extensions.1.0.0.nupkg.sha512"
-    },
     "Microsoft.Azure.Functions.Extensions.Dapr.Core/1.0.1": {
       "type": "package",
       "serviceable": true,
@@ -3694,26 +3645,26 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -3750,12 +3701,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XDiqLlFJyhhlqUWNQT4F7ZGSCUbWbsNJ3r/sPAJ+rxnaCwzPS/mspgfF4HX6ABhnOYkZBvMNueXrPPVH6MHGnQ==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.1.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -3764,12 +3715,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bxgSeDk2RbsQzfuuBYLuvWmdGqfUN/R2q9ondIgysWPFvMPGZXrEMvUSyGO6hJshuPpuPdwSz91u/jc8Sq+/3g==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.2.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3778,12 +3729,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.3": {
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DgK/yKI2xodSRwfzThXYjFXtQDfppJjuxhNNYah2Ch6VyasGllOzi8hqvIWeqUopVHEuU0hjM2RhTlDEzpuUJA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.3.nupkg.sha512"
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -3799,12 +3750,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/2.0.3": {
       "type": "package",
@@ -3827,61 +3778,61 @@
       "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
       "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.284": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-En6cNhWmEt1eBDg4kvnxSPcw4sQdEwpvW04K7Su+9usbsetZe0EEbYLYMkdxqY6PlHpWfZYH8LsTDBNoC6d8rg==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.284",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.284.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dl+PoO8su2Ho2/QhODq9tIthR2cdBkjbhYvDYkHaF0Fo7hK5QXHO7FgZzRkQlknEnrdxkq0G8uV4R8IZdbSxzw==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bFEzPY420QkiGvlTLXQItYkplklRWSQWigCqt9ZhTNV08uVswd/wgwhdYKP53FP3OugBVTSOsq4e897nnFwKxQ==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.3.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.3": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RwRZ0OQ2w18YoslTYBhL/JAjExIvAhbADkuS1b6XTh1cmqNqIJiHfshyglwWkctrsqnBgI69UkvuuQKKgvgy9Q==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.3.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Tables/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7djdtFJFTbDwDIrFgZAQ6MRiBAPFOYdHX9OZ/g9f1D81mBrZwQHZGJOw44bSBC2DvqZLeG+Uwutp8rwEr3fYfQ==",
-      "path": "microsoft.azure.webjobs.extensions.tables/1.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.2.nupkg.sha512"
+      "sha512": "sha512-0MknEtohJx9bGMKHH5tfAFVx/YMV59SUVbfdzif05mELjAUa7DC/3TGyQhXcGn7ZYYDGd2HC0AL+VnXV/KDD+g==",
+      "path": "microsoft.azure.webjobs.extensions.tables/1.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.tables.1.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -3925,12 +3876,12 @@
       "path": "microsoft.azure.webpubsub.common/1.3.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.3.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/6.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
-      "path": "microsoft.bcl.asyncinterfaces/6.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
+      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
+      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -3939,12 +3890,12 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CSharp/4.5.0": {
+    "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ==",
-      "path": "microsoft.csharp/4.5.0",
-      "hashPath": "microsoft.csharp.4.5.0.nupkg.sha512"
+      "sha512": "sha512-pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA==",
+      "path": "microsoft.csharp/4.7.0",
+      "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
@@ -3967,33 +3918,26 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U0Q+EiOpPoaX1zUPDZSlwXdnKeEoqbaLuJgtqWXwwMqlqPJw14LSc8U6V3+moEZYtcDJgxrxaq7NsGXemyZ2pg==",
-      "path": "microsoft.durabletask.grpc/1.3.0",
-      "hashPath": "microsoft.durabletask.grpc.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.5.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5M726SSosFoh1Aji4HuqbsG58ZwmFJSTaNVycY4Mvrpd4ZpEaeOcQmv8/fJ8Ch2LQlRq2V9RcZXFYm4F5aot4Q==",
-      "path": "microsoft.durabletask.sqlserver/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.5.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.0": {
+    "Microsoft.Extensions.Azure/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rgNokoVmfnlVJ7vvDKhYaO7BKZqz3nZcGtOdG3obKXzvMQ7x8Nxg4F9WHV6GZTXt2kG2qHekQZBHQlzHsGU1Bg==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.0.nupkg.sha512"
-    },
-    "Microsoft.Extensions.Azure/1.7.6": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-o2dLnQ8cMw5p7KAtxAPukkk4Mhs4tu96nUyFee4lvfLZEkuyTLhLGT2D5o5bagCwHVxqzt+w4Eb4YOl/pLq6Cw==",
-      "path": "microsoft.extensions.azure/1.7.6",
-      "hashPath": "microsoft.extensions.azure.1.7.6.nupkg.sha512"
+      "sha512": "sha512-hKYPTmD2NS/DVxS1vSqO24cAjBO3yFioAiXAzs/9UDjHVJZc2CEowtpPMtNMvhoXknFTyu3nlGTpFlj/ofDUtg==",
+      "path": "microsoft.extensions.azure/1.10.0",
+      "hashPath": "microsoft.extensions.azure.1.10.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/2.2.0": {
       "type": "package",
@@ -4044,12 +3988,12 @@
       "path": "microsoft.extensions.dependencyinjection/6.0.0",
       "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -4156,19 +4100,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.65.0": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RV35ZcJ5/P7n+Zu6J3wmtiDdK6MW5h6EpZ0ojjB9sMwNhGHEJCv829cb3kZ4PZ664llYFv8sbUITWWGvBTqv0Q==",
-      "path": "microsoft.identity.client/4.65.0",
-      "hashPath": "microsoft.identity.client.4.65.0.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.65.0": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JIOBFMAyVSqGWP4dNoST+A9BRJMGC8m73BNbR1oKA8nUjGyR8Fd4eOOME/VDrd26I5JWU4RtmWqpt20lpp2r5w==",
-      "path": "microsoft.identity.client.extensions.msal/4.65.0",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.65.0.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/6.35.0": {
       "type": "package",
@@ -4225,6 +4169,13 @@
       "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
       "path": "microsoft.net.sdk.functions/4.4.0",
       "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+    },
+    "Microsoft.NET.StringTools/17.6.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
     },
     "Microsoft.NETCore.Platforms/1.1.1": {
       "type": "package",
@@ -4604,12 +4555,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "StackExchange.Redis/2.7.4": {
       "type": "package",
@@ -4617,6 +4568,13 @@
       "sha512": "sha512-lD6a0lGOCyV9iuvObnzStL74EDWAyK31w6lS+Md9gIz1eP4U6KChDIflzTdtrktxlvVkeOvPtkaYOcm4qjbHSw==",
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
+    },
+    "starkbank-ecdsa/1.3.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
     },
     "System.AppContext/4.3.0": {
       "type": "package",
@@ -4688,12 +4646,12 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Configuration.ConfigurationManager/6.0.1": {
+    "System.Configuration.ConfigurationManager/6.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jXw9MlUu/kRfEU0WyTptAVueupqIeE3/rl0EZDMlf8pcvJnitQ8HeVEp69rZdaStXwTV72boi/Bhw8lOeO+U2w==",
-      "path": "system.configuration.configurationmanager/6.0.1",
-      "hashPath": "system.configuration.configurationmanager.6.0.1.nupkg.sha512"
+      "sha512": "sha512-LtqgY79MRntWIM0AeQf4uj1mGyqpVhR7O9N1+UODQu/EGQwRTERqMqpYTeedE7VTK2ngoCtxzAaTn9gRDa+6Qw==",
+      "path": "system.configuration.configurationmanager/6.0.2",
+      "hashPath": "system.configuration.configurationmanager.6.0.2.nupkg.sha512"
     },
     "System.Console/4.3.0": {
       "type": "package",
@@ -4884,12 +4842,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/6.0.0": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
-      "path": "system.memory.data/6.0.0",
-      "hashPath": "system.memory.data.6.0.0.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5066,12 +5024,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/6.0.0": {
+    "System.Runtime.Caching/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-E0e03kUp5X2k+UAoVl6efmI7uU7JRBWi5EIdlQ7cr0NpBGjHG4fWII35PgsBY9T4fJQ8E4QPsL0rKksU9gcL5A==",
-      "path": "system.runtime.caching/6.0.0",
-      "hashPath": "system.runtime.caching.6.0.0.nupkg.sha512"
+      "sha512": "sha512-LemwNEizWlwWOAVqKDj6HM42d2eRiujS6Dkom13YqQFE8XzojGMXciUWN2d7Njv5uLbbvG9d5P3gpUJdUZiOcQ==",
+      "path": "system.runtime.caching/6.0.1",
+      "hashPath": "system.runtime.caching.6.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -5121,20 +5079,6 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
-    "System.Security.AccessControl/6.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-AUADIc0LIEQe7MzC+I0cl0rAT8RrTAKFHl53yHjEUzNVIaUlhFY11vc2ebiVJzVBuOzun6F7FBA+8KAbGTTedQ==",
-      "path": "system.security.accesscontrol/6.0.0",
-      "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",
@@ -5199,12 +5143,12 @@
       "path": "system.security.cryptography.x509certificates/4.3.0",
       "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
     },
-    "System.Security.Permissions/6.0.0": {
+    "System.Security.Permissions/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
-      "path": "system.security.permissions/6.0.0",
-      "hashPath": "system.security.permissions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-QufGNXopGXxdXbkDn87hta4ajdNKNI3a1+HoJbKkmBbMtYPhEgEJKSiPZHGjI0zQpgZ7gi5L0gSV3PeewKRtew==",
+      "path": "system.security.permissions/6.0.1",
+      "hashPath": "system.security.permissions.6.0.1.nupkg.sha512"
     },
     "System.Security.Principal/4.3.0": {
       "type": "package",
@@ -5241,12 +5185,12 @@
       "path": "system.text.encodings.web/6.0.0",
       "hashPath": "system.text.encodings.web.6.0.0.nupkg.sha512"
     },
-    "System.Text.Json/6.0.10": {
+    "System.Text.Json/6.0.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NSB0kDipxn2ychp88NXWfFRFlmi1bst/xynOutbnpEfRCT9JZkZ7KOmF/I/hNKo2dILiMGnqblm+j1sggdLB9g==",
-      "path": "system.text.json/6.0.10",
-      "hashPath": "system.text.json.6.0.10.nupkg.sha512"
+      "sha512": "sha512-xqC1HIbJMBFhrpYs76oYP+NAskNVjc6v73HqLal7ECRDPIp4oRU5pPavkD//vNactCn9DA2aaald/I5N+uZ5/g==",
+      "path": "system.text.json/6.0.11",
+      "hashPath": "system.text.json.6.0.11.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage",
-    "version": "5.3.3",
+    "majorVersion": "5",
     "name": "AzureStorage",
     "bindings": [
       "blobtrigger",
@@ -12,7 +12,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
-    "version": "5.3.3",
+    "majorVersion": "5",
     "name": "AzureStorageQueues",
     "bindings": [
       "queue",
@@ -29,7 +29,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
-    "version": "5.3.3",
+    "majorVersion": "5",
     "name": "AzureStorageBlobs",
     "bindings": [
       "blobtrigger",


### PR DESCRIPTION
Unpin storage extensions and update test dependencies.

Kafka update:
```
  - Confluent.Kafka.dll: 1.9.0.0/1.9.0.0 -> 2.4.0.0/2.4.0.0
  - Confluent.SchemaRegistry.dll: 1.9.0.0/1.9.0.0 -> 2.4.0.0/2.4.0.0
  - Confluent.SchemaRegistry.Serdes.Avro.dll: 1.9.0.0/1.9.0.0 -> 2.4.0.0/2.4.0.0
  - Confluent.SchemaRegistry.Serdes.Protobuf.dll: 1.9.0.0/1.9.0.0 -> 2.4.0.0/2.4.0.0
  - Microsoft.Azure.WebJobs.Extensions.Kafka.dll: 3.9.0.0/3.9.0.0 -> 4.1.0.0/4.1.0.0
```
SignalR update:

```
  - MessagePack.dll: 1.9.0.0/1.9.11.48492 -> 2.5.0.0/2.5.192.54228
  - Microsoft.Azure.WebJobs.Extensions.SignalRService.dll: 1.14.0.0/1.1400.24.28101 -> 2.0.1.0/2.0.125.16401
```

Storage update: - (**causing below updates for all extensions**)
```
  - Microsoft.Bcl.AsyncInterfaces.dll: 6.0.0.0/6.0.21.52210 -> 8.0.0.0/8.0.23.53103 
  - Microsoft.Azure.Core.NewtonsoftJson.dll: 1.0.0.0/1.0.21.5702 -> 2.0.0.0/2.0.23.61406
```