### PR TITLE
Upgrade to dotnet 8 and enable vulnerability report check

### DIFF
--- a/ExtensionBundle.Tests/ExtensionBundle.Tests.csproj
+++ b/ExtensionBundle.Tests/ExtensionBundle.Tests.csproj
@@ -2,16 +2,16 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<AssemblyName>Microsoft.Azure.Functions.ExtensionBundle.Tests</AssemblyName>
 		<RootNamespace>Microsoft.Azure.Functions.ExtensionBundle.Tests</RootNamespace>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Colors.Net" Version="1.1.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="NuGet.Versioning" Version="6.12.1" />
-		<PackageReference Include="NuGet.Protocol" Version="6.12.1" />
-		<PackageReference Include="System.IO.Abstractions" Version="21.1.7" />
+		<PackageReference Include="NuGet.Versioning" Version="6.13.2" />
+		<PackageReference Include="NuGet.Protocol" Version="6.13.2" />
+		<PackageReference Include="System.IO.Abstractions" Version="22.0.12" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Remove="runtimes.json" />

--- a/build/Build.sln
+++ b/build/Build.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29324.147
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build", "Build.csproj", "{8DE7CCB0-583B-44F6-8009-A8D5783F9CD6}"
 EndProject

--- a/build/Build.sln
+++ b/build/Build.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35913.81 d17.13
+VisualStudioVersion = 17.13.35913.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Build", "Build.csproj", "{8DE7CCB0-583B-44F6-8009-A8D5783F9CD6}"
 EndProject

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -2,44 +2,44 @@ parameters:
   - name: official
     type: boolean
     default: false
-
+    
 jobs:
-  - job: Build
-    displayName: Build and publish artifacts
+- job: Build
+  displayName: Build and publish artifacts
 
-    templateContext:
-      outputParentDirectory: $(Build.ArtifactStagingDirectory)
-      outputs:
-        - output: pipelineArtifact
-          displayName: Publish bundles
-          path: $(Build.ArtifactStagingDirectory)
-          artifact: zip
+  templateContext:
+    outputParentDirectory: $(Build.ArtifactStagingDirectory)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish bundles
+      path: $(Build.ArtifactStagingDirectory)
+      artifact: zip
 
-    steps:
-      - task: DownloadBuildArtifacts@1
-        inputs:
-          buildType: 'specific'
-          project: '3f99e810-c336-441f-8892-84983093ad7f'
-          pipeline: '963'
-          buildVersionToDownload: 'latestFromBranch'
-          branchName: 'refs/heads/release/main'
-          downloadType: 'single'
-          artifactName: 'drop'
-          downloadPath: '$(Build.Repository.LocalPath)\templatesArtifacts'
-        condition: ${{ parameters.official }}
+  steps:
+  - task: DownloadBuildArtifacts@1
+    inputs:
+      buildType: 'specific'
+      project: '3f99e810-c336-441f-8892-84983093ad7f'
+      pipeline: '963'
+      buildVersionToDownload: 'latestFromBranch'
+      branchName: 'refs/heads/release/main'
+      downloadType: 'single'
+      artifactName: 'drop'
+      downloadPath: '$(Build.Repository.LocalPath)\templatesArtifacts'
+    condition: ${{ parameters.official }}
 
-      - task: DotNetCoreCLI@2
-        displayName: 'Build'
-        inputs:
-          command: 'run'
-          workingDirectory: '.\build'
-          ${{ if eq(parameters.official, false) }}:
-            arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
+  - task: DotNetCoreCLI@2
+    displayName: 'Build'
+    inputs:
+      command: 'run'
+      workingDirectory: '.\build'
+      ${{ if eq(parameters.official, false) }}:
+        arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
 
-      - ${{ if eq(parameters.official, true) }}:
-          - task: CopyFiles@2
-            inputs:
-              SourceFolder: '$(Build.Repository.LocalPath)\artifacts'
-              Contents: '*.zip'
-              TargetFolder: '$(Build.ArtifactStagingDirectory)'
-              CleanTargetFolder: false
+  - ${{ if eq(parameters.official, true) }}:
+    - task: CopyFiles@2
+      inputs:
+        SourceFolder: '$(Build.Repository.LocalPath)\artifacts'
+        Contents: '*.zip'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        CleanTargetFolder: false

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -2,46 +2,44 @@ parameters:
   - name: official
     type: boolean
     default: false
-    
+
 jobs:
-- job: Build
-  displayName: Build and publish artifacts
+  - job: Build
+    displayName: Build and publish artifacts
 
-  templateContext:
-    outputParentDirectory: $(Build.ArtifactStagingDirectory)
-    outputs:
-    - output: pipelineArtifact
-      displayName: Publish bundles
-      path: $(Build.ArtifactStagingDirectory)
-      artifact: zip
+    templateContext:
+      outputParentDirectory: $(Build.ArtifactStagingDirectory)
+      outputs:
+        - output: pipelineArtifact
+          displayName: Publish bundles
+          path: $(Build.ArtifactStagingDirectory)
+          artifact: zip
 
-  steps:
-  - task: DownloadBuildArtifacts@1
-    inputs:
-      buildType: 'specific'
-      project: '3f99e810-c336-441f-8892-84983093ad7f'
-      pipeline: '963'
-      buildVersionToDownload: 'latestFromBranch'
-      branchName: 'refs/heads/release/main'
-      downloadType: 'single'
-      artifactName: 'drop'
-      downloadPath: '$(Build.Repository.LocalPath)\templatesArtifacts'
-    condition: ${{ parameters.official }}
+    steps:
+      - task: DownloadBuildArtifacts@1
+        inputs:
+          buildType: 'specific'
+          project: '3f99e810-c336-441f-8892-84983093ad7f'
+          pipeline: '963'
+          buildVersionToDownload: 'latestFromBranch'
+          branchName: 'refs/heads/release/main'
+          downloadType: 'single'
+          artifactName: 'drop'
+          downloadPath: '$(Build.Repository.LocalPath)\templatesArtifacts'
+        condition: ${{ parameters.official }}
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Build'
-    inputs:
-      command: 'run'
-      workingDirectory: '.\build'
-      ${{ if eq(parameters.official, false) }}:
-        arguments: 'skip:DownloadTemplates,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
-      ${{ else }}:
-        arguments: 'skip:GenerateVulnerabilityReport'
+      - task: DotNetCoreCLI@2
+        displayName: 'Build'
+        inputs:
+          command: 'run'
+          workingDirectory: '.\build'
+          ${{ if eq(parameters.official, false) }}:
+            arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
 
-  - ${{ if eq(parameters.official, true) }}:
-    - task: CopyFiles@2
-      inputs:
-        SourceFolder: '$(Build.Repository.LocalPath)\artifacts'
-        Contents: '*.zip'
-        TargetFolder: '$(Build.ArtifactStagingDirectory)'
-        CleanTargetFolder: false
+      - ${{ if eq(parameters.official, true) }}:
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: '$(Build.Repository.LocalPath)\artifacts'
+              Contents: '*.zip'
+              TargetFolder: '$(Build.ArtifactStagingDirectory)'
+              CleanTargetFolder: false

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.csproj
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -207,7 +207,7 @@
   {
     "id": "System.Drawing.Common",
     "Version": "6.0.0",
-    "name": "SystemDrawingCommon", // pinning until MySQL extension fixes this transitive dependency
+    "name": "SystemDrawingCommon",
     "bindings": []
   },
   {

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -205,6 +205,12 @@
     "bindings": []
   },
   {
+    "id": "System.Drawing.Common",
+    "Version": "6.0.0",
+    "name": "SystemDrawingCommon", // pinning until MySQL extension fixes this transitive dependency
+    "bindings": []
+  },
+  {
     "id": "Microsoft.Azure.WebJobs.Extensions.Dapr",
     "majorVersion": "1",
     "name": "Dapr",


### PR DESCRIPTION
- Upgrade 3 projects to dotnet 8 as dotnet 6 is out of support
- Update nuget packages
- Stop skipping GenerateVulnerabilityReportCheck
- Pin System.Drawing.Common to 6.0.0 until MySQL fixes the transitive dependency
- Verified BlobTrigger working locally