### PR TITLE
Use experimental bundle and add Mcp extension

### DIFF
--- a/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -1,39 +1,43 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v6.0",
+    "name": ".NETCoreApp,Version=v8.0",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v6.0": {
+    ".NETCoreApp,Version=v8.0": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "1.5.4",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.0.0-beta423",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.2",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "0.4.2-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.1.54-rc",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.10-Preview",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.3.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.2.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.15.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.2.9-rc",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.11-Preview",
+          "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.31-preview",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.4.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.3.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.16.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.169-preview",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.3.0",
-          "Microsoft.NET.Sdk.Functions": "4.4.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0-beta.4",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
+          "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
         },
@@ -77,9 +81,9 @@
       },
       "Azure.AI.OpenAI/1.0.0-beta.15": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.ClientModel": "1.0.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.ClientModel": "1.1.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.AI.OpenAI.dll": {
@@ -88,21 +92,21 @@
           }
         }
       },
-      "Azure.Core/1.41.0": {
+      "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.ClientModel": "1.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Core.dll": {
-            "assemblyVersion": "1.41.0.0",
-            "fileVersion": "1.4100.24.36109"
+            "assemblyVersion": "1.44.1.0",
+            "fileVersion": "1.4400.124.50905"
           }
         }
       },
@@ -110,7 +114,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -119,40 +123,39 @@
           }
         }
       },
-      "Azure.Data.Tables/12.8.3": {
+      "Azure.Data.Tables/12.9.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
-            "assemblyVersion": "12.8.3.0",
-            "fileVersion": "12.800.324.10602"
+            "assemblyVersion": "12.9.1.0",
+            "fileVersion": "12.900.124.46702"
           }
         }
       },
-      "Azure.Identity/1.12.0": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.0.0",
-            "fileVersion": "1.1200.24.31701"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -161,82 +164,112 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.9.2": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Threading.Channels": "4.7.1",
+          "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.9.2.0",
-            "fileVersion": "5.900.223.30602"
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.41401"
+          }
+        }
+      },
+      "Azure.Messaging.ServiceBus/7.18.2": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.Memory.Data": "1.0.2"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
-      "Azure.Search.Documents/11.5.1": {
+      "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Channels": "4.7.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.40602"
+          }
+        }
+      },
+      "Azure.Search.Documents/11.6.0": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Search.Documents.dll": {
-            "assemblyVersion": "11.5.1.0",
-            "fileVersion": "11.500.123.57802"
+            "assemblyVersion": "11.6.0.0",
+            "fileVersion": "11.600.24.36703"
           }
         }
       },
-      "Azure.Storage.Blobs/12.21.0": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.36603"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.20.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.20.0.0",
-            "fileVersion": "12.2000.24.36603"
+          "lib/net8.0/Azure.Storage.Common.dll": {
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
       "Azure.Storage.Files.DataLake/12.18.0": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Files.DataLake.dll": {
@@ -245,22 +278,21 @@
           }
         }
       },
-      "Azure.Storage.Queues/12.19.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
-          "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.19.0.0",
-            "fileVersion": "12.1900.24.36603"
+          "lib/net8.0/Azure.Storage.Queues.dll": {
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
       "Castle.Core/5.0.0": {
         "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
+          "System.Diagnostics.EventLog": "8.0.1"
         },
         "runtime": {
           "lib/net6.0/Castle.Core.dll": {
@@ -283,7 +315,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -292,58 +324,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Google.Protobuf": "3.24.3",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Google.Protobuf": "3.28.2",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -358,27 +390,27 @@
           }
         }
       },
-      "Google.Protobuf/3.24.3": {
+      "Google.Protobuf/3.28.2": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.24.3.0",
-            "fileVersion": "3.24.3.0"
+            "assemblyVersion": "3.28.2.0",
+            "fileVersion": "3.28.2.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
+          "Google.Protobuf": "3.28.2",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.49.0"
+          "Grpc.Tools": "2.68.1"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -390,7 +422,7 @@
           "Grpc.Net.ClientFactory": "2.49.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -398,7 +430,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.67.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -435,54 +467,80 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
-        "dependencies": {
-          "System.Memory": "4.5.5"
-        },
+      "Grpc.Core.Api/2.67.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.67.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Grpc.Net.Common": "2.67.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Client.dll": {
+          "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.ClientFactory.dll": {
+          "lib/net7.0/Grpc.Net.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.67.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Common.dll": {
+          "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "Grpc.Tools/2.68.1": {},
+      "K4os.Compression.LZ4/1.3.5": {
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Compression.LZ4.Streams/1.3.5": {
+        "dependencies": {
+          "K4os.Compression.LZ4": "1.3.5",
+          "K4os.Hash.xxHash": "1.0.8",
+          "System.IO.Pipelines": "6.0.3"
+        },
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.Streams.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Hash.xxHash/1.0.8": {
+        "runtime": {
+          "lib/net6.0/K4os.Hash.xxHash.dll": {
+            "assemblyVersion": "1.0.8.0",
+            "fileVersion": "1.0.8.0"
+          }
+        }
+      },
+      "librdkafka.redist/2.4.0": {
         "runtimeTargets": {
           "runtimes/linux-arm64/native/librdkafka.so": {
             "rid": "linux-arm64",
@@ -509,20 +567,25 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
+          "runtimes/osx-arm64/native/librdkafka.dylib": {
+            "rid": "osx-arm64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
           "runtimes/osx-x64/native/librdkafka.dylib": {
             "rid": "osx-x64",
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/libcrypto-1_1-x64.dll": {
+          "runtimes/win-x64/native/libcrypto-3-x64.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/libcurl.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x64/native/librdkafka.dll": {
             "rid": "win-x64",
@@ -534,30 +597,30 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/libssl-1_1-x64.dll": {
+          "runtimes/win-x64/native/libssl-3-x64.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/zlib1.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x64/native/zstd.dll": {
             "rid": "win-x64",
             "assetType": "native",
             "fileVersion": "1.5.2.0"
           },
-          "runtimes/win-x86/native/libcrypto-1_1.dll": {
+          "runtimes/win-x86/native/libcrypto-3.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/libcurl.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x86/native/librdkafka.dll": {
             "rid": "win-x86",
@@ -569,10 +632,10 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x86/native/libssl-1_1.dll": {
+          "runtimes/win-x86/native/libssl-3.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.1.1.14"
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/msvcp140.dll": {
             "rid": "win-x86",
@@ -587,7 +650,7 @@
           "runtimes/win-x86/native/zlib1.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x86/native/zstd.dll": {
             "rid": "win-x86",
@@ -596,18 +659,23 @@
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -619,6 +687,90 @@
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
             "assemblyVersion": "2.22.0.997",
             "fileVersion": "2.22.0.997"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.AspNetCore/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.EventCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Microsoft.AspNetCore.Hosting": "2.2.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.21.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.ApplicationInsights.AspNetCore.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.DependencyCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.EventCounterCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.EventCounterCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.Extensions.Caching.Memory": "1.0.0",
+          "System.Diagnostics.PerformanceCounter": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.PerfCounterCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.WindowsServer.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.ServerTelemetryChannel.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
           }
         }
       },
@@ -637,8 +789,8 @@
       "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
@@ -650,8 +802,8 @@
       },
       "Microsoft.AspNetCore.Authorization/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
@@ -663,7 +815,7 @@
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         }
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
@@ -671,14 +823,14 @@
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Configuration": "2.2.0",
+          "Microsoft.Extensions.Configuration": "3.1.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reflection.Metadata": "1.6.0"
         }
@@ -693,7 +845,7 @@
       "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
         }
       },
       "Microsoft.AspNetCore.Http/2.2.2": {
@@ -701,7 +853,7 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0"
         }
       },
@@ -711,36 +863,17 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Buffers": "4.5.1"
         }
       },
       "Microsoft.AspNetCore.Http.Features/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
@@ -772,10 +905,10 @@
           "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -802,16 +935,16 @@
       },
       "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing/2.2.2": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
@@ -824,7 +957,7 @@
           "Microsoft.AspNetCore.Hosting": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Https": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1"
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
@@ -834,8 +967,8 @@
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
@@ -867,38 +1000,11 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.WebUtilities/2.2.0": {
@@ -915,46 +1021,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "8.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -975,51 +1083,54 @@
           "runtimes/win-x64/native/msvcp140.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140_1.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.1.0.0",
-            "fileVersion": "0.1.6.6114"
+            "assemblyVersion": "0.2.0.0",
+            "fileVersion": "0.2.0.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
         "dependencies": {
-          "Azure.Data.Tables": "12.8.3",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "WindowsAzure.Storage": "9.3.1"
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "1.17.0.0",
-            "fileVersion": "1.17.4.42221"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.1.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/2.17.1": {
+      "Microsoft.Azure.DurableTask.Core/3.0.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reactive.Compatibility": "4.4.1",
@@ -1027,80 +1138,47 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "2.17.0.0",
-            "fileVersion": "2.17.1.6114"
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.42734"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.EventHubs.Processor": "4.3.2",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Messaging.EventHubs.Processor": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Threading.Channels": "4.7.1"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
-        "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.DurableTask.Netherite": "1.5.4",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.AzureFunctions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Azure.Services.AppAuthentication": "1.0.3",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.EventHubs": "4.3.2",
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.Processor.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
+          "lib/netstandard2.0/DurableTask.Netherite.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
+          }
+        }
+      },
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
+        },
+        "runtime": {
+          "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
       "Microsoft.Azure.Functions.Extensions/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
@@ -1111,7 +1189,7 @@
       },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/0.17.0-preview01": {
         "dependencies": {
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -1120,250 +1198,134 @@
           }
         }
       },
-      "Microsoft.Azure.KeyVault.Core/3.0.3": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.0.0-beta423": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1"
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
+          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "System.Drawing.Common": "4.7.3",
+          "System.Net.Http": "4.3.4",
+          "System.Net.ServerSentEvents": "10.0.0-preview.1.25080.5",
+          "System.Text.RegularExpressions": "4.3.1"
         },
         "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.KeyVault.Core.dll": {
-            "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.3.0"
+          "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1",
           "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
           "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
           "System.Security.Principal.Windows": "5.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.Msal.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Data/12.2.3": {
+      "Microsoft.Azure.Kusto.Data/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Data.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+      "Microsoft.Azure.Kusto.Ingest/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Ingest.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.14.2",
-          "NETStandard.Library": "2.0.1",
-          "System.Diagnostics.Process": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.Services.AppAuthentication.dll": {
-            "assemblyVersion": "1.0.3.0",
-            "fileVersion": "1.0.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.SignalR/1.25.2": {
-        "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Common.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
-          "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "3.1.32",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -1381,8 +1343,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1392,69 +1354,44 @@
           }
         }
       },
-      "Microsoft.Azure.Storage.Blob/11.2.3": {
+      "Microsoft.Azure.WebJobs/3.0.41": {
         "dependencies": {
-          "Microsoft.Azure.Storage.Common": "11.2.3",
-          "NETStandard.Library": "2.0.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Blob.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.Storage.Common/11.2.3": {
-        "dependencies": {
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "NETStandard.Library": "2.0.1",
-          "Newtonsoft.Json": "13.0.3"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Common.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.WebJobs/3.0.39": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.39",
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Microsoft.Azure.WebJobs.Core": "3.0.41",
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
-          "Microsoft.Extensions.Configuration.Json": "2.1.0",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
           "Microsoft.Extensions.Hosting": "2.1.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.39": {
+      "Microsoft.Azure.WebJobs.Core/3.0.41": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Host.Storage": "3.0.14",
           "ncrontab.signed": "3.3.0"
         },
@@ -1468,7 +1405,7 @@
       "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/1.0.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -1480,17 +1417,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.0.0",
-            "fileVersion": "4.8.0.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1502,8 +1440,8 @@
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
@@ -1512,50 +1450,68 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.1.6",
-          "Microsoft.Azure.DurableTask.AzureStorage": "1.17.4",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.0.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
-          "Microsoft.DurableTask.Grpc": "1.1.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/netcoreapp3.1/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
-            "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.13.5.0"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
         "dependencies": {
-          "Azure.Messaging.EventGrid": "4.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Grpc.Tools": "2.68.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "Microsoft.DurableTask.AzureManagedBackend": "0.4.2-alpha",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.400.224.38002"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+        "dependencies": {
+          "Azure.Messaging.EventGrid": "4.21.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1564,25 +1520,25 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Azure.Storage.Files.DataLake": "12.18.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           }
         }
       },
@@ -1593,7 +1549,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -1602,97 +1558,118 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
         "dependencies": {
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Kusto.dll": {
-            "assemblyVersion": "1.0.10.0",
-            "fileVersion": "1.0.10.0"
+            "assemblyVersion": "1.0.11.0",
+            "fileVersion": "1.0.11.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
+          "MySql.Data": "8.0.33",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Net.Http": "4.3.4",
+          "System.Runtime.Caching": "8.0.1",
+          "System.Text.Json": "8.0.4",
+          "morelinq": "4.1.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.MySql.dll": {
+            "assemblyVersion": "1.0.31.0",
+            "fileVersion": "1.0.31.0"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
         "dependencies": {
           "Azure.AI.OpenAI": "1.0.0-beta.15",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.0-preview",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.dll": {
-            "assemblyVersion": "0.16.0.0",
-            "fileVersion": "0.16.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
         "dependencies": {
-          "Azure.Search.Documents": "11.5.1",
+          "Azure.Search.Documents": "11.6.0",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.AzureAISearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "MongoDB.Driver": "2.25.0"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "MongoDB.Driver": "2.29.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.CosmosDBSearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.Kusto.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "RabbitMQ.Client": "5.1.2",
           "System.Json": "4.5.0"
         },
@@ -1706,8 +1683,8 @@
       "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1718,121 +1695,119 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
         "dependencies": {
           "Grpc.AspNetCore": "2.49.0",
-          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37"
+          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.39"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.Rpc.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Sendgrid": "9.10.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
-          "Google.Protobuf": "3.24.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.37",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.ServiceBus": "7.18.2",
+          "Google.Protobuf": "3.28.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "MessagePack": "2.5.192",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9123.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.0",
-          "morelinq": "3.4.2"
+          "System.Runtime.Caching": "8.0.1",
+          "morelinq": "4.1.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.169.0",
-            "fileVersion": "3.1.169.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Twilio": "5.6.3"
         },
         "runtime": {
@@ -1842,9 +1817,26 @@
           }
         }
       },
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Azure.Messaging.WebPubSub": "1.4.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebPubSub.Common": "1.4.0",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "Microsoft.IdentityModel.Tokens": "7.6.3"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.24.47903"
+          }
+        }
+      },
       "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "WindowsAzure.Storage": "9.3.1"
         },
         "runtime": {
@@ -1854,28 +1846,31 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
+      "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
         "dependencies": {
-          "Microsoft.CodeAnalysis": "3.3.1",
-          "Microsoft.CodeAnalysis.CSharp": "3.3.1",
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Collections.Immutable": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.14492.0"
+            "fileVersion": "1.0.22000.0"
           }
         }
       },
@@ -1884,11 +1879,24 @@
           "System.Runtime.Loader": "4.3.0"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+      "Microsoft.Azure.WebPubSub.Common/1.4.0": {
+        "dependencies": {
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Encodings.Web": "8.0.0",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.47402"
+          }
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces/10.0.0-preview.2.25163.2": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "assemblyVersion": "10.0.0.0",
+            "fileVersion": "10.0.25.16302"
           }
         }
       },
@@ -1900,398 +1908,68 @@
           }
         }
       },
-      "Microsoft.CodeAnalysis/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.3.1",
-          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "3.3.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.Analyzers/2.9.4": {},
-      "Microsoft.CodeAnalysis.Common/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "2.9.4",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Memory": "4.5.5",
-          "System.Reflection.Metadata": "1.6.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encoding.CodePages": "4.5.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.3.1",
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.VisualBasic/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.VisualBasic.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.VisualBasic.Workspaces/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Microsoft.CodeAnalysis.VisualBasic": "3.3.1",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.Workspaces.Common/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "System.Composition": "1.0.31"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
       "Microsoft.CSharp/4.7.0": {},
-      "Microsoft.Data.SqlClient/5.2.1": {
+      "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Data.SqlClient.dll": {
+          "lib/net8.0/Microsoft.Data.SqlClient.dll": {
             "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
+            "fileVersion": "5.22.24240.6"
           }
         },
         "resources": {
-          "lib/net6.0/de/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/de/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "de"
           },
-          "lib/net6.0/es/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/es/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "es"
           },
-          "lib/net6.0/fr/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/fr/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "fr"
           },
-          "lib/net6.0/it/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/it/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "it"
           },
-          "lib/net6.0/ja/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ja/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ja"
           },
-          "lib/net6.0/ko/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ko/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ko"
           },
-          "lib/net6.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "pt-BR"
           },
-          "lib/net6.0/ru/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ru/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ru"
           },
-          "lib/net6.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hans"
           },
-          "lib/net6.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hant"
           }
         },
         "runtimeTargets": {
-          "runtimes/unix/lib/net6.0/Microsoft.Data.SqlClient.dll": {
+          "runtimes/unix/lib/net8.0/Microsoft.Data.SqlClient.dll": {
             "rid": "unix",
             "assetType": "runtime",
             "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
+            "fileVersion": "5.22.24240.6"
           },
-          "runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll": {
+          "runtimes/win/lib/net8.0/Microsoft.Data.SqlClient.dll": {
             "rid": "win",
             "assetType": "runtime",
             "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
+            "fileVersion": "5.22.24240.6"
           }
         }
       },
@@ -2321,14 +1999,14 @@
       },
       "Microsoft.DotNet.PlatformAbstractions/2.1.0": {
         "dependencies": {
-          "System.AppContext": "4.1.0",
+          "System.AppContext": "4.3.0",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.IO.FileSystem": "4.3.0",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
         },
         "runtime": {
           "lib/netstandard1.3/Microsoft.DotNet.PlatformAbstractions.dll": {
@@ -2337,101 +2015,133 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.1.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.1.0.0",
-            "fileVersion": "1.1.0.4758"
+          "lib/net6.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Data.SqlClient": "5.2.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.IdentityModel.Tokens.Jwt": "7.5.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.DurableTask.SqlServer": "1.3.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.4": {
+      "Microsoft.Extensions.Azure/1.11.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.4.0",
-            "fileVersion": "1.700.424.31303"
+          "lib/net8.0/Microsoft.Extensions.Azure.dll": {
+            "assemblyVersion": "1.11.0.0",
+            "fileVersion": "1.1100.25.16402"
           }
         }
       },
-      "Microsoft.Extensions.Configuration/2.2.0": {
+      "Microsoft.Extensions.Caching.Abstractions/1.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Primitives": "7.0.0",
+          "System.Collections": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
+      "Microsoft.Extensions.Caching.Memory/1.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "1.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0",
+          "System.Linq": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration/3.1.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
-      "Microsoft.Extensions.Configuration.FileExtensions/2.2.0": {
+      "Microsoft.Extensions.Configuration.FileExtensions/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Json/2.1.0": {
+      "Microsoft.Extensions.Configuration.Json/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection/6.0.0": {
+      "Microsoft.Extensions.DependencyInjection/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -2447,137 +2157,128 @@
           }
         }
       },
-      "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
+      "Microsoft.Extensions.FileProviders.Abstractions/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
-      "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
+      "Microsoft.Extensions.FileProviders.Physical/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileSystemGlobbing": "2.2.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "3.1.0"
         }
       },
-      "Microsoft.Extensions.FileSystemGlobbing/2.2.0": {},
+      "Microsoft.Extensions.FileSystemGlobbing/3.1.0": {},
       "Microsoft.Extensions.Hosting/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0"
+          "Microsoft.Extensions.Logging": "7.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Http/3.1.32": {
+      "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging/6.0.0": {
+      "Microsoft.Extensions.Logging/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.Logging.Abstractions/7.0.0": {},
+      "Microsoft.Extensions.Logging.ApplicationInsights/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.Extensions.Logging": "7.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.ApplicationInsights.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
       "Microsoft.Extensions.Logging.Configuration/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "2.1.0"
         }
       },
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
-      "Microsoft.Extensions.Options/6.0.0": {
+      "Microsoft.Extensions.Options/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Primitives/6.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
+      "Microsoft.Extensions.Primitives/7.0.0": {},
       "Microsoft.FASTER.Core/2.6.5": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "System.Interactive.Async": "6.0.1",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/FASTER.core.dll": {
+          "lib/net7.0/FASTER.core.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Identity.Client/4.61.3": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "7.6.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
       "Microsoft.IdentityModel.Abstractions/7.6.3": {
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Abstractions.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Abstractions.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
-          }
-        }
-      },
-      "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-        "dependencies": {
-          "NETStandard.Library": "2.0.1",
-          "System.Runtime.Serialization.Json": "4.0.2",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
-          },
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
           }
         }
       },
@@ -2586,7 +2287,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2597,7 +2298,7 @@
           "Microsoft.IdentityModel.Abstractions": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Logging.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Logging.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2632,7 +2333,7 @@
           "Microsoft.IdentityModel.Logging": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Tokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Tokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2648,14 +2349,14 @@
       },
       "Microsoft.Net.Http.Headers/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1"
         }
       },
-      "Microsoft.NET.Sdk.Functions/4.4.0": {
+      "Microsoft.NET.Sdk.Functions/4.6.0": {
         "dependencies": {
           "Microsoft.Azure.Functions.Analyzers": "1.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "3.0.6",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator": "4.0.1",
@@ -2665,7 +2366,15 @@
           "System.Text.RegularExpressions": "4.3.1"
         }
       },
-      "Microsoft.NETCore.Platforms/2.1.2": {},
+      "Microsoft.NET.StringTools/17.6.3": {
+        "runtime": {
+          "lib/net7.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
+        }
+      },
+      "Microsoft.NETCore.Platforms/3.1.9": {},
       "Microsoft.NETCore.Targets/1.1.3": {},
       "Microsoft.SqlServer.Server/1.0.0": {
         "runtime": {
@@ -2675,11 +2384,11 @@
           }
         }
       },
-      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
         "runtime": {
           "lib/net6.0/Microsoft.SqlServer.TransactSql.ScriptDom.dll": {
             "assemblyVersion": "16.1.0.0",
-            "fileVersion": "16.1.9123.0"
+            "fileVersion": "16.1.9135.0"
           }
         },
         "resources": {
@@ -2726,7 +2435,7 @@
       },
       "Microsoft.Win32.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
@@ -2737,39 +2446,58 @@
           "System.Security.Principal.Windows": "5.0.0"
         }
       },
-      "MongoDB.Bson/2.25.0": {
+      "Microsoft.Win32.SystemEvents/4.7.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Win32.SystemEvents.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/netcoreapp3.0/Microsoft.Win32.SystemEvents.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "MongoDB.Bson/2.29.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Bson.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver/2.25.0": {
+      "MongoDB.Driver/2.29.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Driver.Core": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Driver.Core": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver.Core/2.25.0": {
+      "MongoDB.Driver.Core/2.29.0": {
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.100.14",
           "DnsClient": "1.6.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0",
           "SharpCompress": "0.30.1",
           "Snappier": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -2777,16 +2505,16 @@
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.Core.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Libmongocrypt/1.8.2": {
+      "MongoDB.Libmongocrypt/1.12.0": {
         "runtime": {
           "lib/netstandard2.1/MongoDB.Libmongocrypt.dll": {
-            "assemblyVersion": "1.8.2.0",
-            "fileVersion": "1.8.2.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         },
         "runtimeTargets": {
@@ -2807,11 +2535,59 @@
           }
         }
       },
-      "morelinq/3.4.2": {
+      "morelinq/4.1.0": {
         "runtime": {
-          "lib/net6.0/MoreLinq.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.4.2.0"
+          "lib/net8.0/MoreLinq.dll": {
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
+          }
+        }
+      },
+      "MySql.Data/8.0.33": {
+        "dependencies": {
+          "Google.Protobuf": "3.28.2",
+          "K4os.Compression.LZ4.Streams": "1.3.5",
+          "Portable.BouncyCastle": "1.9.0",
+          "System.Buffers": "4.5.1",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Runtime.Loader": "4.3.0",
+          "System.Security.Permissions": "4.7.0",
+          "System.Text.Encoding.CodePages": "4.4.0",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/net7.0/MySql.Data.dll": {
+            "assemblyVersion": "8.0.33.0",
+            "fileVersion": "8.0.33.0"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win-x64/native/comerr64.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/gssapi64.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/k5sprt64.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/krb5_64.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/krbcc64.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
@@ -2831,9 +2607,52 @@
           }
         }
       },
-      "NETStandard.Library/2.0.1": {
+      "NETStandard.Library/1.6.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2"
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.Compression.ZipFile": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Net.Http": "4.3.4",
+          "System.Net.Primitives": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.1",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Timer": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0"
         }
       },
       "Newtonsoft.Json/13.0.3": {
@@ -2846,7 +2665,7 @@
       },
       "Newtonsoft.Json.Bson/1.0.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -2858,12 +2677,20 @@
       },
       "Pipelines.Sockets.Unofficial/2.2.8": {
         "dependencies": {
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         },
         "runtime": {
           "lib/net5.0/Pipelines.Sockets.Unofficial.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "2.2.8.1080"
+          }
+        }
+      },
+      "Portable.BouncyCastle/1.9.0": {
+        "runtime": {
+          "lib/netstandard2.0/BouncyCastle.Crypto.dll": {
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.1"
           }
         }
       },
@@ -2880,19 +2707,25 @@
       "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.native.System/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
+      "runtime.native.System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "runtime.native.System.Net.Http/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+      "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
         "dependencies": {
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.1"
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
         }
       },
       "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
@@ -2911,7 +2744,7 @@
       },
       "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
-      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {},
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {},
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
@@ -2925,15 +2758,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2955,7 +2788,7 @@
       },
       "StackExchange.Redis/2.7.4": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
         },
         "runtime": {
@@ -2965,21 +2798,29 @@
           }
         }
       },
-      "System.AppContext/4.1.0": {
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
+      "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
         }
       },
       "System.Buffers/4.5.1": {},
-      "System.ClientModel/1.0.0": {
+      "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.24.5302"
+            "assemblyVersion": "1.1.0.0",
+            "fileVersion": "1.100.24.46703"
           }
         }
       },
@@ -2993,7 +2834,7 @@
       },
       "System.Collections/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
@@ -3012,17 +2853,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Collections.Immutable.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -3045,179 +2876,83 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Composition/1.0.31": {
+      "System.Configuration.ConfigurationManager/8.0.1": {
         "dependencies": {
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Convention": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Composition.TypedParts": "1.0.31"
-        }
-      },
-      "System.Composition.AttributedModel/1.0.31": {
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.1"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.AttributedModel.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Convention/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Threading": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Convention.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Hosting/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Threading": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Hosting.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Runtime/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Runtime.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.TypedParts/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.TypedParts.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Configuration.ConfigurationManager/8.0.0": {
-        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
-          "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
+          "lib/net8.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
           }
+        }
+      },
+      "System.Console/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Text.Encoding": "4.3.0"
         }
       },
       "System.Diagnostics.Debug/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
-      "System.Diagnostics.DiagnosticSource/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
+      "System.Diagnostics.DiagnosticSource/8.0.0": {},
+      "System.Diagnostics.EventLog/8.0.1": {
         "runtime": {
-          "lib/net6.0/System.Diagnostics.DiagnosticSource.dll": {
+          "lib/net8.0/System.Diagnostics.EventLog.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/net8.0/System.Diagnostics.EventLog.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
-      "System.Diagnostics.EventLog/6.0.0": {},
-      "System.Diagnostics.Process/4.3.0": {
+      "System.Diagnostics.PerformanceCounter/4.7.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.Win32.Registry": "5.0.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Thread": "4.3.0",
-          "System.Threading.ThreadPool": "4.3.0",
-          "runtime.native.System": "4.3.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Principal.Windows": "5.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/System.Diagnostics.PerformanceCounter.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/netcoreapp2.0/System.Diagnostics.PerformanceCounter.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
         }
       },
       "System.Diagnostics.Tools/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
       "System.Diagnostics.TraceSource/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3230,9 +2965,35 @@
       },
       "System.Diagnostics.Tracing/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
+        }
+      },
+      "System.Drawing.Common/4.7.3": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.Win32.SystemEvents": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/System.Drawing.Common.dll": {
+            "assemblyVersion": "4.0.0.2",
+            "fileVersion": "4.6.29719.1"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/unix/lib/netcoreapp3.0/System.Drawing.Common.dll": {
+            "rid": "unix",
+            "assetType": "runtime",
+            "assemblyVersion": "4.0.2.3",
+            "fileVersion": "4.700.21.51508"
+          },
+          "runtimes/win/lib/netcoreapp3.0/System.Drawing.Common.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.0.2.3",
+            "fileVersion": "4.700.21.51508"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
@@ -3254,24 +3015,17 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Formats.Asn1/6.0.1": {
-        "runtime": {
-          "lib/net6.0/System.Formats.Asn1.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3224.31407"
-          }
-        }
-      },
+      "System.Formats.Asn1/6.0.1": {},
       "System.Globalization/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
       "System.Globalization.Calendars/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Runtime": "4.3.1"
@@ -3279,7 +3033,7 @@
       },
       "System.Globalization.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Globalization": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3293,7 +3047,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/System.IdentityModel.Tokens.Jwt.dll": {
+          "lib/net8.0/System.IdentityModel.Tokens.Jwt.dll": {
             "assemblyVersion": "7.5.1.0",
             "fileVersion": "7.5.1.50405"
           }
@@ -3312,16 +3066,48 @@
       },
       "System.IO/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "System.Buffers": "4.5.1",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile/4.3.0": {
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
       "System.IO.FileSystem/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.IO.FileSystem.Primitives": "4.3.0",
@@ -3329,6 +3115,12 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.AccessControl/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "System.IO.FileSystem.Primitives/4.3.0": {
@@ -3344,7 +3136,7 @@
           }
         }
       },
-      "System.IO.Pipelines/5.0.1": {},
+      "System.IO.Pipelines/6.0.3": {},
       "System.Json/4.5.0": {
         "runtime": {
           "lib/netstandard2.0/System.Json.dll": {
@@ -3364,7 +3156,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3395,21 +3187,17 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/1.0.2": {
-        "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
-          "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+          "lib/net6.0/System.Memory.Data.dll": {
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
       "System.Net.Http/4.3.4": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
@@ -3424,11 +3212,11 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.OpenSsl": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0",
@@ -3439,7 +3227,7 @@
       },
       "System.Net.NameResolution/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Tracing": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3457,28 +3245,28 @@
       },
       "System.Net.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0"
         }
       },
+      "System.Net.ServerSentEvents/10.0.0-preview.1.25080.5": {
+        "runtime": {
+          "lib/net8.0/System.Net.ServerSentEvents.dll": {
+            "assemblyVersion": "10.0.0.0",
+            "fileVersion": "10.0.25.8005"
+          }
+        }
+      },
       "System.Net.Sockets/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Net.Primitives": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Threading.Tasks": "4.3.0"
-        }
-      },
-      "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-        "runtime": {
-          "lib/netcoreapp2.1/System.Net.WebSockets.WebSocketProtocol.dll": {
-            "assemblyVersion": "4.0.0.2",
-            "fileVersion": "4.6.27129.4"
-          }
         }
       },
       "System.Numerics.Vectors/4.5.0": {},
@@ -3489,34 +3277,6 @@
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Threading": "4.3.0"
-        }
-      },
-      "System.Private.DataContractSerialization/4.1.1": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
         }
       },
       "System.Reactive/4.4.1": {},
@@ -3591,7 +3351,7 @@
       },
       "System.Reflection/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
@@ -3624,7 +3384,7 @@
       },
       "System.Reflection.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Runtime": "4.3.1"
@@ -3633,7 +3393,7 @@
       "System.Reflection.Metadata/1.6.0": {},
       "System.Reflection.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
@@ -3641,7 +3401,7 @@
       "System.Reflection.TypeExtensions/4.7.0": {},
       "System.Resources.ResourceManager/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Reflection": "4.3.0",
@@ -3650,47 +3410,47 @@
       },
       "System.Runtime/4.3.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "System.Runtime.Caching/8.0.0": {
+      "System.Runtime.Caching/8.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1"
         },
         "runtime": {
-          "lib/net6.0/System.Runtime.Caching.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+          "lib/net8.0/System.Runtime.Caching.dll": {
+            "assemblyVersion": "8.0.0.1",
+            "fileVersion": "8.0.1024.46610"
           }
         },
         "runtimeTargets": {
-          "runtimes/win/lib/net6.0/System.Runtime.Caching.dll": {
+          "runtimes/win/lib/net8.0/System.Runtime.Caching.dll": {
             "rid": "win",
             "assetType": "runtime",
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "assemblyVersion": "8.0.0.1",
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
       "System.Runtime.CompilerServices.Unsafe/6.0.0": {},
       "System.Runtime.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
       "System.Runtime.Handles/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
       "System.Runtime.InteropServices/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
@@ -3698,10 +3458,10 @@
           "System.Runtime.Handles": "4.3.0"
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
           "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.InteropServices": "4.3.0",
@@ -3724,23 +3484,10 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Json/4.0.2": {
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Private.DataContractSerialization": "4.1.1",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
       "System.Security.AccessControl/6.0.0": {},
-      "System.Security.Cryptography.Algorithms/4.3.1": {
+      "System.Security.Cryptography.Algorithms/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3752,7 +3499,7 @@
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.Apple": "4.3.1",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
@@ -3763,7 +3510,7 @@
       },
       "System.Security.Cryptography.Csp/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3771,7 +3518,7 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3780,7 +3527,7 @@
       },
       "System.Security.Cryptography.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Collections.Concurrent": "4.3.0",
           "System.Linq": "4.3.0",
@@ -3804,7 +3551,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3824,15 +3571,15 @@
       },
       "System.Security.Cryptography.ProtectedData/8.0.0": {
         "runtime": {
-          "lib/net6.0/System.Security.Cryptography.ProtectedData.dll": {
+          "lib/net8.0/System.Security.Cryptography.ProtectedData.dll": {
             "assemblyVersion": "8.0.0.0",
             "fileVersion": "8.0.23.53103"
           }
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.3.2": {
+      "System.Security.Cryptography.X509Certificates/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3846,7 +3593,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Cng": "5.0.0",
           "System.Security.Cryptography.Csp": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
@@ -3859,57 +3606,43 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
+      "System.Security.Permissions/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Windows.Extensions": "4.7.0"
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/System.Security.Permissions.dll": {
+            "assemblyVersion": "4.0.3.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
       "System.Security.Principal.Windows/5.0.0": {},
       "System.Text.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
-      "System.Text.Encoding.CodePages/4.5.1": {
+      "System.Text.Encoding.CodePages/4.4.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.NETCore.Platforms": "3.1.9"
         }
       },
       "System.Text.Encoding.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0"
         }
       },
-      "System.Text.Encodings.Web/8.0.0": {
+      "System.Text.Encodings.Web/8.0.0": {},
+      "System.Text.Json/8.0.4": {
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Encodings.Web.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        },
-        "runtimeTargets": {
-          "runtimes/browser/lib/net6.0/System.Text.Encodings.Web.dll": {
-            "rid": "browser",
-            "assetType": "runtime",
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
-      "System.Text.Json/8.0.1": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "8.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Json.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.123.58001"
-          }
         }
       },
       "System.Text.RegularExpressions/4.3.1": {
@@ -3923,29 +3656,44 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels/4.7.1": {},
+      "System.Threading.Channels/6.0.0": {},
       "System.Threading.Tasks/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
       "System.Threading.Tasks.Extensions/4.5.4": {},
-      "System.Threading.Thread/4.3.0": {
+      "System.Threading.Timer/4.3.0": {
         "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1"
         }
       },
-      "System.Threading.ThreadPool/4.3.0": {
+      "System.ValueTuple/4.5.0": {},
+      "System.Windows.Extensions/4.7.0": {
         "dependencies": {
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Handles": "4.3.0"
+          "System.Drawing.Common": "4.7.3"
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/System.Windows.Extensions.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/netcoreapp3.0/System.Windows.Extensions.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.700.19.56404"
+          }
         }
       },
-      "System.ValueTuple/4.5.0": {},
-      "System.Xml.ReaderWriter/4.0.11": {
+      "System.Xml.ReaderWriter/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
@@ -3964,46 +3712,27 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "System.Xml.XmlDocument/4.0.1": {
+      "System.Xml.XDocument/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Extensions": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11"
-        }
-      },
-      "System.Xml.XmlSerializer/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1"
+          "System.Xml.ReaderWriter": "4.3.0"
         }
       },
       "Twilio/5.6.3": {
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "7.6.3",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Specialized": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -4017,7 +3746,7 @@
       },
       "WindowsAzure.Storage/9.3.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -4029,7 +3758,7 @@
       },
       "ZstdSharp.Port/0.7.3": {
         "runtime": {
-          "lib/net6.0/ZstdSharp.dll": {
+          "lib/net7.0/ZstdSharp.dll": {
             "assemblyVersion": "0.7.3.0",
             "fileVersion": "0.7.3.0"
           }
@@ -4079,12 +3808,12 @@
       "path": "azure.ai.openai/1.0.0-beta.15",
       "hashPath": "azure.ai.openai.1.0.0-beta.15.nupkg.sha512"
     },
-    "Azure.Core/1.41.0": {
+    "Azure.Core/1.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7OO8rPCVSvXj2IQET3NkRf8hU2ZDCCvCIUhlrE089qkLNpNfWufJnBwHRKLAOWF3bhKBGJS/9hPBgjJ8kupUIg==",
-      "path": "azure.core/1.41.0",
-      "hashPath": "azure.core.1.41.0.nupkg.sha512"
+      "sha512": "sha512-YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+      "path": "azure.core/1.44.1",
+      "hashPath": "azure.core.1.44.1.nupkg.sha512"
     },
     "Azure.Core.Amqp/1.3.1": {
       "type": "package",
@@ -4093,19 +3822,19 @@
       "path": "azure.core.amqp/1.3.1",
       "hashPath": "azure.core.amqp.1.3.1.nupkg.sha512"
     },
-    "Azure.Data.Tables/12.8.3": {
+    "Azure.Data.Tables/12.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2wAUXLS1ebTnV+qm9qc1z1MZIPC3as2WJt9bEgL08oC1wlT5UhaW78PlYgTld89p/YWCawJycHtBwVx+SWIuLw==",
-      "path": "azure.data.tables/12.8.3",
-      "hashPath": "azure.data.tables.12.8.3.nupkg.sha512"
+      "sha512": "sha512-d5529gg24alnMKbE8Aw7NY3q9dxFvzfhCMW+TtQA7GGIqASFSIh+536p2qdyJNPEQDFYtqfoLqIBlP9IGqgLfA==",
+      "path": "azure.data.tables/12.9.1",
+      "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.0": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
-      "path": "azure.identity/1.12.0",
-      "hashPath": "azure.identity.1.12.0.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -4114,40 +3843,54 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.9.2": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KAC79xzlOUrtQ0mlrPqijznfmlKeraiqavtZ3RfbV+8ukJf9C5fFSZCMSqq9N/2+eUkW3G4wJSchMXAyf+jxow==",
-      "path": "azure.messaging.eventhubs/5.9.2",
-      "hashPath": "azure.messaging.eventhubs.5.9.2.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-c0ROPOBgzQ8PLvhG9YNBaq+zMMXRWCLr1C/oPgJqxQMsGxHRfuxvYWNvxTVYe96caiBaGkDDLAUb3wsIWJaw2w==",
+      "path": "azure.messaging.eventhubs.processor/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Search.Documents/11.5.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Vg+1mtM3LXVYwKQ+DDi7Wd/Rf2Ajo6rl5/7bFPfouUMBe/cNg71TIU62PY/eEtKfUI3Y7wdFXNcgGkpUG+OVnw==",
-      "path": "azure.search.documents/11.5.1",
-      "hashPath": "azure.search.documents.11.5.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.21.0": {
+    "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W1aSEH11crU3CscfuICUPXScTO9nKwSof3YFsdxmbdi+P+JARYzntkGJuZ685gvmyUse7isBNncNlVEjB5LT0g==",
-      "path": "azure.storage.blobs/12.21.0",
-      "hashPath": "azure.storage.blobs.12.21.0.nupkg.sha512"
+      "sha512": "sha512-27PpgpaTtwOXXP08ZKAt612S/D0ZXINPpR2JTPurbuVPy+eHj1RDvoyJPGsZkHXnk9nVNR6zAu45YBf/8llgOw==",
+      "path": "azure.messaging.webpubsub/1.4.0",
+      "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.20.0": {
+    "Azure.Search.Documents/11.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-C0uTY4E1NSGiNf/dlLMQ/d85a2CDazEg4YYtNJOYnLSb8ZXJ5RBPHYGW7a46kN5Xn5Bc9BKMvs8fME285TfEpw==",
-      "path": "azure.storage.common/12.20.0",
-      "hashPath": "azure.storage.common.12.20.0.nupkg.sha512"
+      "sha512": "sha512-M7WLx3ANLPHymfqb4Nwk4EwcWWRiHqdvnxJ7RH857baAbkEZ3FYVCRJmHgxH+ROpYOTVSx30uJzsa573/cdD8A==",
+      "path": "azure.search.documents/11.6.0",
+      "hashPath": "azure.search.documents.11.6.0.nupkg.sha512"
+    },
+    "Azure.Storage.Blobs/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
+    },
+    "Azure.Storage.Common/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
     "Azure.Storage.Files.DataLake/12.18.0": {
       "type": "package",
@@ -4156,12 +3899,12 @@
       "path": "azure.storage.files.datalake/12.18.0",
       "hashPath": "azure.storage.files.datalake.12.18.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.19.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+EXqf4aTyshZDpi/DBgffEX0CJMbvs9fHTZX4EMPBPc4WHyXCNs2oKelJes1pdHLRwTUVJ3jGdK1kU/IB5lJJw==",
-      "path": "azure.storage.queues/12.19.0",
-      "hashPath": "azure.storage.queues.12.19.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -4184,33 +3927,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4219,12 +3962,12 @@
       "path": "dnsclient/1.6.1",
       "hashPath": "dnsclient.1.6.1.nupkg.sha512"
     },
-    "Google.Protobuf/3.24.3": {
+    "Google.Protobuf/3.28.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HX8KHRTJPUcC4KOvEobKBNlMpHGYmK+3X73xPq+OUE2M5dLYvpGhp9qQQWt2jASgTUbxI1yHaGeBqFYiECBupw==",
-      "path": "google.protobuf/3.24.3",
-      "hashPath": "google.protobuf.3.24.3.nupkg.sha512"
+      "sha512": "sha512-Z86ZKAB+v1B/m0LTM+EVamvZlYw/g3VND3/Gs4M/+aDIxa2JE9YPKjDxTpf0gv2sh26hrve3eI03brxBmzn92g==",
+      "path": "google.protobuf/3.28.2",
+      "hashPath": "google.protobuf.3.28.2.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -4254,19 +3997,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-cL1/2f8kc8lsAGNdfCU25deedXVehhLA6GXKLLN4hAWx16XN7BmjYn3gFU+FBpir5yJynvDTHEypr3Tl0j7x/Q==",
+      "path": "grpc.core.api/2.67.0",
+      "hashPath": "grpc.core.api.2.67.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-ofTjJQfegWkVlk5R4k/LlwpcucpsBzntygd4iAeuKd/eLMkmBWoXN+xcjYJ5IibAahRpIJU461jABZvT6E9dwA==",
+      "path": "grpc.net.client/2.67.0",
+      "hashPath": "grpc.net.client.2.67.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4275,33 +4018,61 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-gazn1cD2Eol0/W5ZJRV4PYbNrxJ9oMs8pGYux5S9E4MymClvl7aqYSmpqgmWAUWvziRqK9K+yt3cjCMfQ3x/5A==",
+      "path": "grpc.net.common/2.67.0",
+      "hashPath": "grpc.net.common.2.67.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.49.0": {
+    "Grpc.Tools/2.68.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fvA8M6m+cKR5cCwVfKNyUtC8/immoNiNGXW8rwLmwb4y4XRFtQJyN9dmGCJNh1mt0cb9LjSSiAZwmSfMgmE2Ng==",
-      "path": "grpc.tools/2.49.0",
-      "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
+      "sha512": "sha512-BZ96s7ijKAhJoRpIK+pqCeLaGaSwyc5/CAZFwgCcBuAnkU2naYvH0P6qnYCkl0pWDY/JBOnE2RvX9IvRX1Yc5Q==",
+      "path": "grpc.tools/2.68.1",
+      "hashPath": "grpc.tools.2.68.1.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "K4os.Compression.LZ4/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-TS4mqlT0X1OlnvOGNfl02QdVUhuqgWuCnn7UxupIa7C9Pb6qlQ5yZA2sPhRh0OSmVULaQU64KV4wJuu//UyVQQ==",
+      "path": "k4os.compression.lz4/1.3.5",
+      "hashPath": "k4os.compression.lz4.1.3.5.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "K4os.Compression.LZ4.Streams/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-M0NufZI8ym3mm6F6HMSPz1jw7TJGdY74fjAtbIXATmnAva/8xLz50eQZJI9tf9mMeHUaFDg76N1BmEh8GR5zeA==",
+      "path": "k4os.compression.lz4.streams/1.3.5",
+      "hashPath": "k4os.compression.lz4.streams.1.3.5.nupkg.sha512"
+    },
+    "K4os.Hash.xxHash/1.0.8": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Wp2F7BamQ2Q/7Hk834nV9vRQapgcr8kgv9Jvfm8J3D0IhDqZMMl+a2yxUq5ltJitvXvQfB8W6K4F4fCbw/P6YQ==",
+      "path": "k4os.hash.xxhash/1.0.8",
+      "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
+    },
+    "librdkafka.redist/2.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+    },
+    "MessagePack/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -4309,6 +4080,48 @@
       "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
       "path": "microsoft.applicationinsights/2.22.0",
       "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.AspNetCore/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-d+7MB4YdUMc9Mtq2u6C7TritzC0eKfHkhGmlnNckDDQiOQuk9IHMPxUmPBRMm/tn+db8fI/BYno9jGxLhI+SZw==",
+      "path": "microsoft.applicationinsights.aspnetcore/2.21.0",
+      "hashPath": "microsoft.applicationinsights.aspnetcore.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.DependencyCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+      "path": "microsoft.applicationinsights.dependencycollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.dependencycollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.EventCounterCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MfF9IKxx9UhaYHVFQ1VKw0LYvBhkjZtPNUmCTYlGws0N7D2EaupmeIj/EWalqP47sQRedR9+VzARsONcwH8OCA==",
+      "path": "microsoft.applicationinsights.eventcountercollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.eventcountercollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-RcckSVkfu+NkDie6/HyM6AVLHmTMVZrUrYnDeJdvRByOc2a+DqTM6KXMtsTHW/5+K7DT9QK5ZrZdi0YbBW8PVA==",
+      "path": "microsoft.applicationinsights.perfcountercollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.perfcountercollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Xbhss7dqbKyE5PENm1lRA9oxzhKEouKGMzgNqJ9xTHPZiogDwKVMK02qdbVhvaXKf9zG8RvvIpM5tnGR5o+Onw==",
+      "path": "microsoft.applicationinsights.windowsserver/2.21.0",
+      "hashPath": "microsoft.applicationinsights.windowsserver.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7D4oq+9YyagEPx+0kNNOXdG6c7IDM/2d+637nAYKFqdWhNN0IqHZEed0DuG28waj7hBSLM9lBO+B8qQqgfE4rw==",
+      "path": "microsoft.applicationinsights.windowsserver.telemetrychannel/2.21.0",
+      "hashPath": "microsoft.applicationinsights.windowsserver.telemetrychannel.2.21.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -4386,20 +4199,6 @@
       "sha512": "sha512-Nxs7Z1q3f1STfLYKJSVXCs1iBl+Ya6E8o4Oy1bCxJ/rNI44E/0f6tbsrVqAWfB7jlnJfyaAtIalBVxPKUPQb4Q==",
       "path": "microsoft.aspnetcore.http.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.2.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-jq2OPhIdCCjkcdZGVd4NMRwDG+A/3yUx2mgR3Bd4z+HXNZMbQzOQnL4hw6YFLsyBjHNnJc17fyeKSyV3DlKLEg==",
-      "path": "microsoft.aspnetcore.http.connections/1.0.15",
-      "hashPath": "microsoft.aspnetcore.http.connections.1.0.15.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-vllvIeTpVzCDs5kPEdICbvcmxLmRAlJUxG6bG55tf29Wfp/ehHQza5P14S1hFl4Ff7kuxJw5VoqSUHD0gaJMKg==",
-      "path": "microsoft.aspnetcore.http.connections.common/1.0.4",
-      "hashPath": "microsoft.aspnetcore.http.connections.common.1.0.4.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
       "type": "package",
@@ -4499,33 +4298,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tzRdyQ0qrMJ5YS0qsXfmhVd/kr25IzLpayoIAvU1yi27wqsqxXVPADDEv0S9PaS7xn6bpMFit8kZw92IICDSWg==",
-      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.1",
-      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.1.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-qTACI0wePgAKCH+YKrMgChyfqJpjwgGZEtSuwBw6TjWLQ66THGasleia/7EZz2t2eAjwWxw8RA/D8ODrBqpj9A==",
+      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -4541,68 +4319,54 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/mBhUF82NJq1mNr2u/7LkP3oDPqtw9jpH8Xo2yYxjwpIX3REK9bvgH1hqcBOLQTZIMGRDqjq6W/pEEzLqH1iZg==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.1.6",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.1.6.nupkg.sha512"
+      "sha512": "sha512-+zLlvMq5Bh1ifxCj27AapYc97muyS3+6y6clIFEBgm0uHAlPDWcvjz06gTp+sLiIMCUWSPRcC3RhzG+V84ZLqQ==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.2.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GxG4vMxZkZGj912TCtDO4RetqSrKprCO+pQAea/f5ouQzN+rB3aqYRV/TC+E8t9+F6dXFlZWFRZZvapj1RIJlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/1.17.4",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.1.17.4.nupkg.sha512"
+      "sha512": "sha512-U8PW868Ao+T4QMnXFBHqJgUefPBePK7SHOH3UpN1apqdsDksGrQuE/n+8jCEcv7EbpjCJSMqdoQKnZTMVbBZKg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.0.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/2.17.1": {
+    "Microsoft.Azure.DurableTask.Core/3.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zKtXC0wxGxOoAGPi5B0TT0f6mqjave2USL/Q7rJOwf+xVg+axiYpU4kad5muvzib4IeikOBfqWqs/xOFOKqR6w==",
-      "path": "microsoft.azure.durabletask.core/2.17.1",
-      "hashPath": "microsoft.azure.durabletask.core.2.17.1.nupkg.sha512"
+      "sha512": "sha512-KqAF02yugJC2hsDBfE4mhjiXAOj4JvKDYs/9GSrxuO/TLXbDY1Nx7meSpFw0E4Jp3kZiIH6UgHOAtHi0mnGCnw==",
+      "path": "microsoft.azure.durabletask.core/3.0.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o+65IPewJLhkuPIvziQxgsan6g3nJ981CWX3xtkHNiSnQqqA9WeUIxjA8ZYYyU1wJLj32CvPmVIyaALK9ejr2Q==",
-      "path": "microsoft.azure.durabletask.netherite/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.1.5.4.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tPosZ6BcmQ8Rg6RDAjGpV71+HzEHPWuPDk+n7GVBtdUTBUasv4ndWcRuW5QYKzLchqUVobLSxrtJLDZRaono/A==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.1.5.4.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-U5PEuRFxw6Jgsu1oc2BwNEFkIVH8PCAWuG8D0zeaF3V/nwKmvsAw3r0N1HR29UHO1WQtCOIl2Vh6yuA0BqxEBw==",
-      "path": "microsoft.azure.eventhubs/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.4.3.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-8zRsNRdPQAWAkASAI3r5SPEHJK/qXdje4KkjZUCNbPXdb+IXcfNno8esV5w34mxiUN59S9mTstZLzWC2VOUqlw==",
-      "path": "microsoft.azure.eventhubs.processor/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.processor.4.3.2.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -4625,68 +4389,61 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.KeyVault.Core/3.0.3": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.0.0-beta423": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-amP4gG7tMficBHRuTaCJpdiPGZyfrLHqYth0D4Yp3lu7Z7XQfEau0/BWNSuvpdZJKWW8M/wmFyI07vTA6EF88A==",
-      "path": "microsoft.azure.keyvault.core/3.0.3",
-      "hashPath": "microsoft.azure.keyvault.core.3.0.3.nupkg.sha512"
+      "sha512": "sha512-KdwGg1+gw3QVXfqa24BS6HT9IftRgnI6afaJBED4ib62XGyQ1hYbv7JBeicXmN8IhwzqLPZgUz/JLQsRCHHShg==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.0.0-beta423",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.0.0-beta423.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RyJsnaSMlwTPLFw8LfEZfff72JwxG+oBNQoI4NM0paAbx5N1Klx0SAAQQvG5oNlIstBgTeImH5sytndbVZIeLg==",
-      "path": "microsoft.azure.kusto.cloud.platform/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.3.nupkg.sha512"
+      "sha512": "sha512-g3gf2XSGf5i3o59ros3dkAuyHh57DvKPIrLe7OBj/3UhD0wbf7pro/RCdBu8urQpeOSdUxXcPbaAueGYXRdW1g==",
+      "path": "microsoft.azure.kusto.cloud.platform/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5owQ2zf16iGrm7hsjNozG0y8dYLQ33VgPeIr3or9xV4pUdWDNMk1QHQkwtl2kKvR7BnSvJvWjiWPJqddbcsv9g==",
-      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.3.nupkg.sha512"
+      "sha512": "sha512-y43GEkrl3eLDSKTl7fJs1JO0V5yc+uNej9J9lJjSPs7Y7Js3/nCsF9vkMSnytNSg1UH7sfENXSSwBQLSe+iAeA==",
+      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Data/12.2.3": {
+    "Microsoft.Azure.Kusto.Data/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-a55PhqueiSMpCAIa96XMUdN1TL73M5rtSsQLzvd8RtAAK7oUhtriy3tLCt0sN643s3w2EdTJEa0GcYHrYQem1w==",
-      "path": "microsoft.azure.kusto.data/12.2.3",
-      "hashPath": "microsoft.azure.kusto.data.12.2.3.nupkg.sha512"
+      "sha512": "sha512-b0yRwFDTRORnyAq7mRUbIFt6K9RsgAHoZrSlGe4CxMDQX0t7+70j//3NHN3vzLQdmQn3SDkTs569wErZbcfrGQ==",
+      "path": "microsoft.azure.kusto.data/12.2.7",
+      "hashPath": "microsoft.azure.kusto.data.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+    "Microsoft.Azure.Kusto.Ingest/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2/5l1EC5Imn7dOHkYY/n0t/06lvqIsYdm6+EuFWcIVSULGN7YNt9qnHzzlLLJHfkwnDEhy0ZP9LMmtT1+97fdQ==",
-      "path": "microsoft.azure.kusto.ingest/12.2.3",
-      "hashPath": "microsoft.azure.kusto.ingest.12.2.3.nupkg.sha512"
+      "sha512": "sha512-x5oTbesbMDVvmN6POpFF0frvh/bnHUtaKynlUxLTivmWUcZq8dw1rgQjnhX+YwfQWEg6fNSlJgpb58BZFV7qug==",
+      "path": "microsoft.azure.kusto.ingest/12.2.7",
+      "hashPath": "microsoft.azure.kusto.ingest.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ywpQaK1klu1IoX4VUf+TBmU4kR71aWNI6O5rEIJU8z28L2xhJhnIm7k2Nf1Zu/PygeuOtt5g0QPCk5+lLltbeQ==",
-      "path": "microsoft.azure.services.appauthentication/1.0.3",
-      "hashPath": "microsoft.azure.services.appauthentication.1.0.3.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -4702,33 +4459,19 @@
       "path": "microsoft.azure.stackexchangeredis/2.0.0",
       "hashPath": "microsoft.azure.stackexchangeredis.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Blob/11.2.3": {
+    "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gM48FyiinUQq+fiUFHf0hGwQaTug4b+zYcYjbZ1KpxC3RkSgOd3twL9Yv9MqpvTkMcexGLwtELYIBhaTQ3zd9A==",
-      "path": "microsoft.azure.storage.blob/11.2.3",
-      "hashPath": "microsoft.azure.storage.blob.11.2.3.nupkg.sha512"
+      "sha512": "sha512-EOigHt+kjrpbg53s8SYn4dlTpZG9IgWPNrdmcdSG8c7U8qKZvcF4BwZtF7ETy3KGir2NtIpJaIc7dUm2+k9/GA==",
+      "path": "microsoft.azure.webjobs/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Common/11.2.3": {
+    "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WqX0ckhXQSUIBEq6wd2xgFz3KPjIONfDdgNg1ClQYxYTvuXQv3g3cnL9DGXCvuxEFZNPk0BJdQeW+uZwGqdDjw==",
-      "path": "microsoft.azure.storage.common/11.2.3",
-      "hashPath": "microsoft.azure.storage.common.11.2.3.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-H/Al/2UOXef8Qqwvsm3Dur9JStz1xvV/UXb0GDys5YPx+qpWDS/U203b/+EUPLeZeuvGTnmcOFtnZzvxMuDamQ==",
-      "path": "microsoft.azure.webjobs/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.3.0.39.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs.Core/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O1RDMe2mBGZI4q4IUns+mxsfCjaMej4FzicMLqvnN5Ti5E3mSo+/kqDbEZzXA/RqnuLIOk+DhvFg/rwKhqEaow==",
-      "path": "microsoft.azure.webjobs.core/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.39.nupkg.sha512"
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
+      "path": "microsoft.azure.webjobs.core/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
       "type": "package",
@@ -4744,12 +4487,12 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WaL+NcxoETT+w7T7hxzSLYhu8wwymlr/9UOXjr0/ZgH2lM+zrOOQIOmB23xh9jUsqIJSm+B9xvgd65Iy1HbVqg==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.0.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4758,12 +4501,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7SPfaLdUnRmN4dajBQEZ4Yei0IzTCL/z7zYkEio0hb3vX9M+XXcWw1exBb3S83yvzOYCFlFYSGDREicYvPxmhg==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/2.13.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.2.13.5.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4772,12 +4515,19 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-P7xUepplf/Tz2YD+Y0qXv0FloYVxPNGs0KuHXphiTB/ZZGUl+QPKiBfV24LhOca6NpcUhyymYtIWUdoWwMGJXA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.2.nupkg.sha512"
+      "sha512": "sha512-uiluTugaUmj+GUhDzkEm+0W18LXLWukVGpwqYqzmxwcYirjsOefl9IMHL3aLazNIF63IyDf8/4/60BbqpEtg7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/0.4.2-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.0.4.2-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -4786,12 +4536,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Lr9MGqAVZdFTmuG8NHdJUIY/SkIrl1thrOmhhdtbQwuFF040pVF6GYyU0UyNisGLax7CaD5ly0MayTV7Psi8sQ==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/0.1.54-rc",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.1.54-rc.nupkg.sha512"
+      "sha512": "sha512-vrgRqOPjkyOF/MDectRoNpbYvTOlsmggG/Qf8ERULdFCXSb1jJKftdNfEot/mz8fBzm2MyGkOP0ilyJzOLyVmQ==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/0.2.9-rc",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.2.9-rc.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -4800,47 +4550,54 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qYD7VIvXk9DQFGtmKkH4wO0SLkoitacfhIcGLO3WUQT7QdZXE15odDsEkWjMhPovoHnkmGCYFjQnAjuL4uKa4Q==",
-      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.10-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.10-preview.nupkg.sha512"
+      "sha512": "sha512-PNNDW4ktUIsTyZWrFdHMrLTQdtAqHyjOibK8sLL6O9qI/emN/VdFFewnmpZfBisLIPnc/5WUKW66KZuyOYA+SQ==",
+      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.11-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.11-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZYBel0IbpiCpryN9u30bBWcFboI8yerraXljCFYJGJZAp5UTcGVjuQmsOfSKUs+6We6yJTFEzFG3CfELjbBNvg==",
-      "path": "microsoft.azure.webjobs.extensions.openai/0.16.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.16.0-alpha.nupkg.sha512"
+      "sha512": "sha512-c6zx4iVHSwV7p2fotzWvxw+Ttrn7gXh/EjVkh2tdQ2g0TgD1E8I08s8j2PoCqww6ke9awIdq3+R/RwG7CwRrRg==",
+      "path": "microsoft.azure.webjobs.extensions.mysql/1.0.31-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.mysql.1.0.31-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3dRX/RvGTzrbPXMVXK0uHZHolzsPr+vhE+vwV+G6h5CRD2tHyf8iJBAmgpO/vOIertM52SZhSDuyCOGfFxOUiQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.3.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.3.0-alpha.nupkg.sha512"
+      "sha512": "sha512-HupnrqbRfod2J9d93SxfjdlNUGM+LwjL9wgYa29Gzfs40gQ2X+bBPnXyLYmYSnEhhlqPV6yToilb+4D9c0uOOg==",
+      "path": "microsoft.azure.webjobs.extensions.openai/0.18.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.18.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vOVQ8OJfd5PZ2zPhs7HPo6lO+xYf+347VOgaIZjQop7TnQQTLqr/2TxcAyIVyS02qH29xsrlmpRrEoOnTE85MQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.2.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.2.0-alpha.nupkg.sha512"
+      "sha512": "sha512-h+zjHJbJgpL0J/h9DEZBxpRXV/0ws/bVwD3V77WaG7219CzhJqSouw1xPZkEISESIEwBF9ZSDaXwq4DQZdqjAw==",
+      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.4.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.4.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JB88Fukr0wMkrGso7eS+7w+jzqJSOi/T7Cbc16BXob5CtDu012fQZ9qm3xVgGBm6yV8MulMc6LAgTSO0kuI2NA==",
-      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.15.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.15.0-alpha.nupkg.sha512"
+      "sha512": "sha512-lyirO2ZWuTTY25dnWuKzcbq0dFn4BlPJ4w21rRvIsKe0RYylV2I45Kfq2yn76Wa6qjLOVc6rg6sTWfbYjKksFA==",
+      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.3.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.3.0-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PyDCInGcaIjzurx5W0fHbcreTR+54JUBMKjFIoLXp9G23InBPxHPNcjYfA2FSa0P1jMJHddDGOdNRKL2ho7s5A==",
+      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.16.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.16.0-alpha.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
       "type": "package",
@@ -4856,61 +4613,61 @@
       "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
       "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6tybd5xeTeBEOSy+CjfmDOkc8Xwwb73nmG/rQdInNiPuPX6hl9vTkHeEQATOeG4Sv7t+oJQZPPdT6ZprypmMaQ==",
-      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.37.nupkg.sha512"
+      "sha512": "sha512-ZTC2+g7/zBqOLvCr9/g0eE08Z68RE8MT5IuC90q2JcM6it4Kqckc3TvR3SilzloDr1/9EOa1wvlxfC57o8bmWA==",
+      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YDOLY05g9RaZHVCLRDlRaQ1LH7e3QvCXTV4N050kK7C3med6taVlrorE3Yy6XMi3AG6CqZlC8LbgnNCIQRIHHw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.169-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.169-preview.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W5VzuQKK41J0HIQr3Eij6ghxtcZOmARjYARRFIB4tDo3eutw8Lr7mKfr5iyEyHAC4MOTSKeIgknY99MaZC7GqA==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h6NX6pd8eX1pkClh4Dxys357aLJCffVAUJMsK1xvjrOlwaityPZRNqMJJ/BCrAXqqn9hqFF1tmcS8DgD2wI7WA==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UAKPp/fm6m2GvYMDjoF8MLudIprgPxuaaaCsBJID49G1ectgFJdp9CuexFWcUx4eHOdTVjqTdomByz9PglsKQw==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.1.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -4919,6 +4676,13 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-J5dRt7gSNkWfdN7kxnt+vP4ActPRYo2+/eLnXK1c/kgiKqqcwS+552EOm2B7dEpEP1d6/eMLeu5Kz3grXSkwjw==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsubforsocketio/1.0.0-beta.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsubforsocketio.1.0.0-beta.4.nupkg.sha512"
+    },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
       "serviceable": true,
@@ -4926,19 +4690,19 @@
       "path": "microsoft.azure.webjobs.host.storage/3.0.14",
       "hashPath": "microsoft.azure.webjobs.host.storage.3.0.14.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KG+ZD6u3KKBBv5bet6r1EeLrP6mNFRoPVWuGUToQTZwpTLlPffouag94JR5IxAJA3DxMQl0A0mV+Qkhg9VorCA==",
-      "path": "microsoft.azure.webjobs.rpc.core/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.37.nupkg.sha512"
+      "sha512": "sha512-sMPOTH6hlAuaiK3EYbf1SfYON8j+Hxl3IL7ZAJX51m9SI5RI0sUR7QPfiwIG0h4Z0BHpfybQXl0so07JbxBqyA==",
+      "path": "microsoft.azure.webjobs.rpc.core/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
+    "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-b2wKKtCrpdLbiQBudEPQ04cFCbwFHw8Bi2c/4CRYS2Qcm1Zs21NO37tvZZM/SGbtS2fxgvQhP/wiySYCKydZaQ==",
-      "path": "microsoft.azure.webjobs.script.abstractions/1.0.0-preview",
-      "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.0-preview.nupkg.sha512"
+      "sha512": "sha512-U/aVn/i0P9MdPsca9TrLmTlKuGOJ8okTdifrBeNviwd80Xbv/+dIM/GGReQXaVVtUM5/SlbUHRAhvA9w0yuEyA==",
+      "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
+      "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator/4.0.1": {
       "type": "package",
@@ -4947,12 +4711,19 @@
       "path": "microsoft.azure.webjobs.script.extensionsmetadatagenerator/4.0.1",
       "hashPath": "microsoft.azure.webjobs.script.extensionsmetadatagenerator.4.0.1.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+    "Microsoft.Azure.WebPubSub.Common/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
-      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
+      "sha512": "sha512-51j7iQ6l5NG8SyieJk2zVKMBff8TzDFnGmIWOIPD2U3V5BMzvyYL0gvzgDe+KRkYPNMxzwPwp+IiYE4kNqBQBA==",
+      "path": "microsoft.azure.webpubsub.common/1.4.0",
+      "hashPath": "microsoft.azure.webpubsub.common.1.4.0.nupkg.sha512"
+    },
+    "Microsoft.Bcl.AsyncInterfaces/10.0.0-preview.2.25163.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hoItOloGu4xv8DfHwnNvsfOU1I0ER6HoTDUq2tqir9noTJoRKMeXb+0qH+rScwQlDZ7vwuyLbQappOUCfBWpJA==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.0-preview.2.25163.2",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.0-preview.2.25163.2.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4961,62 +4732,6 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CodeAnalysis/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-BoPeZD+BFE5x/qu28RnelX7hoCnPDbOZkwymrUnslrZjzj8B155gP/GjrI6m66oUOk2Yh1lxlUs+BRFZOPMBnQ==",
-      "path": "microsoft.codeanalysis/3.3.1",
-      "hashPath": "microsoft.codeanalysis.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Analyzers/2.9.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-alIJhS0VUg/7x5AsHEoovh/wRZ0RfCSS7k5pDSqpRLTyuMTtRgj6OJJPRApRhJHOGYYsLakf1hKeXFoDwKwNkg==",
-      "path": "microsoft.codeanalysis.analyzers/2.9.4",
-      "hashPath": "microsoft.codeanalysis.analyzers.2.9.4.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Common/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-N5yQdGy+M4kimVG7hwCeGTCfgYjK2o5b/Shumkb/rCC+/SAkvP1HUAYK+vxPFS7dLJNtXLRsmPHKj3fnyNWnrw==",
-      "path": "microsoft.codeanalysis.common/3.3.1",
-      "hashPath": "microsoft.codeanalysis.common.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.CSharp/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-WDUIhTHem38H6VJ98x2Ssq0fweakJHnHYl7vbG8ARnsAwLoJKCQCy78EeY1oRrCKG42j0v6JVljKkeqSDA28UA==",
-      "path": "microsoft.codeanalysis.csharp/3.3.1",
-      "hashPath": "microsoft.codeanalysis.csharp.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.CSharp.Workspaces/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-dHs/UyfLgzsVC4FjTi/x+H+yQifgOnpe3rSN8GwkHWjnidePZ3kSqr1JHmFDf5HTQEydYwrwCAfQ0JSzhsEqDA==",
-      "path": "microsoft.codeanalysis.csharp.workspaces/3.3.1",
-      "hashPath": "microsoft.codeanalysis.csharp.workspaces.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.VisualBasic/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-F7fc/G+0ocOYkKSCJ7Y8Q7eAEkAdG5RYODI9FtSl2Hm8zIDBVA3NccCm98gaOvCamLfMHYqeOjpb3yJnnw3m/w==",
-      "path": "microsoft.codeanalysis.visualbasic/3.3.1",
-      "hashPath": "microsoft.codeanalysis.visualbasic.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.VisualBasic.Workspaces/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Oi4AUxMKAYpx7nHNh7jUO8X18JFCzwtIfu/yDzGzOBpo50591AF7EEdv99geAEidGtmJqbzQ6uRk5dEOL+7F/Q==",
-      "path": "microsoft.codeanalysis.visualbasic.workspaces/3.3.1",
-      "hashPath": "microsoft.codeanalysis.visualbasic.workspaces.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Workspaces.Common/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-NfBz3b5hFSbO+7xsCNryD+p8axsIJFTG7qM3jvMTC/MqYrU6b8E1b6JoRj5rJSOBB+pSunk+CMqyGQTOWHeDUg==",
-      "path": "microsoft.codeanalysis.workspaces.common/3.3.1",
-      "hashPath": "microsoft.codeanalysis.workspaces.common.3.3.1.nupkg.sha512"
-    },
     "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
@@ -5024,12 +4739,12 @@
       "path": "microsoft.csharp/4.7.0",
       "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
-    "Microsoft.Data.SqlClient/5.2.1": {
+    "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ojg2XWmih4ubPPtrhRqqXk0SM6wC2ZSTkNNEAlYBhMo4IsRHjLazFc0abzcZCNfw1JyWcqY7vGutWTv8ZaFD9g==",
-      "path": "microsoft.data.sqlclient/5.2.1",
-      "hashPath": "microsoft.data.sqlclient.5.2.1.nupkg.sha512"
+      "sha512": "sha512-mtoeRMh7F/OA536c/Cnh8L4H0uLSKB5kSmoi54oN7Fp0hNJDy22IqyMhaMH4PkDCqI7xL//Fvg9ldtuPHG0h5g==",
+      "path": "microsoft.data.sqlclient/5.2.2",
+      "hashPath": "microsoft.data.sqlclient.5.2.2.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient.SNI.runtime/5.2.0": {
       "type": "package",
@@ -5045,47 +4760,61 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.1.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-O0hn+DEl5Ui4DZOs/yDBTtJHvTd9niT6AW0CGn40VoScStWXYuhBmYiMYQj+fCIn/tWLzw2NqYan8DsVNZX4KA==",
-      "path": "microsoft.durabletask.grpc/1.1.0",
-      "hashPath": "microsoft.durabletask.grpc.1.1.0.nupkg.sha512"
+      "sha512": "sha512-r6m2ZM9F94jS38gbdlkt78YCL3KURRYuerBPZWk0pl2eRTZoPQCLDC9XHxuwnXNv3994z5VofcWtAiVgMl1mPg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/0.4.2-alpha",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.0.4.2-alpha.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-B28jkMmT1d0z5J4IBzBcNyFfTRSQzhaHHvr1JvYN2aaapVvN/zrRD98b5utVCjBX77tdZxKINoKu18GwLdwIKQ==",
-      "path": "microsoft.durabletask.sqlserver/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YLDAWgwwRmz5tN2IJQqVRHIFObPOmkQQ6NR+lMO+CvQiOWiPxdb2wrT1wh9rQ2xp0gYDy+neUuXdIZLDrqdfLQ==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.3.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.7.4": {
+    "Microsoft.Extensions.Azure/1.11.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AVYk0jKLZa1d0r89cNs5pCgPAQMe1uco6g0FIuzyc7eEOccd+TjXGXiRkTNQibf8wYrCd15Qt+xvcKTmGR0sZg==",
-      "path": "microsoft.extensions.azure/1.7.4",
-      "hashPath": "microsoft.extensions.azure.1.7.4.nupkg.sha512"
+      "sha512": "sha512-j6Vb858BgfAbzuv0UQxOvn8jPo8i+96Kkacu1q0RwQi+fAwVljL8WmI0oZX4CCLUsJCs1yzbpJCaS7MYPPCUjw==",
+      "path": "microsoft.extensions.azure/1.11.0",
+      "hashPath": "microsoft.extensions.azure.1.11.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration/2.2.0": {
+    "Microsoft.Extensions.Caching.Abstractions/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nOP8R1mVb/6mZtm2qgAJXn/LFm/2kMjHDAg/QJLFG6CuWYJtaD3p1BwQhufBVvRzL9ceJ/xF0SQ0qsI2GkDQAA==",
-      "path": "microsoft.extensions.configuration/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.2.2.0.nupkg.sha512"
+      "sha512": "sha512-IxlFDVOchL6tdR05bk7EiJvMtvZrVkZXBhkbXqc3GxOHOrHFGcN+92WoWFPeBpdpy8ot/Px5ZdXzt7k+2n1Bdg==",
+      "path": "microsoft.extensions.caching.abstractions/1.0.0",
+      "hashPath": "microsoft.extensions.caching.abstractions.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
+    "Microsoft.Extensions.Caching.Memory/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-65MrmXCziWaQFrI0UHkQbesrX5wTwf9XPjY5yFm/VkgJKFJ5gqvXRoXjIZcf2wLi5ZlwGz/oMYfyURVCWbM5iw==",
-      "path": "microsoft.extensions.configuration.abstractions/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-6+7zTufCnZ+tfrUo7RbIRR3LB0BxwOwxfXuo0IbLyIvgoToGpWuz5wYEDfCYNOvpig9tY8FA0I1uRHYmITMXMQ==",
+      "path": "microsoft.extensions.caching.memory/1.0.0",
+      "hashPath": "microsoft.extensions.caching.memory.1.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+      "path": "microsoft.extensions.configuration/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.3.1.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.Abstractions/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ESz6bVoDQX7sgWdKHF6G9Pq672T8k+19AFb/txDXwdz7MoqaNQj2/in3agm/3qae9V+WvQZH86LLTNVo0it8vQ==",
+      "path": "microsoft.extensions.configuration.abstractions/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration.Binder/2.2.0": {
       "type": "package",
@@ -5101,33 +4830,33 @@
       "path": "microsoft.extensions.configuration.environmentvariables/2.2.0",
       "hashPath": "microsoft.extensions.configuration.environmentvariables.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.FileExtensions/2.2.0": {
+    "Microsoft.Extensions.Configuration.FileExtensions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-H1qCpWBC8Ed4tguTR/qYkbb3F6DI5Su3t8xyFo3/5MzAd8PwPpHzgX8X04KbBxKmk173Pb64x7xMHarczVFQUA==",
-      "path": "microsoft.extensions.configuration.fileextensions/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.fileextensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OjRJIkVxUFiVkr9a39AqVThft9QHoef4But5pDCydJOXJ4D/SkmzuW1tm6J2IXynxj6qfeAz9QTnzQAvOcGvzg==",
+      "path": "microsoft.extensions.configuration.fileextensions/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.fileextensions.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.Json/2.1.0": {
+    "Microsoft.Extensions.Configuration.Json/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9OCdAv7qiRtRlXQnECxW9zINUK8bYPKbNp5x8FQaLZbm/flv7mPvo1muZ1nsKGMZF4uL4Bl6nHw2v1fi3MqQ1Q==",
-      "path": "microsoft.extensions.configuration.json/2.1.0",
-      "hashPath": "microsoft.extensions.configuration.json.2.1.0.nupkg.sha512"
+      "sha512": "sha512-gBpBE1GoaCf1PKYC7u0Bd4mVZ/eR2bnOvn7u8GBXEy3JGar6sC3UVpVfTB9w+biLPtzcukZynBG9uchSBbLTNQ==",
+      "path": "microsoft.extensions.configuration.json/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.json.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
-      "path": "microsoft.extensions.dependencyinjection/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
+      "sha512": "sha512-elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
+      "path": "microsoft.extensions.dependencyinjection/7.0.0",
+      "hashPath": "microsoft.extensions.dependencyinjection.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5136,26 +4865,26 @@
       "path": "microsoft.extensions.dependencymodel/2.1.0",
       "hashPath": "microsoft.extensions.dependencymodel.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
+    "Microsoft.Extensions.FileProviders.Abstractions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EcnaSsPTqx2MGnHrmWOD0ugbuuqVT8iICqSqPzi45V5/MA1LjUNb0kwgcxBGqizV1R+WeBK7/Gw25Jzkyk9bIw==",
-      "path": "microsoft.extensions.fileproviders.abstractions/2.2.0",
-      "hashPath": "microsoft.extensions.fileproviders.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-G3iBMOnn3tETEUvkE9J3a23wQpRkiXZp73zR0XNlicjLFhkeWW1FCaC2bTjrgHhPi2KO6x0BXnHvVuJPIlygBQ==",
+      "path": "microsoft.extensions.fileproviders.abstractions/3.1.0",
+      "hashPath": "microsoft.extensions.fileproviders.abstractions.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
+    "Microsoft.Extensions.FileProviders.Physical/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tbDHZnBJkjYd9NjlRZ9ondDiv1Te3KYCTW2RWpR1B0e1Z8+EnFRo7qNnHkkSCixLdlPZzhjlX24d/PixQ7w2dA==",
-      "path": "microsoft.extensions.fileproviders.physical/2.2.0",
-      "hashPath": "microsoft.extensions.fileproviders.physical.2.2.0.nupkg.sha512"
+      "sha512": "sha512-KsvgrYp2fhNXoD9gqSu8jPK9Sbvaa7SqNtsLqHugJkCwFmgRvdz76z6Jz2tlFlC7wyMTZxwwtRF8WAorRQWTEA==",
+      "path": "microsoft.extensions.fileproviders.physical/3.1.0",
+      "hashPath": "microsoft.extensions.fileproviders.physical.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileSystemGlobbing/2.2.0": {
+    "Microsoft.Extensions.FileSystemGlobbing/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZSsHZp3PyW6vk37tDEdypjgGlNtpJ0EixBMOfUod2Thx7GtwfFSAQXUQx8a8BN8vfWKGGMbp7jPWdoHx/At4wQ==",
-      "path": "microsoft.extensions.filesystemglobbing/2.2.0",
-      "hashPath": "microsoft.extensions.filesystemglobbing.2.2.0.nupkg.sha512"
+      "sha512": "sha512-tK5HZOmVv0kUYkonMjuSsxR0CBk+Rd/69QU3eOMv9FvODGZ2d0SR+7R+n8XIgBcCCoCHJBSsI4GPRaoN3Le4rA==",
+      "path": "microsoft.extensions.filesystemglobbing/3.1.0",
+      "hashPath": "microsoft.extensions.filesystemglobbing.3.1.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Hosting/2.1.0": {
       "type": "package",
@@ -5171,26 +4900,33 @@
       "path": "microsoft.extensions.hosting.abstractions/2.2.0",
       "hashPath": "microsoft.extensions.hosting.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Http/3.1.32": {
+    "Microsoft.Extensions.Http/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0ZNzmbaeKQMQQH8CZ1QVKC26nJ+jOn1AjSrVWKEb9sqX8cgElMbWUtvOXN21BI6IHedS+uhVuzJLQN3Ny46AKw==",
-      "path": "microsoft.extensions.http/3.1.32",
-      "hashPath": "microsoft.extensions.http.3.1.32.nupkg.sha512"
+      "sha512": "sha512-15+pa2G0bAMHbHewaQIdr/y6ag2H3yh4rd9hTXavtWDzQBkvpe2RMqFg8BxDpcQWssmjmBApGPcw93QRz6YcMg==",
+      "path": "microsoft.extensions.http/6.0.0",
+      "hashPath": "microsoft.extensions.http.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging/6.0.0": {
+    "Microsoft.Extensions.Logging/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
-      "path": "microsoft.extensions.logging/6.0.0",
-      "hashPath": "microsoft.extensions.logging.6.0.0.nupkg.sha512"
+      "sha512": "sha512-Nw2muoNrOG5U5qa2ZekXwudUn2BJcD41e65zwmDHb1fQegTX66UokLWZkJRpqSSHXDOWZ5V0iqhbxOEky91atA==",
+      "path": "microsoft.extensions.logging/7.0.0",
+      "hashPath": "microsoft.extensions.logging.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging.Abstractions/6.0.0": {
+    "Microsoft.Extensions.Logging.Abstractions/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA==",
-      "path": "microsoft.extensions.logging.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.logging.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw==",
+      "path": "microsoft.extensions.logging.abstractions/7.0.0",
+      "hashPath": "microsoft.extensions.logging.abstractions.7.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.ApplicationInsights/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
+      "path": "microsoft.extensions.logging.applicationinsights/2.21.0",
+      "hashPath": "microsoft.extensions.logging.applicationinsights.2.21.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Logging.Configuration/2.1.0": {
       "type": "package",
@@ -5206,12 +4942,12 @@
       "path": "microsoft.extensions.objectpool/2.2.0",
       "hashPath": "microsoft.extensions.objectpool.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Options/6.0.0": {
+    "Microsoft.Extensions.Options/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
-      "path": "microsoft.extensions.options/6.0.0",
-      "hashPath": "microsoft.extensions.options.6.0.0.nupkg.sha512"
+      "sha512": "sha512-lP1yBnTTU42cKpMozuafbvNtQ7QcBjr/CcK3bYOGEMH55Fjt+iecXjT6chR7vbgCMqy3PG3aNQSZgo/EuY/9qQ==",
+      "path": "microsoft.extensions.options/7.0.0",
+      "hashPath": "microsoft.extensions.options.7.0.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
       "type": "package",
@@ -5220,12 +4956,12 @@
       "path": "microsoft.extensions.options.configurationextensions/2.1.0",
       "hashPath": "microsoft.extensions.options.configurationextensions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Primitives/6.0.0": {
+    "Microsoft.Extensions.Primitives/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
-      "path": "microsoft.extensions.primitives/6.0.0",
-      "hashPath": "microsoft.extensions.primitives.6.0.0.nupkg.sha512"
+      "sha512": "sha512-um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q==",
+      "path": "microsoft.extensions.primitives/7.0.0",
+      "hashPath": "microsoft.extensions.primitives.7.0.0.nupkg.sha512"
     },
     "Microsoft.FASTER.Core/2.6.5": {
       "type": "package",
@@ -5234,19 +4970,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.61.3": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
-      "path": "microsoft.identity.client/4.61.3",
-      "hashPath": "microsoft.identity.client.4.61.3.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
-      "path": "microsoft.identity.client.extensions.msal/4.61.3",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.61.3.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/7.6.3": {
       "type": "package",
@@ -5254,13 +4990,6 @@
       "sha512": "sha512-EycYJUD/3cZw/b6TioXOpmETjv9OX5/VRk0Tc26x6I+SxxLNxx6ymivwo2dfYeiimqg5d3k88VXnrxc7HJch6Q==",
       "path": "microsoft.identitymodel.abstractions/7.6.3",
       "hashPath": "microsoft.identitymodel.abstractions.7.6.3.nupkg.sha512"
-    },
-    "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TNsJJMiRnkeby1ovThVoV9yFsPWjAdluwOA+Nf0LtSsBVVrKQv8Qp4kYOgyNwMVj+pDwbhXISySk+4HyHVWNZQ==",
-      "path": "microsoft.identitymodel.clients.activedirectory/3.14.2",
-      "hashPath": "microsoft.identitymodel.clients.activedirectory.3.14.2.nupkg.sha512"
     },
     "Microsoft.IdentityModel.JsonWebTokens/7.6.3": {
       "type": "package",
@@ -5311,19 +5040,26 @@
       "path": "microsoft.net.http.headers/2.2.0",
       "hashPath": "microsoft.net.http.headers.2.2.0.nupkg.sha512"
     },
-    "Microsoft.NET.Sdk.Functions/4.4.0": {
+    "Microsoft.NET.Sdk.Functions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
-      "path": "microsoft.net.sdk.functions/4.4.0",
-      "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+      "sha512": "sha512-jDnf2TZ5JcBQY9BhI5hzRsbsu+EzJuz22GzmHmV9iGFFBraD3MaOTsoHxtS5kpd9qX3qCv7I7HuNjUSiH3nTZg==",
+      "path": "microsoft.net.sdk.functions/4.6.0",
+      "hashPath": "microsoft.net.sdk.functions.4.6.0.nupkg.sha512"
     },
-    "Microsoft.NETCore.Platforms/2.1.2": {
+    "Microsoft.NET.StringTools/17.6.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mOJy3M0UN+LUG21dLGMxaWZEP6xYpQEpLuvuEQBaownaX4YuhH6NmNUlN9si+vNkAS6dwJ//N1O4DmLf2CikVg==",
-      "path": "microsoft.netcore.platforms/2.1.2",
-      "hashPath": "microsoft.netcore.platforms.2.1.2.nupkg.sha512"
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
+    },
+    "Microsoft.NETCore.Platforms/3.1.9": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-e+/BrhryHoMojWlbcPJAFcShpk3JYvsMfrmoM26dnvHARWR6vtmGbfHppZcANVqf7DUBDIRxlZXcWg7v/9e1TQ==",
+      "path": "microsoft.netcore.platforms/3.1.9",
+      "hashPath": "microsoft.netcore.platforms.3.1.9.nupkg.sha512"
     },
     "Microsoft.NETCore.Targets/1.1.3": {
       "type": "package",
@@ -5339,12 +5075,12 @@
       "path": "microsoft.sqlserver.server/1.0.0",
       "hashPath": "microsoft.sqlserver.server.1.0.0.nupkg.sha512"
     },
-    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v1I3SV+EqPHBM+RGrB5LyEc2z74t8WRYFmB0BmSc7EMBDUxFgmJ5oentkf9hPkUFfesha9spB0jci4hDtrCE3Q==",
-      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9123.0",
-      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9123.0.nupkg.sha512"
+      "sha512": "sha512-Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g==",
+      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9135.0",
+      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9135.0.nupkg.sha512"
     },
     "Microsoft.Win32.Primitives/4.3.0": {
       "type": "package",
@@ -5360,40 +5096,54 @@
       "path": "microsoft.win32.registry/5.0.0",
       "hashPath": "microsoft.win32.registry.5.0.0.nupkg.sha512"
     },
-    "MongoDB.Bson/2.25.0": {
+    "Microsoft.Win32.SystemEvents/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xQx/qtC2nu9oGiyNqAwfiDpUMweLi0nID677cyKykpwmj5AVMrnd//UwmcmuX95178DeY6rf7cjmA613TQXPiA==",
-      "path": "mongodb.bson/2.25.0",
-      "hashPath": "mongodb.bson.2.25.0.nupkg.sha512"
+      "sha512": "sha512-mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+      "path": "microsoft.win32.systemevents/4.7.0",
+      "hashPath": "microsoft.win32.systemevents.4.7.0.nupkg.sha512"
     },
-    "MongoDB.Driver/2.25.0": {
+    "MongoDB.Bson/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dMqnZTV6MuvoEI4yFtSvKJdAoN6NeyAEvG8aoxnrLIVd7bR84QxLgpsM1nhK17qkOcIx/IrpMIfrvp5iMnYGBg==",
-      "path": "mongodb.driver/2.25.0",
-      "hashPath": "mongodb.driver.2.25.0.nupkg.sha512"
+      "sha512": "sha512-wz8UtxdjnknHRJuMatTRr2QMlh7k9457BRfaDQxl+OiKV01vMzm1K0/jTvQJqORV5eba6HrCAzMJzj7nnt5cag==",
+      "path": "mongodb.bson/2.29.0",
+      "hashPath": "mongodb.bson.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Driver.Core/2.25.0": {
+    "MongoDB.Driver/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oN4nLgO5HQEThTg/zqeoHqaO2+q64DBVb4r7BvhaFb0p0TM9jZKnCKvh1EA8d9E9swIz0CgvMrvL1mPyRCZzag==",
-      "path": "mongodb.driver.core/2.25.0",
-      "hashPath": "mongodb.driver.core.2.25.0.nupkg.sha512"
+      "sha512": "sha512-1IfTnHX8G2SsXIHDz80OVSmcdL95vzzWXGGucR45k7+TUOcWVhiqYcc13ckRXl4NVxn4UTRrrKl+92xvjwWrRA==",
+      "path": "mongodb.driver/2.29.0",
+      "hashPath": "mongodb.driver.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Libmongocrypt/1.8.2": {
+    "MongoDB.Driver.Core/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-z/8JCULSHM1+mzkau0ivIkU9kIn8JEFFSkmYTSaMaWMMHt96JjUtMKuXxeGNGSnHZ5290ZPKIlQfjoWFk2sKog==",
-      "path": "mongodb.libmongocrypt/1.8.2",
-      "hashPath": "mongodb.libmongocrypt.1.8.2.nupkg.sha512"
+      "sha512": "sha512-3M7gdmuLEay4Wc/q4zm/oA5KT4E62SsRBiq3prpT3tGEPkfstr3N3fYRbzYNu8TJgeyS0q5OPe4zI4yi6/GemQ==",
+      "path": "mongodb.driver.core/2.29.0",
+      "hashPath": "mongodb.driver.core.2.29.0.nupkg.sha512"
     },
-    "morelinq/3.4.2": {
+    "MongoDB.Libmongocrypt/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q==",
-      "path": "morelinq/3.4.2",
-      "hashPath": "morelinq.3.4.2.nupkg.sha512"
+      "sha512": "sha512-B1X51jrtNacKvxKoaqWeknYeJfQS5aWf6BmVLT5JZerz3AUXFzv8edPskJYqBc3kLy1J2PWzMqqsnyb9g8FtcA==",
+      "path": "mongodb.libmongocrypt/1.12.0",
+      "hashPath": "mongodb.libmongocrypt.1.12.0.nupkg.sha512"
+    },
+    "morelinq/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tkUeXp5dWNVP47MIhVEsIQk4DaN2oM/owIAnHblNOiwDQ5RB7oKreqZ7a+z+AEdyNgzLSkj6Pv0D0rY6Gh1/Ng==",
+      "path": "morelinq/4.1.0",
+      "hashPath": "morelinq.4.1.0.nupkg.sha512"
+    },
+    "MySql.Data/8.0.33": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mW+A9tc0s+3E3+XYe80aJmr/AvZoKBZG44w13AdVf4+1iRDwgdL6eLMPZgHyQFGwdLwNvQNPKegcOE4rRDuv8Q==",
+      "path": "mysql.data/8.0.33",
+      "hashPath": "mysql.data.8.0.33.nupkg.sha512"
     },
     "ncrontab.signed/3.3.0": {
       "type": "package",
@@ -5402,12 +5152,12 @@
       "path": "ncrontab.signed/3.3.0",
       "hashPath": "ncrontab.signed.3.3.0.nupkg.sha512"
     },
-    "NETStandard.Library/2.0.1": {
+    "NETStandard.Library/1.6.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
-      "path": "netstandard.library/2.0.1",
-      "hashPath": "netstandard.library.2.0.1.nupkg.sha512"
+      "sha512": "sha512-WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+      "path": "netstandard.library/1.6.1",
+      "hashPath": "netstandard.library.1.6.1.nupkg.sha512"
     },
     "Newtonsoft.Json/13.0.3": {
       "type": "package",
@@ -5429,6 +5179,13 @@
       "sha512": "sha512-zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ==",
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
+    },
+    "Portable.BouncyCastle/1.9.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw==",
+      "path": "portable.bouncycastle/1.9.0",
+      "hashPath": "portable.bouncycastle.1.9.0.nupkg.sha512"
     },
     "RabbitMQ.Client/5.1.2": {
       "type": "package",
@@ -5465,6 +5222,13 @@
       "path": "runtime.native.system/4.3.0",
       "hashPath": "runtime.native.system.4.3.0.nupkg.sha512"
     },
+    "runtime.native.System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+      "path": "runtime.native.system.io.compression/4.3.0",
+      "hashPath": "runtime.native.system.io.compression.4.3.0.nupkg.sha512"
+    },
     "runtime.native.System.Net.Http/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5472,12 +5236,12 @@
       "path": "runtime.native.system.net.http/4.3.0",
       "hashPath": "runtime.native.system.net.http.4.3.0.nupkg.sha512"
     },
-    "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UPrVPlqPRSVZaB4ADmbsQ77KXn9ORiWXyA1RP2W2+byCh3bhgT1bQz0jbeOoog9/2oTQ5wWZSDSMeb74MjezcA==",
-      "path": "runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+      "path": "runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5500,12 +5264,12 @@
       "path": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2",
       "hashPath": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg.sha512"
     },
-    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-t15yGf5r6vMV1rB5O6TgfXKChtCaN3niwFw44M2ImX3eZ8yzueplqMqXPCbWzoBDHJVz9fE+9LFUGCsUmS2Jgg==",
-      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ==",
+      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5549,12 +5313,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "SharpCompress/0.30.1": {
       "type": "package",
@@ -5577,12 +5341,19 @@
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
     },
-    "System.AppContext/4.1.0": {
+    "starkbank-ecdsa/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
-      "path": "system.appcontext/4.1.0",
-      "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
+    },
+    "System.AppContext/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+      "path": "system.appcontext/4.3.0",
+      "hashPath": "system.appcontext.4.3.0.nupkg.sha512"
     },
     "System.Buffers/4.5.1": {
       "type": "package",
@@ -5591,12 +5362,12 @@
       "path": "system.buffers/4.5.1",
       "hashPath": "system.buffers.4.5.1.nupkg.sha512"
     },
-    "System.ClientModel/1.0.0": {
+    "System.ClientModel/1.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I3CVkvxeqFYjIVEP59DnjbeoGNfo/+SZrCLpRz2v/g0gpCHaEMPtWSY0s9k/7jR1rAsLNg2z2u1JRB76tPjnIw==",
-      "path": "system.clientmodel/1.0.0",
-      "hashPath": "system.clientmodel.1.0.0.nupkg.sha512"
+      "sha512": "sha512-UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+      "path": "system.clientmodel/1.1.0",
+      "hashPath": "system.clientmodel.1.1.0.nupkg.sha512"
     },
     "System.CodeDom/4.4.0": {
       "type": "package",
@@ -5647,54 +5418,19 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Composition/1.0.31": {
+    "System.Configuration.ConfigurationManager/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I+D26qpYdoklyAVUdqwUBrEIckMNjAYnuPJy/h9dsQItpQwVREkDFs4b4tkBza0kT2Yk48Lcfsv2QQ9hWsh9Iw==",
-      "path": "system.composition/1.0.31",
-      "hashPath": "system.composition.1.0.31.nupkg.sha512"
+      "sha512": "sha512-gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+      "path": "system.configuration.configurationmanager/8.0.1",
+      "hashPath": "system.configuration.configurationmanager.8.0.1.nupkg.sha512"
     },
-    "System.Composition.AttributedModel/1.0.31": {
+    "System.Console/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NHWhkM3ZkspmA0XJEsKdtTt1ViDYuojgSND3yHhTzwxepiwqZf+BCWuvCbjUt4fe0NxxQhUDGJ5km6sLjo9qnQ==",
-      "path": "system.composition.attributedmodel/1.0.31",
-      "hashPath": "system.composition.attributedmodel.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Convention/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GLjh2Ju71k6C0qxMMtl4efHa68NmWeIUYh4fkUI8xbjQrEBvFmRwMDFcylT8/PR9SQbeeL48IkFxU/+gd0nYEQ==",
-      "path": "system.composition.convention/1.0.31",
-      "hashPath": "system.composition.convention.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Hosting/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-fN1bT4RX4vUqjbgoyuJFVUizAl2mYF5VAb+bVIxIYZSSc0BdnX+yGAxcavxJuDDCQ1K+/mdpgyEFc8e9ikjvrg==",
-      "path": "system.composition.hosting/1.0.31",
-      "hashPath": "system.composition.hosting.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Runtime/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-0LEJN+2NVM89CE4SekDrrk5tHV5LeATltkp+9WNYrR+Huiyt0vaCqHbbHtVAjPyeLWIc8dOz/3kthRBj32wGQg==",
-      "path": "system.composition.runtime/1.0.31",
-      "hashPath": "system.composition.runtime.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.TypedParts/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-0Zae/FtzeFgDBBuILeIbC/T9HMYbW4olAmi8XqqAGosSOWvXfiQLfARZEhiGd0LVXaYgXr0NhxiU1LldRP1fpQ==",
-      "path": "system.composition.typedparts/1.0.31",
-      "hashPath": "system.composition.typedparts.1.0.31.nupkg.sha512"
-    },
-    "System.Configuration.ConfigurationManager/8.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
-      "path": "system.configuration.configurationmanager/8.0.0",
-      "hashPath": "system.configuration.configurationmanager.8.0.0.nupkg.sha512"
+      "sha512": "sha512-DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
+      "path": "system.console/4.3.0",
+      "hashPath": "system.console.4.3.0.nupkg.sha512"
     },
     "System.Diagnostics.Debug/4.3.0": {
       "type": "package",
@@ -5710,19 +5446,19 @@
       "path": "system.diagnostics.diagnosticsource/8.0.0",
       "hashPath": "system.diagnostics.diagnosticsource.8.0.0.nupkg.sha512"
     },
-    "System.Diagnostics.EventLog/6.0.0": {
+    "System.Diagnostics.EventLog/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw==",
-      "path": "system.diagnostics.eventlog/6.0.0",
-      "hashPath": "system.diagnostics.eventlog.6.0.0.nupkg.sha512"
+      "sha512": "sha512-n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg==",
+      "path": "system.diagnostics.eventlog/8.0.1",
+      "hashPath": "system.diagnostics.eventlog.8.0.1.nupkg.sha512"
     },
-    "System.Diagnostics.Process/4.3.0": {
+    "System.Diagnostics.PerformanceCounter/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-J0wOX07+QASQblsfxmIMFc9Iq7KTXYL3zs2G/Xc704Ylv3NpuVdo6gij6V3PGiptTxqsK0K7CdXenRvKUnkA2g==",
-      "path": "system.diagnostics.process/4.3.0",
-      "hashPath": "system.diagnostics.process.4.3.0.nupkg.sha512"
+      "sha512": "sha512-kE9szT4i3TYT9bDE/BPfzg9/BL6enMiZlcUmnUEBrhRtxWvurKoa8qhXkLTRhrxMzBqaDleWlRfIPE02tulU+w==",
+      "path": "system.diagnostics.performancecounter/4.7.0",
+      "hashPath": "system.diagnostics.performancecounter.4.7.0.nupkg.sha512"
     },
     "System.Diagnostics.Tools/4.3.0": {
       "type": "package",
@@ -5744,6 +5480,13 @@
       "sha512": "sha512-rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
       "path": "system.diagnostics.tracing/4.3.0",
       "hashPath": "system.diagnostics.tracing.4.3.0.nupkg.sha512"
+    },
+    "System.Drawing.Common/4.7.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-B3+wwhAeoUQ6KeshWSq3IRLQiMoqPEzSHzyVyxTI/EbYuqIp90lXrRISlip2AF+5tj74ycIVPpnRY4M424HahA==",
+      "path": "system.drawing.common/4.7.3",
+      "hashPath": "system.drawing.common.4.7.3.nupkg.sha512"
     },
     "System.Dynamic.Runtime/4.0.11": {
       "type": "package",
@@ -5801,12 +5544,33 @@
       "path": "system.io/4.3.0",
       "hashPath": "system.io.4.3.0.nupkg.sha512"
     },
+    "System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+      "path": "system.io.compression/4.3.0",
+      "hashPath": "system.io.compression.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Compression.ZipFile/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
+      "path": "system.io.compression.zipfile/4.3.0",
+      "hashPath": "system.io.compression.zipfile.4.3.0.nupkg.sha512"
+    },
     "System.IO.FileSystem/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
       "path": "system.io.filesystem/4.3.0",
       "hashPath": "system.io.filesystem.4.3.0.nupkg.sha512"
+    },
+    "System.IO.FileSystem.AccessControl/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vMToiarpU81LR1/KZtnT7VDPvqAZfw9oOS5nY6pPP78nGYz3COLsQH3OfzbR+SjTgltd31R6KmKklz/zDpTmzw==",
+      "path": "system.io.filesystem.accesscontrol/4.7.0",
+      "hashPath": "system.io.filesystem.accesscontrol.4.7.0.nupkg.sha512"
     },
     "System.IO.FileSystem.Primitives/4.3.0": {
       "type": "package",
@@ -5822,12 +5586,12 @@
       "path": "system.io.hashing/6.0.0",
       "hashPath": "system.io.hashing.6.0.0.nupkg.sha512"
     },
-    "System.IO.Pipelines/5.0.1": {
+    "System.IO.Pipelines/6.0.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg==",
-      "path": "system.io.pipelines/5.0.1",
-      "hashPath": "system.io.pipelines.5.0.1.nupkg.sha512"
+      "sha512": "sha512-ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw==",
+      "path": "system.io.pipelines/6.0.3",
+      "hashPath": "system.io.pipelines.6.0.3.nupkg.sha512"
     },
     "System.Json/4.5.0": {
       "type": "package",
@@ -5864,12 +5628,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/1.0.2": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JGkzeqgBsiZwKJZ1IxPNsDFZDhUvuEdX8L8BDC8N3KOj+6zMcNU28CNN59TpZE/VJYy9cP+5M+sbxtWJx3/xtw==",
-      "path": "system.memory.data/1.0.2",
-      "hashPath": "system.memory.data.1.0.2.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5892,19 +5656,19 @@
       "path": "system.net.primitives/4.3.0",
       "hashPath": "system.net.primitives.4.3.0.nupkg.sha512"
     },
+    "System.Net.ServerSentEvents/10.0.0-preview.1.25080.5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WXlkTQNLx+O4Ys5lMZNjGOUsuMXjL8nbmBGCWR0np0EKasGZmmfMXmzm9xT22arIS74uhRb/z8Y5l5C4Ceur9Q==",
+      "path": "system.net.serversentevents/10.0.0-preview.1.25080.5",
+      "hashPath": "system.net.serversentevents.10.0.0-preview.1.25080.5.nupkg.sha512"
+    },
     "System.Net.Sockets/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
       "path": "system.net.sockets/4.3.0",
       "hashPath": "system.net.sockets.4.3.0.nupkg.sha512"
-    },
-    "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O8RIMEVeOFzT8fscu6MDc4y+0LfnlXdqGovb0rJHBNVKhwn6BsNJmTY1oYUZPPsMfcc5OP20WpX4vj/aK8n98g==",
-      "path": "system.net.websockets.websocketprotocol/4.5.3",
-      "hashPath": "system.net.websockets.websocketprotocol.4.5.3.nupkg.sha512"
     },
     "System.Numerics.Vectors/4.5.0": {
       "type": "package",
@@ -5919,13 +5683,6 @@
       "sha512": "sha512-bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
       "path": "system.objectmodel/4.3.0",
       "hashPath": "system.objectmodel.4.3.0.nupkg.sha512"
-    },
-    "System.Private.DataContractSerialization/4.1.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-lcqFBUaCZxPiUkA4dlSOoPZGtZsAuuElH2XHgLwGLxd7ZozWetV5yiz0qGAV2AUYOqw97MtZBjbLMN16Xz4vXA==",
-      "path": "system.private.datacontractserialization/4.1.1",
-      "hashPath": "system.private.datacontractserialization.4.1.1.nupkg.sha512"
     },
     "System.Reactive/4.4.1": {
       "type": "package",
@@ -6046,12 +5803,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/8.0.0": {
+    "System.Runtime.Caching/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4TmlmvGp4kzZomm7J2HJn6IIx0UUrQyhBDyb5O1XiunZlQImXW+B8b7W/sTPcXhSf9rp5NR5aDtQllwbB5elOQ==",
-      "path": "system.runtime.caching/8.0.0",
-      "hashPath": "system.runtime.caching.8.0.0.nupkg.sha512"
+      "sha512": "sha512-tdl7Q47P09UpRu0C/OQsGJU6GacBzzk4vfp5My9rodD+BchrxmajORnTthH8RxPUTPrIoVDJmLyvJcGxB267nQ==",
+      "path": "system.runtime.caching/8.0.1",
+      "hashPath": "system.runtime.caching.8.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -6081,12 +5838,12 @@
       "path": "system.runtime.interopservices/4.3.0",
       "hashPath": "system.runtime.interopservices.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+    "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWPhJxc453RCa8Z29O91EmfGeZIHX1ZH2A8L6lYQVSaKzku2DfArSfMEb1/MYYzPQRJZeu0c9dmYeJKxW5Fgng==",
-      "path": "system.runtime.interopservices.runtimeinformation/4.0.0",
-      "hashPath": "system.runtime.interopservices.runtimeinformation.4.0.0.nupkg.sha512"
+      "sha512": "sha512-cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+      "path": "system.runtime.interopservices.runtimeinformation/4.3.0",
+      "hashPath": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg.sha512"
     },
     "System.Runtime.Loader/4.3.0": {
       "type": "package",
@@ -6102,20 +5859,6 @@
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.Serialization.Json/4.0.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-+7DIJhnKYgCzUgcLbVTtRQb2l1M0FP549XFlFkQM5lmNiUBl44AfNbx4bz61xA8PzLtlYwfmif4JJJW7MPPnjg==",
-      "path": "system.runtime.serialization.json/4.0.2",
-      "hashPath": "system.runtime.serialization.json.4.0.2.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
     "System.Security.AccessControl/6.0.0": {
       "type": "package",
       "serviceable": true,
@@ -6123,12 +5866,12 @@
       "path": "system.security.accesscontrol/6.0.0",
       "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.Algorithms/4.3.1": {
+    "System.Security.Cryptography.Algorithms/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DVUblnRfnarrI5olEC2B/OCsJQd0anjVaObQMndHSc43efbc88/RMOlDyg/EyY0ix5ecyZMXS8zMksb5ukebZA==",
-      "path": "system.security.cryptography.algorithms/4.3.1",
-      "hashPath": "system.security.cryptography.algorithms.4.3.1.nupkg.sha512"
+      "sha512": "sha512-W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+      "path": "system.security.cryptography.algorithms/4.3.0",
+      "hashPath": "system.security.cryptography.algorithms.4.3.0.nupkg.sha512"
     },
     "System.Security.Cryptography.Cng/5.0.0": {
       "type": "package",
@@ -6172,12 +5915,19 @@
       "path": "system.security.cryptography.protecteddata/8.0.0",
       "hashPath": "system.security.cryptography.protecteddata.8.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.X509Certificates/4.3.2": {
+    "System.Security.Cryptography.X509Certificates/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uwlfOnvJd7rXRvP3aV126Q9XebIIEGEaZ245Rd5/ZwOg7U7AU+AmpE0vRh2F0DFjfOTuk7MAexv4nYiNP/RYnQ==",
-      "path": "system.security.cryptography.x509certificates/4.3.2",
-      "hashPath": "system.security.cryptography.x509certificates.4.3.2.nupkg.sha512"
+      "sha512": "sha512-t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+      "path": "system.security.cryptography.x509certificates/4.3.0",
+      "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Permissions/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dkOV6YYVBnYRa15/yv004eCGRBVADXw8qRbbNiCn/XpdJSUXkkUeIvdvFHkvnko4CdKMqG8yRHC4ox83LSlMsQ==",
+      "path": "system.security.permissions/4.7.0",
+      "hashPath": "system.security.permissions.4.7.0.nupkg.sha512"
     },
     "System.Security.Principal.Windows/5.0.0": {
       "type": "package",
@@ -6193,12 +5943,12 @@
       "path": "system.text.encoding/4.3.0",
       "hashPath": "system.text.encoding.4.3.0.nupkg.sha512"
     },
-    "System.Text.Encoding.CodePages/4.5.1": {
+    "System.Text.Encoding.CodePages/4.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w==",
-      "path": "system.text.encoding.codepages/4.5.1",
-      "hashPath": "system.text.encoding.codepages.4.5.1.nupkg.sha512"
+      "sha512": "sha512-6JX7ZdaceBiLKLkYt8zJcp4xTJd1uYyXXEkPw6mnlUIjh1gZPIVKPtRXPmY5kLf6DwZmf5YLwR3QUrRonl7l0A==",
+      "path": "system.text.encoding.codepages/4.4.0",
+      "hashPath": "system.text.encoding.codepages.4.4.0.nupkg.sha512"
     },
     "System.Text.Encoding.Extensions/4.3.0": {
       "type": "package",
@@ -6214,12 +5964,12 @@
       "path": "system.text.encodings.web/8.0.0",
       "hashPath": "system.text.encodings.web.8.0.0.nupkg.sha512"
     },
-    "System.Text.Json/8.0.1": {
+    "System.Text.Json/8.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
-      "path": "system.text.json/8.0.1",
-      "hashPath": "system.text.json.8.0.1.nupkg.sha512"
+      "sha512": "sha512-bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
+      "path": "system.text.json/8.0.4",
+      "hashPath": "system.text.json.8.0.4.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",
@@ -6235,12 +5985,12 @@
       "path": "system.threading/4.3.0",
       "hashPath": "system.threading.4.3.0.nupkg.sha512"
     },
-    "System.Threading.Channels/4.7.1": {
+    "System.Threading.Channels/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6akRtHK/wab3246t4p5v3HQrtQk8LboOt5T4dtpNgsp3zvDeM4/Gx8V12t0h+c/W9/enUrilk8n6EQqdQorZAA==",
-      "path": "system.threading.channels/4.7.1",
-      "hashPath": "system.threading.channels.4.7.1.nupkg.sha512"
+      "sha512": "sha512-TY8/9+tI0mNaUMgntOxxaq2ndTkdXqLSxvPmas7XEqOlv9lQtB7wLjYGd756lOaO7Dvb5r/WXhluM+0Xe87v5Q==",
+      "path": "system.threading.channels/6.0.0",
+      "hashPath": "system.threading.channels.6.0.0.nupkg.sha512"
     },
     "System.Threading.Tasks/4.3.0": {
       "type": "package",
@@ -6263,19 +6013,12 @@
       "path": "system.threading.tasks.extensions/4.5.4",
       "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
     },
-    "System.Threading.Thread/4.3.0": {
+    "System.Threading.Timer/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
-      "path": "system.threading.thread/4.3.0",
-      "hashPath": "system.threading.thread.4.3.0.nupkg.sha512"
-    },
-    "System.Threading.ThreadPool/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-k/+g4b7vjdd4aix83sTgC9VG6oXYKAktSfNIJUNGxPEj7ryEOfzHHhfnmsZvjxawwcD9HyWXKCXmPjX8U4zeSw==",
-      "path": "system.threading.threadpool/4.3.0",
-      "hashPath": "system.threading.threadpool.4.3.0.nupkg.sha512"
+      "sha512": "sha512-Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+      "path": "system.threading.timer/4.3.0",
+      "hashPath": "system.threading.timer.4.3.0.nupkg.sha512"
     },
     "System.ValueTuple/4.5.0": {
       "type": "package",
@@ -6284,26 +6027,26 @@
       "path": "system.valuetuple/4.5.0",
       "hashPath": "system.valuetuple.4.5.0.nupkg.sha512"
     },
-    "System.Xml.ReaderWriter/4.0.11": {
+    "System.Windows.Extensions/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
-      "path": "system.xml.readerwriter/4.0.11",
-      "hashPath": "system.xml.readerwriter.4.0.11.nupkg.sha512"
+      "sha512": "sha512-CeWTdRNfRaSh0pm2gDTJFwVaXfTq6Xwv/sA887iwPTneW7oMtMlpvDIO+U60+3GWTB7Aom6oQwv5VZVUhQRdPQ==",
+      "path": "system.windows.extensions/4.7.0",
+      "hashPath": "system.windows.extensions.4.7.0.nupkg.sha512"
     },
-    "System.Xml.XmlDocument/4.0.1": {
+    "System.Xml.ReaderWriter/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2eZu6IP+etFVBBFUFzw2w6J21DqIN5eL9Y8r8JfJWUmV28Z5P0SNU01oCisVHQgHsDhHPnmq2s1hJrJCFZWloQ==",
-      "path": "system.xml.xmldocument/4.0.1",
-      "hashPath": "system.xml.xmldocument.4.0.1.nupkg.sha512"
+      "sha512": "sha512-GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+      "path": "system.xml.readerwriter/4.3.0",
+      "hashPath": "system.xml.readerwriter.4.3.0.nupkg.sha512"
     },
-    "System.Xml.XmlSerializer/4.0.11": {
+    "System.Xml.XDocument/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FrazwwqfIXTfq23mfv4zH+BjqkSFNaNFBtjzu3I9NRmG8EELYyrv/fJnttCIwRMFRR/YKXF1hmsMmMEnl55HGw==",
-      "path": "system.xml.xmlserializer/4.0.11",
-      "hashPath": "system.xml.xmlserializer.4.0.11.nupkg.sha512"
+      "sha512": "sha512-5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+      "path": "system.xml.xdocument/4.3.0",
+      "hashPath": "system.xml.xdocument.4.3.0.nupkg.sha512"
     },
     "Twilio/5.6.3": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
@@ -1,39 +1,43 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v6.0",
+    "name": ".NETCoreApp,Version=v8.0/linux-x64",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v6.0": {
+    ".NETCoreApp,Version=v8.0": {},
+    ".NETCoreApp,Version=v8.0/linux-x64": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "1.5.4",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.2",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "0.4.2-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.1.54-rc",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.10-Preview",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.3.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.2.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.15.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.2.9-rc",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.11-Preview",
+          "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.31-preview",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.4.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.3.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.16.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.169-preview",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.3.0",
-          "Microsoft.NET.Sdk.Functions": "4.4.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0-beta.4",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
+          "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
         },
@@ -77,9 +81,9 @@
       },
       "Azure.AI.OpenAI/1.0.0-beta.15": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.ClientModel": "1.0.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.ClientModel": "1.1.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.AI.OpenAI.dll": {
@@ -88,21 +92,21 @@
           }
         }
       },
-      "Azure.Core/1.41.0": {
+      "Azure.Core/1.44.1": {
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.ClientModel": "1.0.0",
+          "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.0",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Core.dll": {
-            "assemblyVersion": "1.41.0.0",
-            "fileVersion": "1.4100.24.36109"
+            "assemblyVersion": "1.44.1.0",
+            "fileVersion": "1.4400.124.50905"
           }
         }
       },
@@ -110,7 +114,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -119,40 +123,39 @@
           }
         }
       },
-      "Azure.Data.Tables/12.8.3": {
+      "Azure.Data.Tables/12.9.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
-            "assemblyVersion": "12.8.3.0",
-            "fileVersion": "12.800.324.10602"
+            "assemblyVersion": "12.9.1.0",
+            "fileVersion": "12.900.124.46702"
           }
         }
       },
-      "Azure.Identity/1.12.0": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.0.0",
-            "fileVersion": "1.1200.24.31701"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Memory.Data": "6.0.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -161,82 +164,112 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.9.2": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.0",
           "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Threading.Channels": "4.7.1",
+          "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.9.2.0",
-            "fileVersion": "5.900.223.30602"
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.41401"
+          }
+        }
+      },
+      "Azure.Messaging.ServiceBus/7.18.2": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
-      "Azure.Search.Documents/11.5.1": {
+      "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Channels": "4.7.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.40602"
+          }
+        }
+      },
+      "Azure.Search.Documents/11.6.0": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Search.Documents.dll": {
-            "assemblyVersion": "11.5.1.0",
-            "fileVersion": "11.500.123.57802"
+            "assemblyVersion": "11.6.0.0",
+            "fileVersion": "11.600.24.36703"
           }
         }
       },
-      "Azure.Storage.Blobs/12.21.0": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.22.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.36603"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.20.0": {
+      "Azure.Storage.Common/12.22.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.20.0.0",
-            "fileVersion": "12.2000.24.36603"
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.24.56203"
           }
         }
       },
       "Azure.Storage.Files.DataLake/12.18.0": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Common": "12.22.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Files.DataLake.dll": {
@@ -245,22 +278,22 @@
           }
         }
       },
-      "Azure.Storage.Queues/12.19.0": {
+      "Azure.Storage.Queues/12.21.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.22.0",
+          "System.Memory.Data": "6.0.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.19.0.0",
-            "fileVersion": "12.1900.24.36603"
+            "assemblyVersion": "12.21.0.0",
+            "fileVersion": "12.2100.24.56203"
           }
         }
       },
       "Castle.Core/5.0.0": {
         "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
+          "System.Diagnostics.EventLog": "8.0.1"
         },
         "runtime": {
           "lib/net6.0/Castle.Core.dll": {
@@ -283,7 +316,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -292,58 +325,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Google.Protobuf": "3.24.3",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Google.Protobuf": "3.28.2",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -358,27 +391,27 @@
           }
         }
       },
-      "Google.Protobuf/3.24.3": {
+      "Google.Protobuf/3.28.2": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.24.3.0",
-            "fileVersion": "3.24.3.0"
+            "assemblyVersion": "3.28.2.0",
+            "fileVersion": "3.28.2.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
+          "Google.Protobuf": "3.28.2",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.49.0"
+          "Grpc.Tools": "2.68.1"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -390,7 +423,7 @@
           "Grpc.Net.ClientFactory": "2.49.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -398,7 +431,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.67.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -407,207 +440,118 @@
             "fileVersion": "2.46.6.0"
           }
         },
-        "runtimeTargets": {
-          "runtimes/linux-arm64/native/libgrpc_csharp_ext.arm64.so": {
-            "rid": "linux-arm64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
+        "native": {
           "runtimes/linux-x64/native/libgrpc_csharp_ext.x64.so": {
-            "rid": "linux-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/osx-x64/native/libgrpc_csharp_ext.x64.dylib": {
-            "rid": "osx-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x64/native/grpc_csharp_ext.x64.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x86/native/grpc_csharp_ext.x86.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
             "fileVersion": "0.0.0.0"
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
-        "dependencies": {
-          "System.Memory": "4.5.5"
-        },
+      "Grpc.Core.Api/2.67.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.67.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Grpc.Net.Common": "2.67.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Client.dll": {
+          "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.ClientFactory.dll": {
+          "lib/net7.0/Grpc.Net.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.67.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Common.dll": {
+          "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
-        "runtimeTargets": {
-          "runtimes/linux-arm64/native/librdkafka.so": {
-            "rid": "linux-arm64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
+      "Grpc.Tools/2.68.1": {},
+      "K4os.Compression.LZ4/1.3.5": {
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Compression.LZ4.Streams/1.3.5": {
+        "dependencies": {
+          "K4os.Compression.LZ4": "1.3.5",
+          "K4os.Hash.xxHash": "1.0.8",
+          "System.IO.Pipelines": "6.0.3"
+        },
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.Streams.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Hash.xxHash/1.0.8": {
+        "runtime": {
+          "lib/net6.0/K4os.Hash.xxHash.dll": {
+            "assemblyVersion": "1.0.8.0",
+            "fileVersion": "1.0.8.0"
+          }
+        }
+      },
+      "librdkafka.redist/2.4.0": {
+        "native": {
           "runtimes/linux-x64/native/alpine-librdkafka.so": {
-            "rid": "linux-x64",
-            "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
           "runtimes/linux-x64/native/centos6-librdkafka.so": {
-            "rid": "linux-x64",
-            "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
           "runtimes/linux-x64/native/centos7-librdkafka.so": {
-            "rid": "linux-x64",
-            "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
           "runtimes/linux-x64/native/librdkafka.so": {
-            "rid": "linux-x64",
-            "assetType": "native",
             "fileVersion": "0.0.0.0"
-          },
-          "runtimes/osx-x64/native/librdkafka.dylib": {
-            "rid": "osx-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x64/native/libcrypto-1_1-x64.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "1.1.1.14"
-          },
-          "runtimes/win-x64/native/libcurl.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "7.82.0.0"
-          },
-          "runtimes/win-x64/native/librdkafka.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x64/native/librdkafkacpp.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x64/native/libssl-1_1-x64.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "1.1.1.14"
-          },
-          "runtimes/win-x64/native/zlib1.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "1.2.12.0"
-          },
-          "runtimes/win-x64/native/zstd.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "1.5.2.0"
-          },
-          "runtimes/win-x86/native/libcrypto-1_1.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "1.1.1.14"
-          },
-          "runtimes/win-x86/native/libcurl.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "7.82.0.0"
-          },
-          "runtimes/win-x86/native/librdkafka.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x86/native/librdkafkacpp.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win-x86/native/libssl-1_1.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "1.1.1.14"
-          },
-          "runtimes/win-x86/native/msvcp140.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "14.29.30040.0"
-          },
-          "runtimes/win-x86/native/vcruntime140.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "14.29.30040.0"
-          },
-          "runtimes/win-x86/native/zlib1.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "1.2.12.0"
-          },
-          "runtimes/win-x86/native/zstd.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "1.5.2.0"
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -637,8 +581,8 @@
       "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
@@ -650,8 +594,8 @@
       },
       "Microsoft.AspNetCore.Authorization/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
@@ -663,7 +607,7 @@
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         }
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
@@ -674,11 +618,11 @@
           "Microsoft.Extensions.Configuration": "2.2.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reflection.Metadata": "1.6.0"
         }
@@ -701,7 +645,7 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0"
         }
       },
@@ -709,25 +653,6 @@
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
           "System.Text.Encodings.Web": "8.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
         }
       },
       "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
@@ -740,7 +665,7 @@
       },
       "Microsoft.AspNetCore.Http.Features/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
@@ -772,10 +697,10 @@
           "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -802,16 +727,16 @@
       },
       "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing/2.2.2": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
@@ -824,7 +749,7 @@
           "Microsoft.AspNetCore.Hosting": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Https": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1"
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
@@ -834,8 +759,8 @@
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
@@ -867,38 +792,11 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.WebUtilities/2.2.0": {
@@ -915,111 +813,89 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "8.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
             "fileVersion": "1.1.0.0"
           }
-        },
-        "runtimeTargets": {
-          "runtimes/win-x64/native/Cosmos.CRTCompat.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "2.0.0.0"
-          },
-          "runtimes/win-x64/native/Microsoft.Azure.Cosmos.ServiceInterop.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "2.14.0.0"
-          },
-          "runtimes/win-x64/native/msvcp140.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "14.38.33133.0"
-          },
-          "runtimes/win-x64/native/vcruntime140.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "14.38.33133.0"
-          },
-          "runtimes/win-x64/native/vcruntime140_1.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "14.38.33133.0"
-          }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.1.0.0",
-            "fileVersion": "0.1.6.6114"
+            "assemblyVersion": "0.2.0.0",
+            "fileVersion": "0.2.0.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
         "dependencies": {
-          "Azure.Data.Tables": "12.8.3",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "WindowsAzure.Storage": "9.3.1"
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.21.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "1.17.0.0",
-            "fileVersion": "1.17.4.42221"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.1.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/2.17.1": {
+      "Microsoft.Azure.DurableTask.Core/3.0.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reactive.Compatibility": "4.4.1",
@@ -1027,80 +903,47 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "2.17.0.0",
-            "fileVersion": "2.17.1.6114"
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.42734"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.EventHubs.Processor": "4.3.2",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Messaging.EventHubs.Processor": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Threading.Channels": "4.7.1"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
-        "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.DurableTask.Netherite": "1.5.4",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.AzureFunctions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Azure.Services.AppAuthentication": "1.0.3",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.EventHubs": "4.3.2",
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.Processor.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
+          "lib/netstandard2.0/DurableTask.Netherite.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
+          }
+        }
+      },
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
+        },
+        "runtime": {
+          "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
       "Microsoft.Azure.Functions.Extensions/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
@@ -1111,7 +954,7 @@
       },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/0.17.0-preview01": {
         "dependencies": {
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -1120,250 +963,114 @@
           }
         }
       },
-      "Microsoft.Azure.KeyVault.Core/3.0.3": {
-        "dependencies": {
-          "NETStandard.Library": "2.0.1"
-        },
-        "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.KeyVault.Core.dll": {
-            "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1",
           "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
           "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
           "System.Security.Principal.Windows": "5.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.Msal.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Data/12.2.3": {
+      "Microsoft.Azure.Kusto.Data/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Data.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+      "Microsoft.Azure.Kusto.Ingest/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.21.0",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Ingest.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.14.2",
-          "NETStandard.Library": "2.0.1",
-          "System.Diagnostics.Process": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.Services.AppAuthentication.dll": {
-            "assemblyVersion": "1.0.3.0",
-            "fileVersion": "1.0.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.SignalR/1.25.2": {
-        "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Common.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
-          "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "3.1.32",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -1381,8 +1088,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1392,69 +1099,44 @@
           }
         }
       },
-      "Microsoft.Azure.Storage.Blob/11.2.3": {
+      "Microsoft.Azure.WebJobs/3.0.41": {
         "dependencies": {
-          "Microsoft.Azure.Storage.Common": "11.2.3",
-          "NETStandard.Library": "2.0.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Blob.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.Storage.Common/11.2.3": {
-        "dependencies": {
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "NETStandard.Library": "2.0.1",
-          "Newtonsoft.Json": "13.0.3"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Common.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.WebJobs/3.0.39": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.39",
+          "Microsoft.Azure.WebJobs.Core": "3.0.41",
           "Microsoft.Extensions.Configuration": "2.2.0",
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
           "Microsoft.Extensions.Configuration.Json": "2.1.0",
           "Microsoft.Extensions.Hosting": "2.1.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.0",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.39": {
+      "Microsoft.Azure.WebJobs.Core/3.0.41": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Host.Storage": "3.0.14",
           "ncrontab.signed": "3.3.0"
         },
@@ -1468,7 +1150,7 @@
       "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/1.0.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -1480,17 +1162,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.0.0",
-            "fileVersion": "4.8.0.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1502,8 +1185,8 @@
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
@@ -1512,50 +1195,68 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.1.6",
-          "Microsoft.Azure.DurableTask.AzureStorage": "1.17.4",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.0.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
-          "Microsoft.DurableTask.Grpc": "1.1.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.10.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/netcoreapp3.1/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
-            "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.13.5.0"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
         "dependencies": {
-          "Azure.Messaging.EventGrid": "4.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Grpc.Tools": "2.68.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.DurableTask.AzureManagedBackend": "0.4.2-alpha",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.400.224.38002"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+        "dependencies": {
+          "Azure.Messaging.EventGrid": "4.21.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1564,25 +1265,25 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Azure.Storage.Files.DataLake": "12.18.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           }
         }
       },
@@ -1593,7 +1294,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -1602,97 +1303,118 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
         "dependencies": {
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Kusto.dll": {
-            "assemblyVersion": "1.0.10.0",
-            "fileVersion": "1.0.10.0"
+            "assemblyVersion": "1.0.11.0",
+            "fileVersion": "1.0.11.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
+          "MySql.Data": "8.0.33",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Net.Http": "4.3.4",
+          "System.Runtime.Caching": "8.0.1",
+          "System.Text.Json": "8.0.4",
+          "morelinq": "4.1.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.MySql.dll": {
+            "assemblyVersion": "1.0.31.0",
+            "fileVersion": "1.0.31.0"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
         "dependencies": {
           "Azure.AI.OpenAI": "1.0.0-beta.15",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.0-preview",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.dll": {
-            "assemblyVersion": "0.16.0.0",
-            "fileVersion": "0.16.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
         "dependencies": {
-          "Azure.Search.Documents": "11.5.1",
+          "Azure.Search.Documents": "11.6.0",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.AzureAISearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "MongoDB.Driver": "2.25.0"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "MongoDB.Driver": "2.29.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.CosmosDBSearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.Kusto.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "RabbitMQ.Client": "5.1.2",
           "System.Json": "4.5.0"
         },
@@ -1706,8 +1428,8 @@
       "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1718,121 +1440,119 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
         "dependencies": {
           "Grpc.AspNetCore": "2.49.0",
-          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37"
+          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.39"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.Rpc.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Sendgrid": "9.10.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
-          "Google.Protobuf": "3.24.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.37",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.ServiceBus": "7.18.2",
+          "Google.Protobuf": "3.28.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "MessagePack": "2.5.192",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9123.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.0",
-          "morelinq": "3.4.2"
+          "System.Runtime.Caching": "8.0.1",
+          "morelinq": "4.1.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.169.0",
-            "fileVersion": "3.1.169.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.21.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Queues": "12.21.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Twilio": "5.6.3"
         },
         "runtime": {
@@ -1842,9 +1562,26 @@
           }
         }
       },
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Azure.Messaging.WebPubSub": "1.4.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebPubSub.Common": "1.4.0",
+          "Microsoft.Extensions.Azure": "1.10.0",
+          "Microsoft.IdentityModel.Tokens": "7.6.3"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.24.47903"
+          }
+        }
+      },
       "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "WindowsAzure.Storage": "9.3.1"
         },
         "runtime": {
@@ -1854,14 +1591,14 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
@@ -1882,6 +1619,19 @@
       "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator/4.0.1": {
         "dependencies": {
           "System.Runtime.Loader": "4.3.0"
+        }
+      },
+      "Microsoft.Azure.WebPubSub.Common/1.4.0": {
+        "dependencies": {
+          "System.Memory.Data": "6.0.0",
+          "System.Text.Encodings.Web": "8.0.0",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.47402"
+          }
         }
       },
       "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
@@ -2231,104 +1981,67 @@
         }
       },
       "Microsoft.CSharp/4.7.0": {},
-      "Microsoft.Data.SqlClient/5.2.1": {
+      "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Data.SqlClient.dll": {
+          "runtimes/unix/lib/net8.0/Microsoft.Data.SqlClient.dll": {
             "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
+            "fileVersion": "5.22.24240.6"
           }
         },
         "resources": {
-          "lib/net6.0/de/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/de/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "de"
           },
-          "lib/net6.0/es/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/es/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "es"
           },
-          "lib/net6.0/fr/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/fr/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "fr"
           },
-          "lib/net6.0/it/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/it/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "it"
           },
-          "lib/net6.0/ja/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ja/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ja"
           },
-          "lib/net6.0/ko/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ko/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ko"
           },
-          "lib/net6.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "pt-BR"
           },
-          "lib/net6.0/ru/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ru/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ru"
           },
-          "lib/net6.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hans"
           },
-          "lib/net6.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hant"
           }
-        },
-        "runtimeTargets": {
-          "runtimes/unix/lib/net6.0/Microsoft.Data.SqlClient.dll": {
-            "rid": "unix",
-            "assetType": "runtime",
-            "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
-          },
-          "runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll": {
-            "rid": "win",
-            "assetType": "runtime",
-            "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
-          }
         }
       },
-      "Microsoft.Data.SqlClient.SNI.runtime/5.2.0": {
-        "runtimeTargets": {
-          "runtimes/win-arm/native/Microsoft.Data.SqlClient.SNI.dll": {
-            "rid": "win-arm",
-            "assetType": "native",
-            "fileVersion": "5.2.0.0"
-          },
-          "runtimes/win-arm64/native/Microsoft.Data.SqlClient.SNI.dll": {
-            "rid": "win-arm64",
-            "assetType": "native",
-            "fileVersion": "5.2.0.0"
-          },
-          "runtimes/win-x64/native/Microsoft.Data.SqlClient.SNI.dll": {
-            "rid": "win-x64",
-            "assetType": "native",
-            "fileVersion": "5.2.0.0"
-          },
-          "runtimes/win-x86/native/Microsoft.Data.SqlClient.SNI.dll": {
-            "rid": "win-x86",
-            "assetType": "native",
-            "fileVersion": "5.2.0.0"
-          }
-        }
-      },
+      "Microsoft.Data.SqlClient.SNI.runtime/5.2.0": {},
       "Microsoft.DotNet.PlatformAbstractions/2.1.0": {
         "dependencies": {
-          "System.AppContext": "4.1.0",
+          "System.AppContext": "4.3.0",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.IO.FileSystem": "4.3.0",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
         },
         "runtime": {
           "lib/netstandard1.3/Microsoft.DotNet.PlatformAbstractions.dll": {
@@ -2337,58 +2050,69 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.1.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.1.0.0",
-            "fileVersion": "1.1.0.4758"
+          "lib/net6.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Data.SqlClient": "5.2.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.IdentityModel.Tokens.Jwt": "7.5.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.DurableTask.SqlServer": "1.3.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.4": {
+      "Microsoft.Extensions.Azure/1.10.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.4.0",
-            "fileVersion": "1.700.424.31303"
+          "lib/net8.0/Microsoft.Extensions.Azure.dll": {
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.1000.25.10602"
           }
         }
       },
@@ -2399,7 +2123,7 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder/2.2.0": {
@@ -2425,13 +2149,19 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
-      "Microsoft.Extensions.DependencyInjection/6.0.0": {
+      "Microsoft.Extensions.DependencyInjection/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -2449,7 +2179,7 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
@@ -2462,122 +2192,101 @@
       "Microsoft.Extensions.Hosting/2.1.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0"
+          "Microsoft.Extensions.Logging": "7.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
           "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Http/3.1.32": {
+      "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging/6.0.0": {
+      "Microsoft.Extensions.Logging/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.Logging.Abstractions/7.0.0": {},
       "Microsoft.Extensions.Logging.Configuration/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "2.1.0"
         }
       },
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
-      "Microsoft.Extensions.Options/6.0.0": {
+      "Microsoft.Extensions.Options/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Primitives/6.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
+      "Microsoft.Extensions.Primitives/7.0.0": {},
       "Microsoft.FASTER.Core/2.6.5": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "System.Interactive.Async": "6.0.1",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/FASTER.core.dll": {
+          "lib/net7.0/FASTER.core.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Identity.Client/4.61.3": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "7.6.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
       "Microsoft.IdentityModel.Abstractions/7.6.3": {
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Abstractions.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Abstractions.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
-          }
-        }
-      },
-      "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-        "dependencies": {
-          "NETStandard.Library": "2.0.1",
-          "System.Runtime.Serialization.Json": "4.0.2",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
-          },
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
           }
         }
       },
@@ -2586,7 +2295,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2597,7 +2306,7 @@
           "Microsoft.IdentityModel.Abstractions": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Logging.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Logging.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2632,7 +2341,7 @@
           "Microsoft.IdentityModel.Logging": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Tokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Tokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2648,14 +2357,14 @@
       },
       "Microsoft.Net.Http.Headers/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1"
         }
       },
-      "Microsoft.NET.Sdk.Functions/4.4.0": {
+      "Microsoft.NET.Sdk.Functions/4.6.0": {
         "dependencies": {
           "Microsoft.Azure.Functions.Analyzers": "1.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "3.0.6",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator": "4.0.1",
@@ -2665,7 +2374,15 @@
           "System.Text.RegularExpressions": "4.3.1"
         }
       },
-      "Microsoft.NETCore.Platforms/2.1.2": {},
+      "Microsoft.NET.StringTools/17.6.3": {
+        "runtime": {
+          "lib/net7.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
+        }
+      },
+      "Microsoft.NETCore.Platforms/3.1.0": {},
       "Microsoft.NETCore.Targets/1.1.3": {},
       "Microsoft.SqlServer.Server/1.0.0": {
         "runtime": {
@@ -2675,11 +2392,11 @@
           }
         }
       },
-      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
         "runtime": {
           "lib/net6.0/Microsoft.SqlServer.TransactSql.ScriptDom.dll": {
             "assemblyVersion": "16.1.0.0",
-            "fileVersion": "16.1.9123.0"
+            "fileVersion": "16.1.9135.0"
           }
         },
         "resources": {
@@ -2726,9 +2443,10 @@
       },
       "Microsoft.Win32.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.unix.Microsoft.Win32.Primitives": "4.3.0"
         }
       },
       "Microsoft.Win32.Registry/5.0.0": {
@@ -2737,39 +2455,50 @@
           "System.Security.Principal.Windows": "5.0.0"
         }
       },
-      "MongoDB.Bson/2.25.0": {
+      "Microsoft.Win32.SystemEvents/4.7.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Win32.SystemEvents.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "MongoDB.Bson/2.29.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Bson.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver/2.25.0": {
+      "MongoDB.Driver/2.29.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Driver.Core": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Driver.Core": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver.Core/2.25.0": {
+      "MongoDB.Driver.Core/2.29.0": {
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.100.14",
           "DnsClient": "1.6.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0",
           "SharpCompress": "0.30.1",
           "Snappier": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -2777,41 +2506,50 @@
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.Core.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Libmongocrypt/1.8.2": {
+      "MongoDB.Libmongocrypt/1.12.0": {
         "runtime": {
           "lib/netstandard2.1/MongoDB.Libmongocrypt.dll": {
-            "assemblyVersion": "1.8.2.0",
-            "fileVersion": "1.8.2.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         },
-        "runtimeTargets": {
+        "native": {
           "runtimes/linux/native/libmongocrypt.so": {
-            "rid": "linux",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/osx/native/libmongocrypt.dylib": {
-            "rid": "osx",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/win/native/mongocrypt.dll": {
-            "rid": "win",
-            "assetType": "native",
             "fileVersion": "0.0.0.0"
           }
         }
       },
-      "morelinq/3.4.2": {
+      "morelinq/4.1.0": {
         "runtime": {
-          "lib/net6.0/MoreLinq.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.4.2.0"
+          "lib/net8.0/MoreLinq.dll": {
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
+          }
+        }
+      },
+      "MySql.Data/8.0.33": {
+        "dependencies": {
+          "Google.Protobuf": "3.28.2",
+          "K4os.Compression.LZ4.Streams": "1.3.5",
+          "Portable.BouncyCastle": "1.9.0",
+          "System.Buffers": "4.5.1",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Runtime.Loader": "4.3.0",
+          "System.Security.Permissions": "4.7.0",
+          "System.Text.Encoding.CodePages": "4.5.1",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/net7.0/MySql.Data.dll": {
+            "assemblyVersion": "8.0.33.0",
+            "fileVersion": "8.0.33.0"
           }
         }
       },
@@ -2831,9 +2569,52 @@
           }
         }
       },
-      "NETStandard.Library/2.0.1": {
+      "NETStandard.Library/1.6.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2"
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.Compression.ZipFile": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Net.Http": "4.3.4",
+          "System.Net.Primitives": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.1",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Timer": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0"
         }
       },
       "Newtonsoft.Json/13.0.3": {
@@ -2846,7 +2627,7 @@
       },
       "Newtonsoft.Json.Bson/1.0.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -2858,12 +2639,20 @@
       },
       "Pipelines.Sockets.Unofficial/2.2.8": {
         "dependencies": {
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         },
         "runtime": {
           "lib/net5.0/Pipelines.Sockets.Unofficial.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "2.2.8.1080"
+          }
+        }
+      },
+      "Portable.BouncyCastle/1.9.0": {
+        "runtime": {
+          "lib/netstandard2.0/BouncyCastle.Crypto.dll": {
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.1"
           }
         }
       },
@@ -2875,24 +2664,55 @@
           }
         }
       },
+      "runtime.any.System.Collections/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.1"
+        }
+      },
+      "runtime.any.System.Diagnostics.Tools/4.3.0": {},
+      "runtime.any.System.Diagnostics.Tracing/4.3.0": {},
+      "runtime.any.System.Globalization/4.3.0": {},
+      "runtime.any.System.Globalization.Calendars/4.3.0": {},
+      "runtime.any.System.IO/4.3.0": {},
+      "runtime.any.System.Reflection/4.3.0": {},
+      "runtime.any.System.Reflection.Extensions/4.3.0": {},
+      "runtime.any.System.Reflection.Primitives/4.3.0": {},
+      "runtime.any.System.Resources.ResourceManager/4.3.0": {},
+      "runtime.any.System.Runtime/4.3.0": {
+        "dependencies": {
+          "System.Private.Uri": "4.3.0"
+        }
+      },
+      "runtime.any.System.Runtime.Handles/4.3.0": {},
+      "runtime.any.System.Runtime.InteropServices/4.3.0": {},
+      "runtime.any.System.Text.Encoding/4.3.0": {},
+      "runtime.any.System.Text.Encoding.Extensions/4.3.0": {},
+      "runtime.any.System.Threading.Tasks/4.3.0": {},
+      "runtime.any.System.Threading.Timer/4.3.0": {},
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.native.System/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
+      "runtime.native.System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "runtime.native.System.Net.Http/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+      "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
         "dependencies": {
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.1"
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
         }
       },
       "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
@@ -2911,12 +2731,108 @@
       },
       "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
-      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {},
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {},
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
+      "runtime.unix.Microsoft.Win32.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.1",
+          "System.Runtime.InteropServices": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.Console/4.3.1": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.Diagnostics.Debug/4.3.0": {
+        "dependencies": {
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.IO.FileSystem/4.3.0": {
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.Net.Primitives/4.3.0": {
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.Net.Sockets/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.NameResolution": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.Private.Uri/4.3.0": {
+        "dependencies": {
+          "runtime.native.System": "4.3.0"
+        }
+      },
+      "runtime.unix.System.Runtime.Extensions/4.3.0": {
+        "dependencies": {
+          "System.Private.Uri": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
+        }
+      },
       "SemanticVersion/2.1.0": {
         "runtime": {
           "lib/netstandard2.1/SemanticVersion.dll": {
@@ -2925,15 +2841,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2955,7 +2871,7 @@
       },
       "StackExchange.Redis/2.7.4": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
         },
         "runtime": {
@@ -2965,21 +2881,29 @@
           }
         }
       },
-      "System.AppContext/4.1.0": {
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
+      "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
         }
       },
       "System.Buffers/4.5.1": {},
-      "System.ClientModel/1.0.0": {
+      "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "System.Memory.Data": "6.0.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.24.5302"
+            "assemblyVersion": "1.1.0.0",
+            "fileVersion": "1.100.24.46703"
           }
         }
       },
@@ -2993,9 +2917,10 @@
       },
       "System.Collections/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Collections": "4.3.0"
         }
       },
       "System.Collections.Concurrent/4.3.0": {
@@ -3012,17 +2937,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Collections.Immutable.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -3153,71 +3068,56 @@
           }
         }
       },
-      "System.Configuration.ConfigurationManager/8.0.0": {
+      "System.Configuration.ConfigurationManager/8.0.1": {
         "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
-          "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
+          "lib/net8.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
           }
+        }
+      },
+      "System.Console/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.unix.System.Console": "4.3.1"
         }
       },
       "System.Diagnostics.Debug/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Diagnostics.DiagnosticSource/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Diagnostics.DiagnosticSource.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
-      "System.Diagnostics.EventLog/6.0.0": {},
-      "System.Diagnostics.Process/4.3.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "Microsoft.Win32.Primitives": "4.3.0",
-          "Microsoft.Win32.Registry": "5.0.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Thread": "4.3.0",
-          "System.Threading.ThreadPool": "4.3.0",
-          "runtime.native.System": "4.3.0"
+          "runtime.unix.System.Diagnostics.Debug": "4.3.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/8.0.0": {},
+      "System.Diagnostics.EventLog/8.0.1": {
+        "runtime": {
+          "lib/net8.0/System.Diagnostics.EventLog.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
         }
       },
       "System.Diagnostics.Tools/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Diagnostics.Tools": "4.3.0"
         }
       },
       "System.Diagnostics.TraceSource/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3230,9 +3130,22 @@
       },
       "System.Diagnostics.Tracing/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Diagnostics.Tracing": "4.3.0"
+        }
+      },
+      "System.Drawing.Common/4.7.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.SystemEvents": "4.7.0"
+        },
+        "runtime": {
+          "runtimes/unix/lib/netcoreapp3.0/System.Drawing.Common.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
@@ -3254,32 +3167,27 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Formats.Asn1/6.0.1": {
-        "runtime": {
-          "lib/net6.0/System.Formats.Asn1.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3224.31407"
-          }
-        }
-      },
+      "System.Formats.Asn1/6.0.1": {},
       "System.Globalization/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Globalization": "4.3.0"
         }
       },
       "System.Globalization.Calendars/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Globalization.Calendars": "4.3.0"
         }
       },
       "System.Globalization.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Globalization": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3293,7 +3201,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/System.IdentityModel.Tokens.Jwt.dll": {
+          "lib/net8.0/System.IdentityModel.Tokens.Jwt.dll": {
             "assemblyVersion": "7.5.1.0",
             "fileVersion": "7.5.1.50405"
           }
@@ -3312,23 +3220,57 @@
       },
       "System.IO/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.any.System.IO": "4.3.0"
+        }
+      },
+      "System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "System.Buffers": "4.5.1",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile/4.3.0": {
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
         }
       },
       "System.IO.FileSystem/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.IO.FileSystem.Primitives": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0",
           "System.Text.Encoding": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.unix.System.IO.FileSystem": "4.3.0"
         }
       },
       "System.IO.FileSystem.Primitives/4.3.0": {
@@ -3344,7 +3286,7 @@
           }
         }
       },
-      "System.IO.Pipelines/5.0.1": {},
+      "System.IO.Pipelines/6.0.3": {},
       "System.Json/4.5.0": {
         "runtime": {
           "lib/netstandard2.0/System.Json.dll": {
@@ -3395,21 +3337,20 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/1.0.2": {
+      "System.Memory.Data/6.0.0": {
         "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
-          "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+          "lib/net6.0/System.Memory.Data.dll": {
+            "assemblyVersion": "6.0.0.0",
+            "fileVersion": "6.0.21.52210"
           }
         }
       },
       "System.Net.Http/4.3.4": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
@@ -3424,11 +3365,11 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.OpenSsl": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0",
@@ -3439,7 +3380,7 @@
       },
       "System.Net.NameResolution/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Tracing": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3457,28 +3398,22 @@
       },
       "System.Net.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
-          "System.Runtime.Handles": "4.3.0"
+          "System.Runtime.Handles": "4.3.0",
+          "runtime.unix.System.Net.Primitives": "4.3.0"
         }
       },
       "System.Net.Sockets/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Net.Primitives": "4.3.0",
           "System.Runtime": "4.3.1",
-          "System.Threading.Tasks": "4.3.0"
-        }
-      },
-      "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-        "runtime": {
-          "lib/netcoreapp2.1/System.Net.WebSockets.WebSocketProtocol.dll": {
-            "assemblyVersion": "4.0.0.2",
-            "fileVersion": "4.6.27129.4"
-          }
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.unix.System.Net.Sockets": "4.3.0"
         }
       },
       "System.Numerics.Vectors/4.5.0": {},
@@ -3491,32 +3426,11 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Private.DataContractSerialization/4.1.1": {
+      "System.Private.Uri/4.3.0": {
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "runtime.unix.System.Private.Uri": "4.3.0"
         }
       },
       "System.Reactive/4.4.1": {},
@@ -3591,11 +3505,12 @@
       },
       "System.Reflection/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Reflection": "4.3.0"
         }
       },
       "System.Reflection.Emit/4.3.0": {
@@ -3624,84 +3539,83 @@
       },
       "System.Reflection.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Reflection.Extensions": "4.3.0"
         }
       },
       "System.Reflection.Metadata/1.6.0": {},
       "System.Reflection.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Reflection.Primitives": "4.3.0"
         }
       },
       "System.Reflection.TypeExtensions/4.7.0": {},
       "System.Resources.ResourceManager/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Resources.ResourceManager": "4.3.0"
         }
       },
       "System.Runtime/4.3.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "Microsoft.NETCore.Targets": "1.1.3"
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "runtime.any.System.Runtime": "4.3.0"
         }
       },
-      "System.Runtime.Caching/8.0.0": {
+      "System.Runtime.Caching/8.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1"
         },
         "runtime": {
-          "lib/net6.0/System.Runtime.Caching.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        },
-        "runtimeTargets": {
-          "runtimes/win/lib/net6.0/System.Runtime.Caching.dll": {
-            "rid": "win",
-            "assetType": "runtime",
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+          "lib/net8.0/System.Runtime.Caching.dll": {
+            "assemblyVersion": "8.0.0.1",
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
       "System.Runtime.CompilerServices.Unsafe/6.0.0": {},
       "System.Runtime.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.unix.System.Runtime.Extensions": "4.3.0"
         }
       },
       "System.Runtime.Handles/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Runtime.Handles": "4.3.0"
         }
       },
       "System.Runtime.InteropServices/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
           "System.Runtime": "4.3.1",
-          "System.Runtime.Handles": "4.3.0"
+          "System.Runtime.Handles": "4.3.0",
+          "runtime.any.System.Runtime.InteropServices": "4.3.0"
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
           "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.InteropServices": "4.3.0",
@@ -3724,23 +3638,10 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Json/4.0.2": {
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Private.DataContractSerialization": "4.1.1",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
       "System.Security.AccessControl/6.0.0": {},
-      "System.Security.Cryptography.Algorithms/4.3.1": {
+      "System.Security.Cryptography.Algorithms/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3752,7 +3653,7 @@
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.Apple": "4.3.1",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
@@ -3763,7 +3664,7 @@
       },
       "System.Security.Cryptography.Csp/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3771,7 +3672,7 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3780,7 +3681,7 @@
       },
       "System.Security.Cryptography.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Collections": "4.3.0",
           "System.Collections.Concurrent": "4.3.0",
           "System.Linq": "4.3.0",
@@ -3804,7 +3705,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3824,15 +3725,15 @@
       },
       "System.Security.Cryptography.ProtectedData/8.0.0": {
         "runtime": {
-          "lib/net6.0/System.Security.Cryptography.ProtectedData.dll": {
+          "lib/net8.0/System.Security.Cryptography.ProtectedData.dll": {
             "assemblyVersion": "8.0.0.0",
             "fileVersion": "8.0.23.53103"
           }
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.3.2": {
+      "System.Security.Cryptography.X509Certificates/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3846,7 +3747,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Cng": "5.0.0",
           "System.Security.Cryptography.Csp": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
@@ -3859,57 +3760,46 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
+      "System.Security.Permissions/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Windows.Extensions": "4.7.0"
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/System.Security.Permissions.dll": {
+            "assemblyVersion": "4.0.3.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
       "System.Security.Principal.Windows/5.0.0": {},
       "System.Text.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Text.Encoding": "4.3.0"
         }
       },
       "System.Text.Encoding.CodePages/4.5.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Text.Encoding.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
-          "System.Text.Encoding": "4.3.0"
+          "System.Text.Encoding": "4.3.0",
+          "runtime.any.System.Text.Encoding.Extensions": "4.3.0"
         }
       },
-      "System.Text.Encodings.Web/8.0.0": {
+      "System.Text.Encodings.Web/8.0.0": {},
+      "System.Text.Json/8.0.4": {
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Encodings.Web.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        },
-        "runtimeTargets": {
-          "runtimes/browser/lib/net6.0/System.Text.Encodings.Web.dll": {
-            "rid": "browser",
-            "assetType": "runtime",
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
-      "System.Text.Json/8.0.1": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "8.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Json.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.123.58001"
-          }
         }
       },
       "System.Text.RegularExpressions/4.3.1": {
@@ -3923,29 +3813,44 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels/4.7.1": {},
+      "System.Threading.Channels/6.0.0": {},
       "System.Threading.Tasks/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.0",
           "Microsoft.NETCore.Targets": "1.1.3",
-          "System.Runtime": "4.3.1"
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Threading.Tasks": "4.3.0"
         }
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
       "System.Threading.Tasks.Extensions/4.5.4": {},
-      "System.Threading.Thread/4.3.0": {
-        "dependencies": {
-          "System.Runtime": "4.3.1"
-        }
-      },
       "System.Threading.ThreadPool/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0"
         }
       },
+      "System.Threading.Timer/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "System.Runtime": "4.3.1",
+          "runtime.any.System.Threading.Timer": "4.3.0"
+        }
+      },
       "System.ValueTuple/4.5.0": {},
-      "System.Xml.ReaderWriter/4.0.11": {
+      "System.Windows.Extensions/4.7.0": {
+        "dependencies": {
+          "System.Drawing.Common": "4.7.0"
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/System.Windows.Extensions.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "System.Xml.ReaderWriter/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
@@ -3964,46 +3869,27 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "System.Xml.XmlDocument/4.0.1": {
+      "System.Xml.XDocument/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Extensions": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11"
-        }
-      },
-      "System.Xml.XmlSerializer/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1"
+          "System.Xml.ReaderWriter": "4.3.0"
         }
       },
       "Twilio/5.6.3": {
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "7.6.3",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Specialized": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -4017,7 +3903,7 @@
       },
       "WindowsAzure.Storage/9.3.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -4029,7 +3915,7 @@
       },
       "ZstdSharp.Port/0.7.3": {
         "runtime": {
-          "lib/net6.0/ZstdSharp.dll": {
+          "lib/net7.0/ZstdSharp.dll": {
             "assemblyVersion": "0.7.3.0",
             "fileVersion": "0.7.3.0"
           }
@@ -4079,12 +3965,12 @@
       "path": "azure.ai.openai/1.0.0-beta.15",
       "hashPath": "azure.ai.openai.1.0.0-beta.15.nupkg.sha512"
     },
-    "Azure.Core/1.41.0": {
+    "Azure.Core/1.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7OO8rPCVSvXj2IQET3NkRf8hU2ZDCCvCIUhlrE089qkLNpNfWufJnBwHRKLAOWF3bhKBGJS/9hPBgjJ8kupUIg==",
-      "path": "azure.core/1.41.0",
-      "hashPath": "azure.core.1.41.0.nupkg.sha512"
+      "sha512": "sha512-YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+      "path": "azure.core/1.44.1",
+      "hashPath": "azure.core.1.44.1.nupkg.sha512"
     },
     "Azure.Core.Amqp/1.3.1": {
       "type": "package",
@@ -4093,19 +3979,19 @@
       "path": "azure.core.amqp/1.3.1",
       "hashPath": "azure.core.amqp.1.3.1.nupkg.sha512"
     },
-    "Azure.Data.Tables/12.8.3": {
+    "Azure.Data.Tables/12.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2wAUXLS1ebTnV+qm9qc1z1MZIPC3as2WJt9bEgL08oC1wlT5UhaW78PlYgTld89p/YWCawJycHtBwVx+SWIuLw==",
-      "path": "azure.data.tables/12.8.3",
-      "hashPath": "azure.data.tables.12.8.3.nupkg.sha512"
+      "sha512": "sha512-d5529gg24alnMKbE8Aw7NY3q9dxFvzfhCMW+TtQA7GGIqASFSIh+536p2qdyJNPEQDFYtqfoLqIBlP9IGqgLfA==",
+      "path": "azure.data.tables/12.9.1",
+      "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.0": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
-      "path": "azure.identity/1.12.0",
-      "hashPath": "azure.identity.1.12.0.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -4114,40 +4000,54 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.9.2": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KAC79xzlOUrtQ0mlrPqijznfmlKeraiqavtZ3RfbV+8ukJf9C5fFSZCMSqq9N/2+eUkW3G4wJSchMXAyf+jxow==",
-      "path": "azure.messaging.eventhubs/5.9.2",
-      "hashPath": "azure.messaging.eventhubs.5.9.2.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-c0ROPOBgzQ8PLvhG9YNBaq+zMMXRWCLr1C/oPgJqxQMsGxHRfuxvYWNvxTVYe96caiBaGkDDLAUb3wsIWJaw2w==",
+      "path": "azure.messaging.eventhubs.processor/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Search.Documents/11.5.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Vg+1mtM3LXVYwKQ+DDi7Wd/Rf2Ajo6rl5/7bFPfouUMBe/cNg71TIU62PY/eEtKfUI3Y7wdFXNcgGkpUG+OVnw==",
-      "path": "azure.search.documents/11.5.1",
-      "hashPath": "azure.search.documents.11.5.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.21.0": {
+    "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W1aSEH11crU3CscfuICUPXScTO9nKwSof3YFsdxmbdi+P+JARYzntkGJuZ685gvmyUse7isBNncNlVEjB5LT0g==",
-      "path": "azure.storage.blobs/12.21.0",
-      "hashPath": "azure.storage.blobs.12.21.0.nupkg.sha512"
+      "sha512": "sha512-27PpgpaTtwOXXP08ZKAt612S/D0ZXINPpR2JTPurbuVPy+eHj1RDvoyJPGsZkHXnk9nVNR6zAu45YBf/8llgOw==",
+      "path": "azure.messaging.webpubsub/1.4.0",
+      "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.20.0": {
+    "Azure.Search.Documents/11.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-C0uTY4E1NSGiNf/dlLMQ/d85a2CDazEg4YYtNJOYnLSb8ZXJ5RBPHYGW7a46kN5Xn5Bc9BKMvs8fME285TfEpw==",
-      "path": "azure.storage.common/12.20.0",
-      "hashPath": "azure.storage.common.12.20.0.nupkg.sha512"
+      "sha512": "sha512-M7WLx3ANLPHymfqb4Nwk4EwcWWRiHqdvnxJ7RH857baAbkEZ3FYVCRJmHgxH+ROpYOTVSx30uJzsa573/cdD8A==",
+      "path": "azure.search.documents/11.6.0",
+      "hashPath": "azure.search.documents.11.6.0.nupkg.sha512"
+    },
+    "Azure.Storage.Blobs/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
+    },
+    "Azure.Storage.Common/12.22.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-0Vm30bRpQ0fcswB0xQMhKAOSXnRygnF2f/029uPaIDLaj1/yfX4jmU0fFjJe9ojGEj/vlAmsApCEOyL9if6zHg==",
+      "path": "azure.storage.common/12.22.0",
+      "hashPath": "azure.storage.common.12.22.0.nupkg.sha512"
     },
     "Azure.Storage.Files.DataLake/12.18.0": {
       "type": "package",
@@ -4156,12 +4056,12 @@
       "path": "azure.storage.files.datalake/12.18.0",
       "hashPath": "azure.storage.files.datalake.12.18.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.19.0": {
+    "Azure.Storage.Queues/12.21.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+EXqf4aTyshZDpi/DBgffEX0CJMbvs9fHTZX4EMPBPc4WHyXCNs2oKelJes1pdHLRwTUVJ3jGdK1kU/IB5lJJw==",
-      "path": "azure.storage.queues/12.19.0",
-      "hashPath": "azure.storage.queues.12.19.0.nupkg.sha512"
+      "sha512": "sha512-4Ql71evO/iosdzZD8KFKBByVyvCXvVeC979w8JOdT7UdStncBg4BbnZREq3B56ud4paUgKdPv45qEasTYUsH2w==",
+      "path": "azure.storage.queues/12.21.0",
+      "hashPath": "azure.storage.queues.12.21.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -4184,33 +4084,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4219,12 +4119,12 @@
       "path": "dnsclient/1.6.1",
       "hashPath": "dnsclient.1.6.1.nupkg.sha512"
     },
-    "Google.Protobuf/3.24.3": {
+    "Google.Protobuf/3.28.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HX8KHRTJPUcC4KOvEobKBNlMpHGYmK+3X73xPq+OUE2M5dLYvpGhp9qQQWt2jASgTUbxI1yHaGeBqFYiECBupw==",
-      "path": "google.protobuf/3.24.3",
-      "hashPath": "google.protobuf.3.24.3.nupkg.sha512"
+      "sha512": "sha512-Z86ZKAB+v1B/m0LTM+EVamvZlYw/g3VND3/Gs4M/+aDIxa2JE9YPKjDxTpf0gv2sh26hrve3eI03brxBmzn92g==",
+      "path": "google.protobuf/3.28.2",
+      "hashPath": "google.protobuf.3.28.2.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -4254,19 +4154,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-cL1/2f8kc8lsAGNdfCU25deedXVehhLA6GXKLLN4hAWx16XN7BmjYn3gFU+FBpir5yJynvDTHEypr3Tl0j7x/Q==",
+      "path": "grpc.core.api/2.67.0",
+      "hashPath": "grpc.core.api.2.67.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-ofTjJQfegWkVlk5R4k/LlwpcucpsBzntygd4iAeuKd/eLMkmBWoXN+xcjYJ5IibAahRpIJU461jABZvT6E9dwA==",
+      "path": "grpc.net.client/2.67.0",
+      "hashPath": "grpc.net.client.2.67.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4275,33 +4175,61 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-gazn1cD2Eol0/W5ZJRV4PYbNrxJ9oMs8pGYux5S9E4MymClvl7aqYSmpqgmWAUWvziRqK9K+yt3cjCMfQ3x/5A==",
+      "path": "grpc.net.common/2.67.0",
+      "hashPath": "grpc.net.common.2.67.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.49.0": {
+    "Grpc.Tools/2.68.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fvA8M6m+cKR5cCwVfKNyUtC8/immoNiNGXW8rwLmwb4y4XRFtQJyN9dmGCJNh1mt0cb9LjSSiAZwmSfMgmE2Ng==",
-      "path": "grpc.tools/2.49.0",
-      "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
+      "sha512": "sha512-BZ96s7ijKAhJoRpIK+pqCeLaGaSwyc5/CAZFwgCcBuAnkU2naYvH0P6qnYCkl0pWDY/JBOnE2RvX9IvRX1Yc5Q==",
+      "path": "grpc.tools/2.68.1",
+      "hashPath": "grpc.tools.2.68.1.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "K4os.Compression.LZ4/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-TS4mqlT0X1OlnvOGNfl02QdVUhuqgWuCnn7UxupIa7C9Pb6qlQ5yZA2sPhRh0OSmVULaQU64KV4wJuu//UyVQQ==",
+      "path": "k4os.compression.lz4/1.3.5",
+      "hashPath": "k4os.compression.lz4.1.3.5.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "K4os.Compression.LZ4.Streams/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-M0NufZI8ym3mm6F6HMSPz1jw7TJGdY74fjAtbIXATmnAva/8xLz50eQZJI9tf9mMeHUaFDg76N1BmEh8GR5zeA==",
+      "path": "k4os.compression.lz4.streams/1.3.5",
+      "hashPath": "k4os.compression.lz4.streams.1.3.5.nupkg.sha512"
+    },
+    "K4os.Hash.xxHash/1.0.8": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Wp2F7BamQ2Q/7Hk834nV9vRQapgcr8kgv9Jvfm8J3D0IhDqZMMl+a2yxUq5ltJitvXvQfB8W6K4F4fCbw/P6YQ==",
+      "path": "k4os.hash.xxhash/1.0.8",
+      "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
+    },
+    "librdkafka.redist/2.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+    },
+    "MessagePack/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -4386,20 +4314,6 @@
       "sha512": "sha512-Nxs7Z1q3f1STfLYKJSVXCs1iBl+Ya6E8o4Oy1bCxJ/rNI44E/0f6tbsrVqAWfB7jlnJfyaAtIalBVxPKUPQb4Q==",
       "path": "microsoft.aspnetcore.http.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.2.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-jq2OPhIdCCjkcdZGVd4NMRwDG+A/3yUx2mgR3Bd4z+HXNZMbQzOQnL4hw6YFLsyBjHNnJc17fyeKSyV3DlKLEg==",
-      "path": "microsoft.aspnetcore.http.connections/1.0.15",
-      "hashPath": "microsoft.aspnetcore.http.connections.1.0.15.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-vllvIeTpVzCDs5kPEdICbvcmxLmRAlJUxG6bG55tf29Wfp/ehHQza5P14S1hFl4Ff7kuxJw5VoqSUHD0gaJMKg==",
-      "path": "microsoft.aspnetcore.http.connections.common/1.0.4",
-      "hashPath": "microsoft.aspnetcore.http.connections.common.1.0.4.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
       "type": "package",
@@ -4499,33 +4413,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tzRdyQ0qrMJ5YS0qsXfmhVd/kr25IzLpayoIAvU1yi27wqsqxXVPADDEv0S9PaS7xn6bpMFit8kZw92IICDSWg==",
-      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.1",
-      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.1.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-qTACI0wePgAKCH+YKrMgChyfqJpjwgGZEtSuwBw6TjWLQ66THGasleia/7EZz2t2eAjwWxw8RA/D8ODrBqpj9A==",
+      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -4541,68 +4434,54 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/mBhUF82NJq1mNr2u/7LkP3oDPqtw9jpH8Xo2yYxjwpIX3REK9bvgH1hqcBOLQTZIMGRDqjq6W/pEEzLqH1iZg==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.1.6",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.1.6.nupkg.sha512"
+      "sha512": "sha512-+zLlvMq5Bh1ifxCj27AapYc97muyS3+6y6clIFEBgm0uHAlPDWcvjz06gTp+sLiIMCUWSPRcC3RhzG+V84ZLqQ==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.2.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GxG4vMxZkZGj912TCtDO4RetqSrKprCO+pQAea/f5ouQzN+rB3aqYRV/TC+E8t9+F6dXFlZWFRZZvapj1RIJlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/1.17.4",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.1.17.4.nupkg.sha512"
+      "sha512": "sha512-U8PW868Ao+T4QMnXFBHqJgUefPBePK7SHOH3UpN1apqdsDksGrQuE/n+8jCEcv7EbpjCJSMqdoQKnZTMVbBZKg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.0.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/2.17.1": {
+    "Microsoft.Azure.DurableTask.Core/3.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zKtXC0wxGxOoAGPi5B0TT0f6mqjave2USL/Q7rJOwf+xVg+axiYpU4kad5muvzib4IeikOBfqWqs/xOFOKqR6w==",
-      "path": "microsoft.azure.durabletask.core/2.17.1",
-      "hashPath": "microsoft.azure.durabletask.core.2.17.1.nupkg.sha512"
+      "sha512": "sha512-KqAF02yugJC2hsDBfE4mhjiXAOj4JvKDYs/9GSrxuO/TLXbDY1Nx7meSpFw0E4Jp3kZiIH6UgHOAtHi0mnGCnw==",
+      "path": "microsoft.azure.durabletask.core/3.0.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o+65IPewJLhkuPIvziQxgsan6g3nJ981CWX3xtkHNiSnQqqA9WeUIxjA8ZYYyU1wJLj32CvPmVIyaALK9ejr2Q==",
-      "path": "microsoft.azure.durabletask.netherite/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.1.5.4.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tPosZ6BcmQ8Rg6RDAjGpV71+HzEHPWuPDk+n7GVBtdUTBUasv4ndWcRuW5QYKzLchqUVobLSxrtJLDZRaono/A==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.1.5.4.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-U5PEuRFxw6Jgsu1oc2BwNEFkIVH8PCAWuG8D0zeaF3V/nwKmvsAw3r0N1HR29UHO1WQtCOIl2Vh6yuA0BqxEBw==",
-      "path": "microsoft.azure.eventhubs/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.4.3.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-8zRsNRdPQAWAkASAI3r5SPEHJK/qXdje4KkjZUCNbPXdb+IXcfNno8esV5w34mxiUN59S9mTstZLzWC2VOUqlw==",
-      "path": "microsoft.azure.eventhubs.processor/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.processor.4.3.2.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -4625,68 +4504,54 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.KeyVault.Core/3.0.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-amP4gG7tMficBHRuTaCJpdiPGZyfrLHqYth0D4Yp3lu7Z7XQfEau0/BWNSuvpdZJKWW8M/wmFyI07vTA6EF88A==",
-      "path": "microsoft.azure.keyvault.core/3.0.3",
-      "hashPath": "microsoft.azure.keyvault.core.3.0.3.nupkg.sha512"
+      "sha512": "sha512-g3gf2XSGf5i3o59ros3dkAuyHh57DvKPIrLe7OBj/3UhD0wbf7pro/RCdBu8urQpeOSdUxXcPbaAueGYXRdW1g==",
+      "path": "microsoft.azure.kusto.cloud.platform/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RyJsnaSMlwTPLFw8LfEZfff72JwxG+oBNQoI4NM0paAbx5N1Klx0SAAQQvG5oNlIstBgTeImH5sytndbVZIeLg==",
-      "path": "microsoft.azure.kusto.cloud.platform/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.3.nupkg.sha512"
+      "sha512": "sha512-y43GEkrl3eLDSKTl7fJs1JO0V5yc+uNej9J9lJjSPs7Y7Js3/nCsF9vkMSnytNSg1UH7sfENXSSwBQLSe+iAeA==",
+      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+    "Microsoft.Azure.Kusto.Data/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5owQ2zf16iGrm7hsjNozG0y8dYLQ33VgPeIr3or9xV4pUdWDNMk1QHQkwtl2kKvR7BnSvJvWjiWPJqddbcsv9g==",
-      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.3.nupkg.sha512"
+      "sha512": "sha512-b0yRwFDTRORnyAq7mRUbIFt6K9RsgAHoZrSlGe4CxMDQX0t7+70j//3NHN3vzLQdmQn3SDkTs569wErZbcfrGQ==",
+      "path": "microsoft.azure.kusto.data/12.2.7",
+      "hashPath": "microsoft.azure.kusto.data.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Data/12.2.3": {
+    "Microsoft.Azure.Kusto.Ingest/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-a55PhqueiSMpCAIa96XMUdN1TL73M5rtSsQLzvd8RtAAK7oUhtriy3tLCt0sN643s3w2EdTJEa0GcYHrYQem1w==",
-      "path": "microsoft.azure.kusto.data/12.2.3",
-      "hashPath": "microsoft.azure.kusto.data.12.2.3.nupkg.sha512"
+      "sha512": "sha512-x5oTbesbMDVvmN6POpFF0frvh/bnHUtaKynlUxLTivmWUcZq8dw1rgQjnhX+YwfQWEg6fNSlJgpb58BZFV7qug==",
+      "path": "microsoft.azure.kusto.ingest/12.2.7",
+      "hashPath": "microsoft.azure.kusto.ingest.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2/5l1EC5Imn7dOHkYY/n0t/06lvqIsYdm6+EuFWcIVSULGN7YNt9qnHzzlLLJHfkwnDEhy0ZP9LMmtT1+97fdQ==",
-      "path": "microsoft.azure.kusto.ingest/12.2.3",
-      "hashPath": "microsoft.azure.kusto.ingest.12.2.3.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ywpQaK1klu1IoX4VUf+TBmU4kR71aWNI6O5rEIJU8z28L2xhJhnIm7k2Nf1Zu/PygeuOtt5g0QPCk5+lLltbeQ==",
-      "path": "microsoft.azure.services.appauthentication/1.0.3",
-      "hashPath": "microsoft.azure.services.appauthentication.1.0.3.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -4702,33 +4567,19 @@
       "path": "microsoft.azure.stackexchangeredis/2.0.0",
       "hashPath": "microsoft.azure.stackexchangeredis.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Blob/11.2.3": {
+    "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gM48FyiinUQq+fiUFHf0hGwQaTug4b+zYcYjbZ1KpxC3RkSgOd3twL9Yv9MqpvTkMcexGLwtELYIBhaTQ3zd9A==",
-      "path": "microsoft.azure.storage.blob/11.2.3",
-      "hashPath": "microsoft.azure.storage.blob.11.2.3.nupkg.sha512"
+      "sha512": "sha512-EOigHt+kjrpbg53s8SYn4dlTpZG9IgWPNrdmcdSG8c7U8qKZvcF4BwZtF7ETy3KGir2NtIpJaIc7dUm2+k9/GA==",
+      "path": "microsoft.azure.webjobs/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Common/11.2.3": {
+    "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WqX0ckhXQSUIBEq6wd2xgFz3KPjIONfDdgNg1ClQYxYTvuXQv3g3cnL9DGXCvuxEFZNPk0BJdQeW+uZwGqdDjw==",
-      "path": "microsoft.azure.storage.common/11.2.3",
-      "hashPath": "microsoft.azure.storage.common.11.2.3.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-H/Al/2UOXef8Qqwvsm3Dur9JStz1xvV/UXb0GDys5YPx+qpWDS/U203b/+EUPLeZeuvGTnmcOFtnZzvxMuDamQ==",
-      "path": "microsoft.azure.webjobs/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.3.0.39.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs.Core/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O1RDMe2mBGZI4q4IUns+mxsfCjaMej4FzicMLqvnN5Ti5E3mSo+/kqDbEZzXA/RqnuLIOk+DhvFg/rwKhqEaow==",
-      "path": "microsoft.azure.webjobs.core/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.39.nupkg.sha512"
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
+      "path": "microsoft.azure.webjobs.core/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
       "type": "package",
@@ -4744,12 +4595,12 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WaL+NcxoETT+w7T7hxzSLYhu8wwymlr/9UOXjr0/ZgH2lM+zrOOQIOmB23xh9jUsqIJSm+B9xvgd65Iy1HbVqg==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.0.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4758,12 +4609,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7SPfaLdUnRmN4dajBQEZ4Yei0IzTCL/z7zYkEio0hb3vX9M+XXcWw1exBb3S83yvzOYCFlFYSGDREicYvPxmhg==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/2.13.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.2.13.5.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4772,12 +4623,19 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-P7xUepplf/Tz2YD+Y0qXv0FloYVxPNGs0KuHXphiTB/ZZGUl+QPKiBfV24LhOca6NpcUhyymYtIWUdoWwMGJXA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.2.nupkg.sha512"
+      "sha512": "sha512-uiluTugaUmj+GUhDzkEm+0W18LXLWukVGpwqYqzmxwcYirjsOefl9IMHL3aLazNIF63IyDf8/4/60BbqpEtg7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/0.4.2-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.0.4.2-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -4786,12 +4644,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Lr9MGqAVZdFTmuG8NHdJUIY/SkIrl1thrOmhhdtbQwuFF040pVF6GYyU0UyNisGLax7CaD5ly0MayTV7Psi8sQ==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/0.1.54-rc",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.1.54-rc.nupkg.sha512"
+      "sha512": "sha512-vrgRqOPjkyOF/MDectRoNpbYvTOlsmggG/Qf8ERULdFCXSb1jJKftdNfEot/mz8fBzm2MyGkOP0ilyJzOLyVmQ==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/0.2.9-rc",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.2.9-rc.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -4800,47 +4658,54 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qYD7VIvXk9DQFGtmKkH4wO0SLkoitacfhIcGLO3WUQT7QdZXE15odDsEkWjMhPovoHnkmGCYFjQnAjuL4uKa4Q==",
-      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.10-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.10-preview.nupkg.sha512"
+      "sha512": "sha512-PNNDW4ktUIsTyZWrFdHMrLTQdtAqHyjOibK8sLL6O9qI/emN/VdFFewnmpZfBisLIPnc/5WUKW66KZuyOYA+SQ==",
+      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.11-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.11-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZYBel0IbpiCpryN9u30bBWcFboI8yerraXljCFYJGJZAp5UTcGVjuQmsOfSKUs+6We6yJTFEzFG3CfELjbBNvg==",
-      "path": "microsoft.azure.webjobs.extensions.openai/0.16.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.16.0-alpha.nupkg.sha512"
+      "sha512": "sha512-c6zx4iVHSwV7p2fotzWvxw+Ttrn7gXh/EjVkh2tdQ2g0TgD1E8I08s8j2PoCqww6ke9awIdq3+R/RwG7CwRrRg==",
+      "path": "microsoft.azure.webjobs.extensions.mysql/1.0.31-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.mysql.1.0.31-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3dRX/RvGTzrbPXMVXK0uHZHolzsPr+vhE+vwV+G6h5CRD2tHyf8iJBAmgpO/vOIertM52SZhSDuyCOGfFxOUiQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.3.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.3.0-alpha.nupkg.sha512"
+      "sha512": "sha512-HupnrqbRfod2J9d93SxfjdlNUGM+LwjL9wgYa29Gzfs40gQ2X+bBPnXyLYmYSnEhhlqPV6yToilb+4D9c0uOOg==",
+      "path": "microsoft.azure.webjobs.extensions.openai/0.18.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.18.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vOVQ8OJfd5PZ2zPhs7HPo6lO+xYf+347VOgaIZjQop7TnQQTLqr/2TxcAyIVyS02qH29xsrlmpRrEoOnTE85MQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.2.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.2.0-alpha.nupkg.sha512"
+      "sha512": "sha512-h+zjHJbJgpL0J/h9DEZBxpRXV/0ws/bVwD3V77WaG7219CzhJqSouw1xPZkEISESIEwBF9ZSDaXwq4DQZdqjAw==",
+      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.4.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.4.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JB88Fukr0wMkrGso7eS+7w+jzqJSOi/T7Cbc16BXob5CtDu012fQZ9qm3xVgGBm6yV8MulMc6LAgTSO0kuI2NA==",
-      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.15.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.15.0-alpha.nupkg.sha512"
+      "sha512": "sha512-lyirO2ZWuTTY25dnWuKzcbq0dFn4BlPJ4w21rRvIsKe0RYylV2I45Kfq2yn76Wa6qjLOVc6rg6sTWfbYjKksFA==",
+      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.3.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.3.0-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PyDCInGcaIjzurx5W0fHbcreTR+54JUBMKjFIoLXp9G23InBPxHPNcjYfA2FSa0P1jMJHddDGOdNRKL2ho7s5A==",
+      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.16.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.16.0-alpha.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
       "type": "package",
@@ -4856,61 +4721,61 @@
       "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
       "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6tybd5xeTeBEOSy+CjfmDOkc8Xwwb73nmG/rQdInNiPuPX6hl9vTkHeEQATOeG4Sv7t+oJQZPPdT6ZprypmMaQ==",
-      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.37.nupkg.sha512"
+      "sha512": "sha512-ZTC2+g7/zBqOLvCr9/g0eE08Z68RE8MT5IuC90q2JcM6it4Kqckc3TvR3SilzloDr1/9EOa1wvlxfC57o8bmWA==",
+      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YDOLY05g9RaZHVCLRDlRaQ1LH7e3QvCXTV4N050kK7C3med6taVlrorE3Yy6XMi3AG6CqZlC8LbgnNCIQRIHHw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.169-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.169-preview.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W5VzuQKK41J0HIQr3Eij6ghxtcZOmARjYARRFIB4tDo3eutw8Lr7mKfr5iyEyHAC4MOTSKeIgknY99MaZC7GqA==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h6NX6pd8eX1pkClh4Dxys357aLJCffVAUJMsK1xvjrOlwaityPZRNqMJJ/BCrAXqqn9hqFF1tmcS8DgD2wI7WA==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UAKPp/fm6m2GvYMDjoF8MLudIprgPxuaaaCsBJID49G1ectgFJdp9CuexFWcUx4eHOdTVjqTdomByz9PglsKQw==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.1.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -4919,6 +4784,13 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-J5dRt7gSNkWfdN7kxnt+vP4ActPRYo2+/eLnXK1c/kgiKqqcwS+552EOm2B7dEpEP1d6/eMLeu5Kz3grXSkwjw==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsubforsocketio/1.0.0-beta.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsubforsocketio.1.0.0-beta.4.nupkg.sha512"
+    },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
       "serviceable": true,
@@ -4926,12 +4798,12 @@
       "path": "microsoft.azure.webjobs.host.storage/3.0.14",
       "hashPath": "microsoft.azure.webjobs.host.storage.3.0.14.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KG+ZD6u3KKBBv5bet6r1EeLrP6mNFRoPVWuGUToQTZwpTLlPffouag94JR5IxAJA3DxMQl0A0mV+Qkhg9VorCA==",
-      "path": "microsoft.azure.webjobs.rpc.core/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.37.nupkg.sha512"
+      "sha512": "sha512-sMPOTH6hlAuaiK3EYbf1SfYON8j+Hxl3IL7ZAJX51m9SI5RI0sUR7QPfiwIG0h4Z0BHpfybQXl0so07JbxBqyA==",
+      "path": "microsoft.azure.webjobs.rpc.core/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.39.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
       "type": "package",
@@ -4946,6 +4818,13 @@
       "sha512": "sha512-o1E0hetLv8Ix0teA1hGH9D136RGSs24Njm5+a4FKzJHLlxfclvmOxmcg87vcr6LIszKzenNKd1oJGnOwg2WMnw==",
       "path": "microsoft.azure.webjobs.script.extensionsmetadatagenerator/4.0.1",
       "hashPath": "microsoft.azure.webjobs.script.extensionsmetadatagenerator.4.0.1.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebPubSub.Common/1.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-51j7iQ6l5NG8SyieJk2zVKMBff8TzDFnGmIWOIPD2U3V5BMzvyYL0gvzgDe+KRkYPNMxzwPwp+IiYE4kNqBQBA==",
+      "path": "microsoft.azure.webpubsub.common/1.4.0",
+      "hashPath": "microsoft.azure.webpubsub.common.1.4.0.nupkg.sha512"
     },
     "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
       "type": "package",
@@ -5024,12 +4903,12 @@
       "path": "microsoft.csharp/4.7.0",
       "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
-    "Microsoft.Data.SqlClient/5.2.1": {
+    "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ojg2XWmih4ubPPtrhRqqXk0SM6wC2ZSTkNNEAlYBhMo4IsRHjLazFc0abzcZCNfw1JyWcqY7vGutWTv8ZaFD9g==",
-      "path": "microsoft.data.sqlclient/5.2.1",
-      "hashPath": "microsoft.data.sqlclient.5.2.1.nupkg.sha512"
+      "sha512": "sha512-mtoeRMh7F/OA536c/Cnh8L4H0uLSKB5kSmoi54oN7Fp0hNJDy22IqyMhaMH4PkDCqI7xL//Fvg9ldtuPHG0h5g==",
+      "path": "microsoft.data.sqlclient/5.2.2",
+      "hashPath": "microsoft.data.sqlclient.5.2.2.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient.SNI.runtime/5.2.0": {
       "type": "package",
@@ -5045,33 +4924,33 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.1.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-O0hn+DEl5Ui4DZOs/yDBTtJHvTd9niT6AW0CGn40VoScStWXYuhBmYiMYQj+fCIn/tWLzw2NqYan8DsVNZX4KA==",
-      "path": "microsoft.durabletask.grpc/1.1.0",
-      "hashPath": "microsoft.durabletask.grpc.1.1.0.nupkg.sha512"
+      "sha512": "sha512-r6m2ZM9F94jS38gbdlkt78YCL3KURRYuerBPZWk0pl2eRTZoPQCLDC9XHxuwnXNv3994z5VofcWtAiVgMl1mPg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/0.4.2-alpha",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.0.4.2-alpha.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-B28jkMmT1d0z5J4IBzBcNyFfTRSQzhaHHvr1JvYN2aaapVvN/zrRD98b5utVCjBX77tdZxKINoKu18GwLdwIKQ==",
-      "path": "microsoft.durabletask.sqlserver/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YLDAWgwwRmz5tN2IJQqVRHIFObPOmkQQ6NR+lMO+CvQiOWiPxdb2wrT1wh9rQ2xp0gYDy+neUuXdIZLDrqdfLQ==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.3.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.7.4": {
+    "Microsoft.Extensions.Azure/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AVYk0jKLZa1d0r89cNs5pCgPAQMe1uco6g0FIuzyc7eEOccd+TjXGXiRkTNQibf8wYrCd15Qt+xvcKTmGR0sZg==",
-      "path": "microsoft.extensions.azure/1.7.4",
-      "hashPath": "microsoft.extensions.azure.1.7.4.nupkg.sha512"
+      "sha512": "sha512-hKYPTmD2NS/DVxS1vSqO24cAjBO3yFioAiXAzs/9UDjHVJZc2CEowtpPMtNMvhoXknFTyu3nlGTpFlj/ofDUtg==",
+      "path": "microsoft.extensions.azure/1.10.0",
+      "hashPath": "microsoft.extensions.azure.1.10.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/2.2.0": {
       "type": "package",
@@ -5115,19 +4994,19 @@
       "path": "microsoft.extensions.configuration.json/2.1.0",
       "hashPath": "microsoft.extensions.configuration.json.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
-      "path": "microsoft.extensions.dependencyinjection/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
+      "sha512": "sha512-elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
+      "path": "microsoft.extensions.dependencyinjection/7.0.0",
+      "hashPath": "microsoft.extensions.dependencyinjection.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5171,26 +5050,26 @@
       "path": "microsoft.extensions.hosting.abstractions/2.2.0",
       "hashPath": "microsoft.extensions.hosting.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Http/3.1.32": {
+    "Microsoft.Extensions.Http/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0ZNzmbaeKQMQQH8CZ1QVKC26nJ+jOn1AjSrVWKEb9sqX8cgElMbWUtvOXN21BI6IHedS+uhVuzJLQN3Ny46AKw==",
-      "path": "microsoft.extensions.http/3.1.32",
-      "hashPath": "microsoft.extensions.http.3.1.32.nupkg.sha512"
+      "sha512": "sha512-15+pa2G0bAMHbHewaQIdr/y6ag2H3yh4rd9hTXavtWDzQBkvpe2RMqFg8BxDpcQWssmjmBApGPcw93QRz6YcMg==",
+      "path": "microsoft.extensions.http/6.0.0",
+      "hashPath": "microsoft.extensions.http.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging/6.0.0": {
+    "Microsoft.Extensions.Logging/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
-      "path": "microsoft.extensions.logging/6.0.0",
-      "hashPath": "microsoft.extensions.logging.6.0.0.nupkg.sha512"
+      "sha512": "sha512-Nw2muoNrOG5U5qa2ZekXwudUn2BJcD41e65zwmDHb1fQegTX66UokLWZkJRpqSSHXDOWZ5V0iqhbxOEky91atA==",
+      "path": "microsoft.extensions.logging/7.0.0",
+      "hashPath": "microsoft.extensions.logging.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging.Abstractions/6.0.0": {
+    "Microsoft.Extensions.Logging.Abstractions/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA==",
-      "path": "microsoft.extensions.logging.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.logging.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw==",
+      "path": "microsoft.extensions.logging.abstractions/7.0.0",
+      "hashPath": "microsoft.extensions.logging.abstractions.7.0.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Logging.Configuration/2.1.0": {
       "type": "package",
@@ -5206,12 +5085,12 @@
       "path": "microsoft.extensions.objectpool/2.2.0",
       "hashPath": "microsoft.extensions.objectpool.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Options/6.0.0": {
+    "Microsoft.Extensions.Options/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
-      "path": "microsoft.extensions.options/6.0.0",
-      "hashPath": "microsoft.extensions.options.6.0.0.nupkg.sha512"
+      "sha512": "sha512-lP1yBnTTU42cKpMozuafbvNtQ7QcBjr/CcK3bYOGEMH55Fjt+iecXjT6chR7vbgCMqy3PG3aNQSZgo/EuY/9qQ==",
+      "path": "microsoft.extensions.options/7.0.0",
+      "hashPath": "microsoft.extensions.options.7.0.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
       "type": "package",
@@ -5220,12 +5099,12 @@
       "path": "microsoft.extensions.options.configurationextensions/2.1.0",
       "hashPath": "microsoft.extensions.options.configurationextensions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Primitives/6.0.0": {
+    "Microsoft.Extensions.Primitives/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
-      "path": "microsoft.extensions.primitives/6.0.0",
-      "hashPath": "microsoft.extensions.primitives.6.0.0.nupkg.sha512"
+      "sha512": "sha512-um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q==",
+      "path": "microsoft.extensions.primitives/7.0.0",
+      "hashPath": "microsoft.extensions.primitives.7.0.0.nupkg.sha512"
     },
     "Microsoft.FASTER.Core/2.6.5": {
       "type": "package",
@@ -5234,19 +5113,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.61.3": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
-      "path": "microsoft.identity.client/4.61.3",
-      "hashPath": "microsoft.identity.client.4.61.3.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
-      "path": "microsoft.identity.client.extensions.msal/4.61.3",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.61.3.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/7.6.3": {
       "type": "package",
@@ -5254,13 +5133,6 @@
       "sha512": "sha512-EycYJUD/3cZw/b6TioXOpmETjv9OX5/VRk0Tc26x6I+SxxLNxx6ymivwo2dfYeiimqg5d3k88VXnrxc7HJch6Q==",
       "path": "microsoft.identitymodel.abstractions/7.6.3",
       "hashPath": "microsoft.identitymodel.abstractions.7.6.3.nupkg.sha512"
-    },
-    "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TNsJJMiRnkeby1ovThVoV9yFsPWjAdluwOA+Nf0LtSsBVVrKQv8Qp4kYOgyNwMVj+pDwbhXISySk+4HyHVWNZQ==",
-      "path": "microsoft.identitymodel.clients.activedirectory/3.14.2",
-      "hashPath": "microsoft.identitymodel.clients.activedirectory.3.14.2.nupkg.sha512"
     },
     "Microsoft.IdentityModel.JsonWebTokens/7.6.3": {
       "type": "package",
@@ -5311,19 +5183,26 @@
       "path": "microsoft.net.http.headers/2.2.0",
       "hashPath": "microsoft.net.http.headers.2.2.0.nupkg.sha512"
     },
-    "Microsoft.NET.Sdk.Functions/4.4.0": {
+    "Microsoft.NET.Sdk.Functions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
-      "path": "microsoft.net.sdk.functions/4.4.0",
-      "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+      "sha512": "sha512-jDnf2TZ5JcBQY9BhI5hzRsbsu+EzJuz22GzmHmV9iGFFBraD3MaOTsoHxtS5kpd9qX3qCv7I7HuNjUSiH3nTZg==",
+      "path": "microsoft.net.sdk.functions/4.6.0",
+      "hashPath": "microsoft.net.sdk.functions.4.6.0.nupkg.sha512"
     },
-    "Microsoft.NETCore.Platforms/2.1.2": {
+    "Microsoft.NET.StringTools/17.6.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mOJy3M0UN+LUG21dLGMxaWZEP6xYpQEpLuvuEQBaownaX4YuhH6NmNUlN9si+vNkAS6dwJ//N1O4DmLf2CikVg==",
-      "path": "microsoft.netcore.platforms/2.1.2",
-      "hashPath": "microsoft.netcore.platforms.2.1.2.nupkg.sha512"
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
+    },
+    "Microsoft.NETCore.Platforms/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-z7aeg8oHln2CuNulfhiLYxCVMPEwBl3rzicjvIX+4sUuCwvXw5oXQEtbiU2c0z4qYL5L3Kmx0mMA/+t/SbY67w==",
+      "path": "microsoft.netcore.platforms/3.1.0",
+      "hashPath": "microsoft.netcore.platforms.3.1.0.nupkg.sha512"
     },
     "Microsoft.NETCore.Targets/1.1.3": {
       "type": "package",
@@ -5339,12 +5218,12 @@
       "path": "microsoft.sqlserver.server/1.0.0",
       "hashPath": "microsoft.sqlserver.server.1.0.0.nupkg.sha512"
     },
-    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v1I3SV+EqPHBM+RGrB5LyEc2z74t8WRYFmB0BmSc7EMBDUxFgmJ5oentkf9hPkUFfesha9spB0jci4hDtrCE3Q==",
-      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9123.0",
-      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9123.0.nupkg.sha512"
+      "sha512": "sha512-Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g==",
+      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9135.0",
+      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9135.0.nupkg.sha512"
     },
     "Microsoft.Win32.Primitives/4.3.0": {
       "type": "package",
@@ -5360,40 +5239,54 @@
       "path": "microsoft.win32.registry/5.0.0",
       "hashPath": "microsoft.win32.registry.5.0.0.nupkg.sha512"
     },
-    "MongoDB.Bson/2.25.0": {
+    "Microsoft.Win32.SystemEvents/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xQx/qtC2nu9oGiyNqAwfiDpUMweLi0nID677cyKykpwmj5AVMrnd//UwmcmuX95178DeY6rf7cjmA613TQXPiA==",
-      "path": "mongodb.bson/2.25.0",
-      "hashPath": "mongodb.bson.2.25.0.nupkg.sha512"
+      "sha512": "sha512-mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+      "path": "microsoft.win32.systemevents/4.7.0",
+      "hashPath": "microsoft.win32.systemevents.4.7.0.nupkg.sha512"
     },
-    "MongoDB.Driver/2.25.0": {
+    "MongoDB.Bson/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dMqnZTV6MuvoEI4yFtSvKJdAoN6NeyAEvG8aoxnrLIVd7bR84QxLgpsM1nhK17qkOcIx/IrpMIfrvp5iMnYGBg==",
-      "path": "mongodb.driver/2.25.0",
-      "hashPath": "mongodb.driver.2.25.0.nupkg.sha512"
+      "sha512": "sha512-wz8UtxdjnknHRJuMatTRr2QMlh7k9457BRfaDQxl+OiKV01vMzm1K0/jTvQJqORV5eba6HrCAzMJzj7nnt5cag==",
+      "path": "mongodb.bson/2.29.0",
+      "hashPath": "mongodb.bson.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Driver.Core/2.25.0": {
+    "MongoDB.Driver/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oN4nLgO5HQEThTg/zqeoHqaO2+q64DBVb4r7BvhaFb0p0TM9jZKnCKvh1EA8d9E9swIz0CgvMrvL1mPyRCZzag==",
-      "path": "mongodb.driver.core/2.25.0",
-      "hashPath": "mongodb.driver.core.2.25.0.nupkg.sha512"
+      "sha512": "sha512-1IfTnHX8G2SsXIHDz80OVSmcdL95vzzWXGGucR45k7+TUOcWVhiqYcc13ckRXl4NVxn4UTRrrKl+92xvjwWrRA==",
+      "path": "mongodb.driver/2.29.0",
+      "hashPath": "mongodb.driver.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Libmongocrypt/1.8.2": {
+    "MongoDB.Driver.Core/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-z/8JCULSHM1+mzkau0ivIkU9kIn8JEFFSkmYTSaMaWMMHt96JjUtMKuXxeGNGSnHZ5290ZPKIlQfjoWFk2sKog==",
-      "path": "mongodb.libmongocrypt/1.8.2",
-      "hashPath": "mongodb.libmongocrypt.1.8.2.nupkg.sha512"
+      "sha512": "sha512-3M7gdmuLEay4Wc/q4zm/oA5KT4E62SsRBiq3prpT3tGEPkfstr3N3fYRbzYNu8TJgeyS0q5OPe4zI4yi6/GemQ==",
+      "path": "mongodb.driver.core/2.29.0",
+      "hashPath": "mongodb.driver.core.2.29.0.nupkg.sha512"
     },
-    "morelinq/3.4.2": {
+    "MongoDB.Libmongocrypt/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q==",
-      "path": "morelinq/3.4.2",
-      "hashPath": "morelinq.3.4.2.nupkg.sha512"
+      "sha512": "sha512-B1X51jrtNacKvxKoaqWeknYeJfQS5aWf6BmVLT5JZerz3AUXFzv8edPskJYqBc3kLy1J2PWzMqqsnyb9g8FtcA==",
+      "path": "mongodb.libmongocrypt/1.12.0",
+      "hashPath": "mongodb.libmongocrypt.1.12.0.nupkg.sha512"
+    },
+    "morelinq/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tkUeXp5dWNVP47MIhVEsIQk4DaN2oM/owIAnHblNOiwDQ5RB7oKreqZ7a+z+AEdyNgzLSkj6Pv0D0rY6Gh1/Ng==",
+      "path": "morelinq/4.1.0",
+      "hashPath": "morelinq.4.1.0.nupkg.sha512"
+    },
+    "MySql.Data/8.0.33": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mW+A9tc0s+3E3+XYe80aJmr/AvZoKBZG44w13AdVf4+1iRDwgdL6eLMPZgHyQFGwdLwNvQNPKegcOE4rRDuv8Q==",
+      "path": "mysql.data/8.0.33",
+      "hashPath": "mysql.data.8.0.33.nupkg.sha512"
     },
     "ncrontab.signed/3.3.0": {
       "type": "package",
@@ -5402,12 +5295,12 @@
       "path": "ncrontab.signed/3.3.0",
       "hashPath": "ncrontab.signed.3.3.0.nupkg.sha512"
     },
-    "NETStandard.Library/2.0.1": {
+    "NETStandard.Library/1.6.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
-      "path": "netstandard.library/2.0.1",
-      "hashPath": "netstandard.library.2.0.1.nupkg.sha512"
+      "sha512": "sha512-WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+      "path": "netstandard.library/1.6.1",
+      "hashPath": "netstandard.library.1.6.1.nupkg.sha512"
     },
     "Newtonsoft.Json/13.0.3": {
       "type": "package",
@@ -5430,12 +5323,138 @@
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
     },
+    "Portable.BouncyCastle/1.9.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw==",
+      "path": "portable.bouncycastle/1.9.0",
+      "hashPath": "portable.bouncycastle.1.9.0.nupkg.sha512"
+    },
     "RabbitMQ.Client/5.1.2": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-Xhj+un0pw4N7h37SZWptxl/NEv7f1RLHwZhXjqzkCm3w3IdbFJh+HjVyPaciD848BUYLGoEQzadx90nShsbs4Q==",
       "path": "rabbitmq.client/5.1.2",
       "hashPath": "rabbitmq.client.5.1.2.nupkg.sha512"
+    },
+    "runtime.any.System.Collections/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-23g6rqftKmovn2cLeGsuHUYm0FD7pdutb0uQMJpZ3qTvq+zHkgmt6J65VtRry4WDGYlmkMa4xDACtaQ94alNag==",
+      "path": "runtime.any.system.collections/4.3.0",
+      "hashPath": "runtime.any.system.collections.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Diagnostics.Tools/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-S/GPBmfPBB48ZghLxdDR7kDAJVAqgAuThyDJho3OLP5OS4tWD2ydyL8LKm8lhiBxce10OKe9X2zZ6DUjAqEbPg==",
+      "path": "runtime.any.system.diagnostics.tools/4.3.0",
+      "hashPath": "runtime.any.system.diagnostics.tools.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Diagnostics.Tracing/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1lpifymjGDzoYIaam6/Hyqf8GhBI3xXYLK2TgEvTtuZMorG3Kb9QnMTIKhLjJYXIiu1JvxjngHvtVFQQlpQ3HQ==",
+      "path": "runtime.any.system.diagnostics.tracing/4.3.0",
+      "hashPath": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Globalization/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-sMDBnad4rp4t7GY442Jux0MCUuKL4otn5BK6Ni0ARTXTSpRNBzZ7hpMfKSvnVSED5kYJm96YOWsqV0JH0d2uuw==",
+      "path": "runtime.any.system.globalization/4.3.0",
+      "hashPath": "runtime.any.system.globalization.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Globalization.Calendars/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-M1r+760j1CNA6M/ZaW6KX8gOS8nxPRqloqDcJYVidRG566Ykwcs29AweZs2JF+nMOCgWDiMfPSTMfvwOI9F77w==",
+      "path": "runtime.any.system.globalization.calendars/4.3.0",
+      "hashPath": "runtime.any.system.globalization.calendars.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.IO/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-SDZ5AD1DtyRoxYtEcqQ3HDlcrorMYXZeCt7ZhG9US9I5Vva+gpIWDGMkcwa5XiKL0ceQKRZIX2x0XEjLX7PDzQ==",
+      "path": "runtime.any.system.io/4.3.0",
+      "hashPath": "runtime.any.system.io.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Reflection/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hLC3A3rI8jipR5d9k7+f0MgRCW6texsAp0MWkN/ci18FMtQ9KH7E2vDn/DH2LkxsszlpJpOn9qy6Z6/69rH6eQ==",
+      "path": "runtime.any.system.reflection/4.3.0",
+      "hashPath": "runtime.any.system.reflection.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Reflection.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-cPhT+Vqu52+cQQrDai/V91gubXUnDKNRvlBnH+hOgtGyHdC17aQIU64EaehwAQymd7kJA5rSrVRNfDYrbhnzyA==",
+      "path": "runtime.any.system.reflection.extensions/4.3.0",
+      "hashPath": "runtime.any.system.reflection.extensions.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Reflection.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Nrm1p3armp6TTf2xuvaa+jGTTmncALWFq22CpmwRvhDf6dE9ZmH40EbOswD4GnFLrMRS0Ki6Kx5aUPmKK/hZBg==",
+      "path": "runtime.any.system.reflection.primitives/4.3.0",
+      "hashPath": "runtime.any.system.reflection.primitives.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Resources.ResourceManager/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Lxb89SMvf8w9p9+keBLyL6H6x/TEmc6QVsIIA0T36IuyOY3kNvIdyGddA2qt35cRamzxF8K5p0Opq4G4HjNbhQ==",
+      "path": "runtime.any.system.resources.resourcemanager/4.3.0",
+      "hashPath": "runtime.any.system.resources.resourcemanager.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Runtime/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-fRS7zJgaG9NkifaAxGGclDDoRn9HC7hXACl52Or06a/fxdzDajWb5wov3c6a+gVSlekRoexfjwQSK9sh5um5LQ==",
+      "path": "runtime.any.system.runtime/4.3.0",
+      "hashPath": "runtime.any.system.runtime.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Runtime.Handles/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-GG84X6vufoEzqx8PbeBKheE4srOhimv+yLtGb/JkR3Y2FmoqmueLNFU4Xx8Y67plFpltQSdK74x0qlEhIpv/CQ==",
+      "path": "runtime.any.system.runtime.handles/4.3.0",
+      "hashPath": "runtime.any.system.runtime.handles.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Runtime.InteropServices/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-lBoFeQfxe/4eqjPi46E0LU/YaCMdNkQ8B4MZu/mkzdIAZh8RQ1NYZSj0egrQKdgdvlPFtP4STtob40r4o2DBAw==",
+      "path": "runtime.any.system.runtime.interopservices/4.3.0",
+      "hashPath": "runtime.any.system.runtime.interopservices.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Text.Encoding/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-+ihI5VaXFCMVPJNstG4O4eo1CfbrByLxRrQQTqOTp1ttK0kUKDqOdBSTaCB2IBk/QtjDrs6+x4xuezyMXdm0HQ==",
+      "path": "runtime.any.system.text.encoding/4.3.0",
+      "hashPath": "runtime.any.system.text.encoding.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Text.Encoding.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-NLrxmLsfRrOuVqPWG+2lrQZnE53MLVeo+w9c54EV+TUo4c8rILpsDXfY8pPiOy9kHpUHHP07ugKmtsU3vVW5Jg==",
+      "path": "runtime.any.system.text.encoding.extensions/4.3.0",
+      "hashPath": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Threading.Tasks/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OhBAVBQG5kFj1S+hCEQ3TUHBAEtZ3fbEMgZMRNdN8A0Pj4x+5nTELEqL59DU0TjKVE6II3dqKw4Dklb3szT65w==",
+      "path": "runtime.any.system.threading.tasks/4.3.0",
+      "hashPath": "runtime.any.system.threading.tasks.4.3.0.nupkg.sha512"
+    },
+    "runtime.any.System.Threading.Timer/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-w4ehZJ+AwXYmGwYu+rMvym6RvMaRiUEQR1u6dwcyuKHxz8Heu/mO9AG1MquEgTyucnhv3M43X0iKpDOoN17C0w==",
+      "path": "runtime.any.system.threading.timer/4.3.0",
+      "hashPath": "runtime.any.system.threading.timer.4.3.0.nupkg.sha512"
     },
     "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5465,6 +5484,13 @@
       "path": "runtime.native.system/4.3.0",
       "hashPath": "runtime.native.system.4.3.0.nupkg.sha512"
     },
+    "runtime.native.System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+      "path": "runtime.native.system.io.compression/4.3.0",
+      "hashPath": "runtime.native.system.io.compression.4.3.0.nupkg.sha512"
+    },
     "runtime.native.System.Net.Http/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5472,12 +5498,12 @@
       "path": "runtime.native.system.net.http/4.3.0",
       "hashPath": "runtime.native.system.net.http.4.3.0.nupkg.sha512"
     },
-    "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UPrVPlqPRSVZaB4ADmbsQ77KXn9ORiWXyA1RP2W2+byCh3bhgT1bQz0jbeOoog9/2oTQ5wWZSDSMeb74MjezcA==",
-      "path": "runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+      "path": "runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5500,12 +5526,12 @@
       "path": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2",
       "hashPath": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg.sha512"
     },
-    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-t15yGf5r6vMV1rB5O6TgfXKChtCaN3niwFw44M2ImX3eZ8yzueplqMqXPCbWzoBDHJVz9fE+9LFUGCsUmS2Jgg==",
-      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ==",
+      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5542,6 +5568,62 @@
       "path": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.2",
       "hashPath": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg.sha512"
     },
+    "runtime.unix.Microsoft.Win32.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-2mI2Mfq+CVatgr4RWGvAWBjoCfUafy6VNFU7G9OA52DjO8x/okfIbsEq2UPgeGfdpO7X5gmPXKT8slx0tn0Mhw==",
+      "path": "runtime.unix.microsoft.win32.primitives/4.3.0",
+      "hashPath": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg.sha512"
+    },
+    "runtime.unix.System.Console/4.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MOmRf2JcN44Bs/EebFMgHBiCiTtFW6ZcpFds2uPlqoXN+8SSMJ43qb+/r1DQ36CUI9JUXBhnm+jdo19PWOzFTg==",
+      "path": "runtime.unix.system.console/4.3.1",
+      "hashPath": "runtime.unix.system.console.4.3.1.nupkg.sha512"
+    },
+    "runtime.unix.System.Diagnostics.Debug/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WV8KLRHWVUVUDduFnvGMHt0FsEt2wK6xPl1EgDKlaMx2KnZ43A/O0GzP8wIuvAC7mq4T9V1mm90r+PXkL9FPdQ==",
+      "path": "runtime.unix.system.diagnostics.debug/4.3.0",
+      "hashPath": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg.sha512"
+    },
+    "runtime.unix.System.IO.FileSystem/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ajmTcjrqc3vgV1TH54DRioshbEniaFbOAJ0kReGuNsp9uIcqYle0RmUo6+Qlwqe3JIs4TDxgnqs3UzX3gRJ1rA==",
+      "path": "runtime.unix.system.io.filesystem/4.3.0",
+      "hashPath": "runtime.unix.system.io.filesystem.4.3.0.nupkg.sha512"
+    },
+    "runtime.unix.System.Net.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-AZcRXhH7Gamr+bckUfX3iHefPIrujJTt9XWQWo0elNiP1SNasX0KBWINZkDKY0GsOrsyJ7cB4MgIRTZzLlsTKg==",
+      "path": "runtime.unix.system.net.primitives/4.3.0",
+      "hashPath": "runtime.unix.system.net.primitives.4.3.0.nupkg.sha512"
+    },
+    "runtime.unix.System.Net.Sockets/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-4NcLbqajFaD3PvhOdmbieeBlKY4d8/kBfgJ5g28n6k1jWEICabvLM62gvmUS/CvyfvcZxVanKPl+E9LhPzfXZw==",
+      "path": "runtime.unix.system.net.sockets/4.3.0",
+      "hashPath": "runtime.unix.system.net.sockets.4.3.0.nupkg.sha512"
+    },
+    "runtime.unix.System.Private.Uri/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ooWzobr5RAq34r9uan1r/WPXJYG1XWy9KanrxNvEnBzbFdQbMG7Y3bVi4QxR7xZMNLOxLLTAyXvnSkfj5boZSg==",
+      "path": "runtime.unix.system.private.uri/4.3.0",
+      "hashPath": "runtime.unix.system.private.uri.4.3.0.nupkg.sha512"
+    },
+    "runtime.unix.System.Runtime.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-zQiTBVpiLftTQZW8GFsV0gjYikB1WMkEPIxF5O6RkUrSV/OgvRRTYgeFQha/0keBpuS0HYweraGRwhfhJ7dj7w==",
+      "path": "runtime.unix.system.runtime.extensions/4.3.0",
+      "hashPath": "runtime.unix.system.runtime.extensions.4.3.0.nupkg.sha512"
+    },
     "SemanticVersion/2.1.0": {
       "type": "package",
       "serviceable": true,
@@ -5549,12 +5631,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "SharpCompress/0.30.1": {
       "type": "package",
@@ -5577,12 +5659,19 @@
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
     },
-    "System.AppContext/4.1.0": {
+    "starkbank-ecdsa/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
-      "path": "system.appcontext/4.1.0",
-      "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
+    },
+    "System.AppContext/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+      "path": "system.appcontext/4.3.0",
+      "hashPath": "system.appcontext.4.3.0.nupkg.sha512"
     },
     "System.Buffers/4.5.1": {
       "type": "package",
@@ -5591,12 +5680,12 @@
       "path": "system.buffers/4.5.1",
       "hashPath": "system.buffers.4.5.1.nupkg.sha512"
     },
-    "System.ClientModel/1.0.0": {
+    "System.ClientModel/1.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I3CVkvxeqFYjIVEP59DnjbeoGNfo/+SZrCLpRz2v/g0gpCHaEMPtWSY0s9k/7jR1rAsLNg2z2u1JRB76tPjnIw==",
-      "path": "system.clientmodel/1.0.0",
-      "hashPath": "system.clientmodel.1.0.0.nupkg.sha512"
+      "sha512": "sha512-UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+      "path": "system.clientmodel/1.1.0",
+      "hashPath": "system.clientmodel.1.1.0.nupkg.sha512"
     },
     "System.CodeDom/4.4.0": {
       "type": "package",
@@ -5689,12 +5778,19 @@
       "path": "system.composition.typedparts/1.0.31",
       "hashPath": "system.composition.typedparts.1.0.31.nupkg.sha512"
     },
-    "System.Configuration.ConfigurationManager/8.0.0": {
+    "System.Configuration.ConfigurationManager/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
-      "path": "system.configuration.configurationmanager/8.0.0",
-      "hashPath": "system.configuration.configurationmanager.8.0.0.nupkg.sha512"
+      "sha512": "sha512-gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+      "path": "system.configuration.configurationmanager/8.0.1",
+      "hashPath": "system.configuration.configurationmanager.8.0.1.nupkg.sha512"
+    },
+    "System.Console/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
+      "path": "system.console/4.3.0",
+      "hashPath": "system.console.4.3.0.nupkg.sha512"
     },
     "System.Diagnostics.Debug/4.3.0": {
       "type": "package",
@@ -5710,19 +5806,12 @@
       "path": "system.diagnostics.diagnosticsource/8.0.0",
       "hashPath": "system.diagnostics.diagnosticsource.8.0.0.nupkg.sha512"
     },
-    "System.Diagnostics.EventLog/6.0.0": {
+    "System.Diagnostics.EventLog/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw==",
-      "path": "system.diagnostics.eventlog/6.0.0",
-      "hashPath": "system.diagnostics.eventlog.6.0.0.nupkg.sha512"
-    },
-    "System.Diagnostics.Process/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-J0wOX07+QASQblsfxmIMFc9Iq7KTXYL3zs2G/Xc704Ylv3NpuVdo6gij6V3PGiptTxqsK0K7CdXenRvKUnkA2g==",
-      "path": "system.diagnostics.process/4.3.0",
-      "hashPath": "system.diagnostics.process.4.3.0.nupkg.sha512"
+      "sha512": "sha512-n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg==",
+      "path": "system.diagnostics.eventlog/8.0.1",
+      "hashPath": "system.diagnostics.eventlog.8.0.1.nupkg.sha512"
     },
     "System.Diagnostics.Tools/4.3.0": {
       "type": "package",
@@ -5744,6 +5833,13 @@
       "sha512": "sha512-rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
       "path": "system.diagnostics.tracing/4.3.0",
       "hashPath": "system.diagnostics.tracing.4.3.0.nupkg.sha512"
+    },
+    "System.Drawing.Common/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-v+XbyYHaZjDfn0ENmJEV1VYLgGgCTx1gnfOBcppowbpOAriglYgGCvFCPr2EEZyBvXlpxbEsTwkOlInl107ahA==",
+      "path": "system.drawing.common/4.7.0",
+      "hashPath": "system.drawing.common.4.7.0.nupkg.sha512"
     },
     "System.Dynamic.Runtime/4.0.11": {
       "type": "package",
@@ -5801,6 +5897,20 @@
       "path": "system.io/4.3.0",
       "hashPath": "system.io.4.3.0.nupkg.sha512"
     },
+    "System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+      "path": "system.io.compression/4.3.0",
+      "hashPath": "system.io.compression.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Compression.ZipFile/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
+      "path": "system.io.compression.zipfile/4.3.0",
+      "hashPath": "system.io.compression.zipfile.4.3.0.nupkg.sha512"
+    },
     "System.IO.FileSystem/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5822,12 +5932,12 @@
       "path": "system.io.hashing/6.0.0",
       "hashPath": "system.io.hashing.6.0.0.nupkg.sha512"
     },
-    "System.IO.Pipelines/5.0.1": {
+    "System.IO.Pipelines/6.0.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg==",
-      "path": "system.io.pipelines/5.0.1",
-      "hashPath": "system.io.pipelines.5.0.1.nupkg.sha512"
+      "sha512": "sha512-ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw==",
+      "path": "system.io.pipelines/6.0.3",
+      "hashPath": "system.io.pipelines.6.0.3.nupkg.sha512"
     },
     "System.Json/4.5.0": {
       "type": "package",
@@ -5864,12 +5974,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/1.0.2": {
+    "System.Memory.Data/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JGkzeqgBsiZwKJZ1IxPNsDFZDhUvuEdX8L8BDC8N3KOj+6zMcNU28CNN59TpZE/VJYy9cP+5M+sbxtWJx3/xtw==",
-      "path": "system.memory.data/1.0.2",
-      "hashPath": "system.memory.data.1.0.2.nupkg.sha512"
+      "sha512": "sha512-ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
+      "path": "system.memory.data/6.0.0",
+      "hashPath": "system.memory.data.6.0.0.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5899,13 +6009,6 @@
       "path": "system.net.sockets/4.3.0",
       "hashPath": "system.net.sockets.4.3.0.nupkg.sha512"
     },
-    "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O8RIMEVeOFzT8fscu6MDc4y+0LfnlXdqGovb0rJHBNVKhwn6BsNJmTY1oYUZPPsMfcc5OP20WpX4vj/aK8n98g==",
-      "path": "system.net.websockets.websocketprotocol/4.5.3",
-      "hashPath": "system.net.websockets.websocketprotocol.4.5.3.nupkg.sha512"
-    },
     "System.Numerics.Vectors/4.5.0": {
       "type": "package",
       "serviceable": true,
@@ -5920,12 +6023,12 @@
       "path": "system.objectmodel/4.3.0",
       "hashPath": "system.objectmodel.4.3.0.nupkg.sha512"
     },
-    "System.Private.DataContractSerialization/4.1.1": {
+    "System.Private.Uri/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lcqFBUaCZxPiUkA4dlSOoPZGtZsAuuElH2XHgLwGLxd7ZozWetV5yiz0qGAV2AUYOqw97MtZBjbLMN16Xz4vXA==",
-      "path": "system.private.datacontractserialization/4.1.1",
-      "hashPath": "system.private.datacontractserialization.4.1.1.nupkg.sha512"
+      "sha512": "sha512-I4SwANiUGho1esj4V4oSlPllXjzCZDE+5XXso2P03LW2vOda2Enzh8DWOxwN6hnrJyp314c7KuVu31QYhRzOGg==",
+      "path": "system.private.uri/4.3.0",
+      "hashPath": "system.private.uri.4.3.0.nupkg.sha512"
     },
     "System.Reactive/4.4.1": {
       "type": "package",
@@ -6046,12 +6149,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/8.0.0": {
+    "System.Runtime.Caching/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4TmlmvGp4kzZomm7J2HJn6IIx0UUrQyhBDyb5O1XiunZlQImXW+B8b7W/sTPcXhSf9rp5NR5aDtQllwbB5elOQ==",
-      "path": "system.runtime.caching/8.0.0",
-      "hashPath": "system.runtime.caching.8.0.0.nupkg.sha512"
+      "sha512": "sha512-tdl7Q47P09UpRu0C/OQsGJU6GacBzzk4vfp5My9rodD+BchrxmajORnTthH8RxPUTPrIoVDJmLyvJcGxB267nQ==",
+      "path": "system.runtime.caching/8.0.1",
+      "hashPath": "system.runtime.caching.8.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -6081,12 +6184,12 @@
       "path": "system.runtime.interopservices/4.3.0",
       "hashPath": "system.runtime.interopservices.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+    "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWPhJxc453RCa8Z29O91EmfGeZIHX1ZH2A8L6lYQVSaKzku2DfArSfMEb1/MYYzPQRJZeu0c9dmYeJKxW5Fgng==",
-      "path": "system.runtime.interopservices.runtimeinformation/4.0.0",
-      "hashPath": "system.runtime.interopservices.runtimeinformation.4.0.0.nupkg.sha512"
+      "sha512": "sha512-cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+      "path": "system.runtime.interopservices.runtimeinformation/4.3.0",
+      "hashPath": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg.sha512"
     },
     "System.Runtime.Loader/4.3.0": {
       "type": "package",
@@ -6102,20 +6205,6 @@
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.Serialization.Json/4.0.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-+7DIJhnKYgCzUgcLbVTtRQb2l1M0FP549XFlFkQM5lmNiUBl44AfNbx4bz61xA8PzLtlYwfmif4JJJW7MPPnjg==",
-      "path": "system.runtime.serialization.json/4.0.2",
-      "hashPath": "system.runtime.serialization.json.4.0.2.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
     "System.Security.AccessControl/6.0.0": {
       "type": "package",
       "serviceable": true,
@@ -6123,12 +6212,12 @@
       "path": "system.security.accesscontrol/6.0.0",
       "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.Algorithms/4.3.1": {
+    "System.Security.Cryptography.Algorithms/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DVUblnRfnarrI5olEC2B/OCsJQd0anjVaObQMndHSc43efbc88/RMOlDyg/EyY0ix5ecyZMXS8zMksb5ukebZA==",
-      "path": "system.security.cryptography.algorithms/4.3.1",
-      "hashPath": "system.security.cryptography.algorithms.4.3.1.nupkg.sha512"
+      "sha512": "sha512-W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+      "path": "system.security.cryptography.algorithms/4.3.0",
+      "hashPath": "system.security.cryptography.algorithms.4.3.0.nupkg.sha512"
     },
     "System.Security.Cryptography.Cng/5.0.0": {
       "type": "package",
@@ -6172,12 +6261,19 @@
       "path": "system.security.cryptography.protecteddata/8.0.0",
       "hashPath": "system.security.cryptography.protecteddata.8.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.X509Certificates/4.3.2": {
+    "System.Security.Cryptography.X509Certificates/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uwlfOnvJd7rXRvP3aV126Q9XebIIEGEaZ245Rd5/ZwOg7U7AU+AmpE0vRh2F0DFjfOTuk7MAexv4nYiNP/RYnQ==",
-      "path": "system.security.cryptography.x509certificates/4.3.2",
-      "hashPath": "system.security.cryptography.x509certificates.4.3.2.nupkg.sha512"
+      "sha512": "sha512-t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+      "path": "system.security.cryptography.x509certificates/4.3.0",
+      "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Permissions/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dkOV6YYVBnYRa15/yv004eCGRBVADXw8qRbbNiCn/XpdJSUXkkUeIvdvFHkvnko4CdKMqG8yRHC4ox83LSlMsQ==",
+      "path": "system.security.permissions/4.7.0",
+      "hashPath": "system.security.permissions.4.7.0.nupkg.sha512"
     },
     "System.Security.Principal.Windows/5.0.0": {
       "type": "package",
@@ -6214,12 +6310,12 @@
       "path": "system.text.encodings.web/8.0.0",
       "hashPath": "system.text.encodings.web.8.0.0.nupkg.sha512"
     },
-    "System.Text.Json/8.0.1": {
+    "System.Text.Json/8.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
-      "path": "system.text.json/8.0.1",
-      "hashPath": "system.text.json.8.0.1.nupkg.sha512"
+      "sha512": "sha512-bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
+      "path": "system.text.json/8.0.4",
+      "hashPath": "system.text.json.8.0.4.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",
@@ -6235,12 +6331,12 @@
       "path": "system.threading/4.3.0",
       "hashPath": "system.threading.4.3.0.nupkg.sha512"
     },
-    "System.Threading.Channels/4.7.1": {
+    "System.Threading.Channels/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6akRtHK/wab3246t4p5v3HQrtQk8LboOt5T4dtpNgsp3zvDeM4/Gx8V12t0h+c/W9/enUrilk8n6EQqdQorZAA==",
-      "path": "system.threading.channels/4.7.1",
-      "hashPath": "system.threading.channels.4.7.1.nupkg.sha512"
+      "sha512": "sha512-TY8/9+tI0mNaUMgntOxxaq2ndTkdXqLSxvPmas7XEqOlv9lQtB7wLjYGd756lOaO7Dvb5r/WXhluM+0Xe87v5Q==",
+      "path": "system.threading.channels/6.0.0",
+      "hashPath": "system.threading.channels.6.0.0.nupkg.sha512"
     },
     "System.Threading.Tasks/4.3.0": {
       "type": "package",
@@ -6263,19 +6359,19 @@
       "path": "system.threading.tasks.extensions/4.5.4",
       "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
     },
-    "System.Threading.Thread/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
-      "path": "system.threading.thread/4.3.0",
-      "hashPath": "system.threading.thread.4.3.0.nupkg.sha512"
-    },
     "System.Threading.ThreadPool/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-k/+g4b7vjdd4aix83sTgC9VG6oXYKAktSfNIJUNGxPEj7ryEOfzHHhfnmsZvjxawwcD9HyWXKCXmPjX8U4zeSw==",
       "path": "system.threading.threadpool/4.3.0",
       "hashPath": "system.threading.threadpool.4.3.0.nupkg.sha512"
+    },
+    "System.Threading.Timer/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+      "path": "system.threading.timer/4.3.0",
+      "hashPath": "system.threading.timer.4.3.0.nupkg.sha512"
     },
     "System.ValueTuple/4.5.0": {
       "type": "package",
@@ -6284,26 +6380,26 @@
       "path": "system.valuetuple/4.5.0",
       "hashPath": "system.valuetuple.4.5.0.nupkg.sha512"
     },
-    "System.Xml.ReaderWriter/4.0.11": {
+    "System.Windows.Extensions/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
-      "path": "system.xml.readerwriter/4.0.11",
-      "hashPath": "system.xml.readerwriter.4.0.11.nupkg.sha512"
+      "sha512": "sha512-CeWTdRNfRaSh0pm2gDTJFwVaXfTq6Xwv/sA887iwPTneW7oMtMlpvDIO+U60+3GWTB7Aom6oQwv5VZVUhQRdPQ==",
+      "path": "system.windows.extensions/4.7.0",
+      "hashPath": "system.windows.extensions.4.7.0.nupkg.sha512"
     },
-    "System.Xml.XmlDocument/4.0.1": {
+    "System.Xml.ReaderWriter/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2eZu6IP+etFVBBFUFzw2w6J21DqIN5eL9Y8r8JfJWUmV28Z5P0SNU01oCisVHQgHsDhHPnmq2s1hJrJCFZWloQ==",
-      "path": "system.xml.xmldocument/4.0.1",
-      "hashPath": "system.xml.xmldocument.4.0.1.nupkg.sha512"
+      "sha512": "sha512-GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+      "path": "system.xml.readerwriter/4.3.0",
+      "hashPath": "system.xml.readerwriter.4.3.0.nupkg.sha512"
     },
-    "System.Xml.XmlSerializer/4.0.11": {
+    "System.Xml.XDocument/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FrazwwqfIXTfq23mfv4zH+BjqkSFNaNFBtjzu3I9NRmG8EELYyrv/fJnttCIwRMFRR/YKXF1hmsMmMEnl55HGw==",
-      "path": "system.xml.xmlserializer/4.0.11",
-      "hashPath": "system.xml.xmlserializer.4.0.11.nupkg.sha512"
+      "sha512": "sha512-5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+      "path": "system.xml.xdocument/4.3.0",
+      "hashPath": "system.xml.xdocument.4.3.0.nupkg.sha512"
     },
     "Twilio/5.6.3": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -1,40 +1,44 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v6.0/win-x64",
+    "name": ".NETCoreApp,Version=v8.0/win-x64",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v6.0": {},
-    ".NETCoreApp,Version=v6.0/win-x64": {
+    ".NETCoreApp,Version=v8.0": {},
+    ".NETCoreApp,Version=v8.0/win-x64": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "1.5.4",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.0.0-beta423",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.2",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "0.4.2-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.1.54-rc",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.10-Preview",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.3.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.2.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.15.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.2.9-rc",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.11-Preview",
+          "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.31-preview",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.4.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.3.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.16.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.169-preview",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.3.0",
-          "Microsoft.NET.Sdk.Functions": "4.4.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0-beta.4",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
+          "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
         },
@@ -78,9 +82,9 @@
       },
       "Azure.AI.OpenAI/1.0.0-beta.15": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.ClientModel": "1.0.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.ClientModel": "1.1.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.AI.OpenAI.dll": {
@@ -89,21 +93,21 @@
           }
         }
       },
-      "Azure.Core/1.41.0": {
+      "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.ClientModel": "1.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Core.dll": {
-            "assemblyVersion": "1.41.0.0",
-            "fileVersion": "1.4100.24.36109"
+            "assemblyVersion": "1.44.1.0",
+            "fileVersion": "1.4400.124.50905"
           }
         }
       },
@@ -111,7 +115,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -120,40 +124,39 @@
           }
         }
       },
-      "Azure.Data.Tables/12.8.3": {
+      "Azure.Data.Tables/12.9.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
-            "assemblyVersion": "12.8.3.0",
-            "fileVersion": "12.800.324.10602"
+            "assemblyVersion": "12.9.1.0",
+            "fileVersion": "12.900.124.46702"
           }
         }
       },
-      "Azure.Identity/1.12.0": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.0.0",
-            "fileVersion": "1.1200.24.31701"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -162,82 +165,112 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.9.2": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Threading.Channels": "4.7.1",
+          "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.9.2.0",
-            "fileVersion": "5.900.223.30602"
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.41401"
+          }
+        }
+      },
+      "Azure.Messaging.ServiceBus/7.18.2": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.Memory.Data": "1.0.2"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
-      "Azure.Search.Documents/11.5.1": {
+      "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Channels": "4.7.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.40602"
+          }
+        }
+      },
+      "Azure.Search.Documents/11.6.0": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Search.Documents.dll": {
-            "assemblyVersion": "11.5.1.0",
-            "fileVersion": "11.500.123.57802"
+            "assemblyVersion": "11.6.0.0",
+            "fileVersion": "11.600.24.36703"
           }
         }
       },
-      "Azure.Storage.Blobs/12.21.0": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.36603"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.20.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.20.0.0",
-            "fileVersion": "12.2000.24.36603"
+          "lib/net8.0/Azure.Storage.Common.dll": {
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
       "Azure.Storage.Files.DataLake/12.18.0": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Files.DataLake.dll": {
@@ -246,22 +279,21 @@
           }
         }
       },
-      "Azure.Storage.Queues/12.19.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
-          "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.19.0.0",
-            "fileVersion": "12.1900.24.36603"
+          "lib/net8.0/Azure.Storage.Queues.dll": {
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
       "Castle.Core/5.0.0": {
         "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
+          "System.Diagnostics.EventLog": "8.0.1"
         },
         "runtime": {
           "lib/net6.0/Castle.Core.dll": {
@@ -284,7 +316,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -293,58 +325,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Google.Protobuf": "3.24.3",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Google.Protobuf": "3.28.2",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -359,27 +391,27 @@
           }
         }
       },
-      "Google.Protobuf/3.24.3": {
+      "Google.Protobuf/3.28.2": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.24.3.0",
-            "fileVersion": "3.24.3.0"
+            "assemblyVersion": "3.28.2.0",
+            "fileVersion": "3.28.2.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
+          "Google.Protobuf": "3.28.2",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.49.0"
+          "Grpc.Tools": "2.68.1"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -391,7 +423,7 @@
           "Grpc.Net.ClientFactory": "2.49.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -399,7 +431,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.67.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -414,60 +446,86 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
-        "dependencies": {
-          "System.Memory": "4.5.5"
-        },
+      "Grpc.Core.Api/2.67.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.67.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Grpc.Net.Common": "2.67.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Client.dll": {
+          "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.ClientFactory.dll": {
+          "lib/net7.0/Grpc.Net.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.67.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Common.dll": {
+          "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "Grpc.Tools/2.68.1": {},
+      "K4os.Compression.LZ4/1.3.5": {
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Compression.LZ4.Streams/1.3.5": {
+        "dependencies": {
+          "K4os.Compression.LZ4": "1.3.5",
+          "K4os.Hash.xxHash": "1.0.8",
+          "System.IO.Pipelines": "6.0.3"
+        },
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.Streams.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Hash.xxHash/1.0.8": {
+        "runtime": {
+          "lib/net6.0/K4os.Hash.xxHash.dll": {
+            "assemblyVersion": "1.0.8.0",
+            "fileVersion": "1.0.8.0"
+          }
+        }
+      },
+      "librdkafka.redist/2.4.0": {
         "native": {
-          "runtimes/win-x64/native/libcrypto-1_1-x64.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x64/native/libcrypto-3-x64.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/libcurl.dll": {
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x64/native/librdkafka.dll": {
             "fileVersion": "0.0.0.0"
@@ -475,29 +533,34 @@
           "runtimes/win-x64/native/librdkafkacpp.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x64/native/libssl-1_1-x64.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x64/native/libssl-3-x64.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x64/native/zlib1.dll": {
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x64/native/zstd.dll": {
             "fileVersion": "1.5.2.0"
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -509,6 +572,90 @@
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
             "assemblyVersion": "2.22.0.997",
             "fileVersion": "2.22.0.997"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.AspNetCore/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.EventCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Microsoft.AspNetCore.Hosting": "2.2.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.21.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.ApplicationInsights.AspNetCore.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.DependencyCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.EventCounterCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.EventCounterCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.Extensions.Caching.Memory": "1.0.0",
+          "System.Diagnostics.PerformanceCounter": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.PerfCounterCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.WindowsServer.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.ServerTelemetryChannel.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
           }
         }
       },
@@ -527,8 +674,8 @@
       "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
@@ -540,8 +687,8 @@
       },
       "Microsoft.AspNetCore.Authorization/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
@@ -553,7 +700,7 @@
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         }
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
@@ -561,14 +708,14 @@
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Configuration": "2.2.0",
+          "Microsoft.Extensions.Configuration": "3.1.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reflection.Metadata": "1.6.0"
         }
@@ -583,7 +730,7 @@
       "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
         }
       },
       "Microsoft.AspNetCore.Http/2.2.2": {
@@ -591,7 +738,7 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0"
         }
       },
@@ -601,36 +748,17 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Buffers": "4.5.1"
         }
       },
       "Microsoft.AspNetCore.Http.Features/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
@@ -662,10 +790,10 @@
           "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -692,16 +820,16 @@
       },
       "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing/2.2.2": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
@@ -714,7 +842,7 @@
           "Microsoft.AspNetCore.Hosting": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Https": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1"
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
@@ -724,8 +852,8 @@
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
@@ -757,38 +885,11 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.WebUtilities/2.2.0": {
@@ -805,46 +906,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "8.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -859,47 +962,50 @@
             "fileVersion": "2.14.0.0"
           },
           "runtimes/win-x64/native/msvcp140.dll": {
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140.dll": {
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           },
           "runtimes/win-x64/native/vcruntime140_1.dll": {
-            "fileVersion": "14.38.33133.0"
+            "fileVersion": "14.39.33521.0"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.1.0.0",
-            "fileVersion": "0.1.6.6114"
+            "assemblyVersion": "0.2.0.0",
+            "fileVersion": "0.2.0.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
         "dependencies": {
-          "Azure.Data.Tables": "12.8.3",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "WindowsAzure.Storage": "9.3.1"
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "1.17.0.0",
-            "fileVersion": "1.17.4.42221"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.1.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/2.17.1": {
+      "Microsoft.Azure.DurableTask.Core/3.0.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reactive.Compatibility": "4.4.1",
@@ -907,80 +1013,47 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "2.17.0.0",
-            "fileVersion": "2.17.1.6114"
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.42734"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.EventHubs.Processor": "4.3.2",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Messaging.EventHubs.Processor": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Threading.Channels": "4.7.1"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
-        "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.DurableTask.Netherite": "1.5.4",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.AzureFunctions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Azure.Services.AppAuthentication": "1.0.3",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.EventHubs": "4.3.2",
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.Processor.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
+          "lib/netstandard2.0/DurableTask.Netherite.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
+          }
+        }
+      },
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
+        },
+        "runtime": {
+          "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
       "Microsoft.Azure.Functions.Extensions/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
@@ -991,7 +1064,7 @@
       },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/0.17.0-preview01": {
         "dependencies": {
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -1000,250 +1073,134 @@
           }
         }
       },
-      "Microsoft.Azure.KeyVault.Core/3.0.3": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.0.0-beta423": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1"
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
+          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "System.Drawing.Common": "4.7.3",
+          "System.Net.Http": "4.3.4",
+          "System.Net.ServerSentEvents": "10.0.0-preview.1.25080.5",
+          "System.Text.RegularExpressions": "4.3.1"
         },
         "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.KeyVault.Core.dll": {
-            "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.3.0"
+          "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1",
           "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
           "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
           "System.Security.Principal.Windows": "5.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.Msal.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Data/12.2.3": {
+      "Microsoft.Azure.Kusto.Data/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Data.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+      "Microsoft.Azure.Kusto.Ingest/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Ingest.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.14.2",
-          "NETStandard.Library": "2.0.1",
-          "System.Diagnostics.Process": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.Services.AppAuthentication.dll": {
-            "assemblyVersion": "1.0.3.0",
-            "fileVersion": "1.0.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.SignalR/1.25.2": {
-        "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Common.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
-          "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "3.1.32",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -1261,8 +1218,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1272,69 +1229,44 @@
           }
         }
       },
-      "Microsoft.Azure.Storage.Blob/11.2.3": {
+      "Microsoft.Azure.WebJobs/3.0.41": {
         "dependencies": {
-          "Microsoft.Azure.Storage.Common": "11.2.3",
-          "NETStandard.Library": "2.0.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Blob.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.Storage.Common/11.2.3": {
-        "dependencies": {
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "NETStandard.Library": "2.0.1",
-          "Newtonsoft.Json": "13.0.3"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Common.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.WebJobs/3.0.39": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.39",
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Microsoft.Azure.WebJobs.Core": "3.0.41",
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
-          "Microsoft.Extensions.Configuration.Json": "2.1.0",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
           "Microsoft.Extensions.Hosting": "2.1.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.39": {
+      "Microsoft.Azure.WebJobs.Core/3.0.41": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Host.Storage": "3.0.14",
           "ncrontab.signed": "3.3.0"
         },
@@ -1348,7 +1280,7 @@
       "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/1.0.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -1360,17 +1292,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.0.0",
-            "fileVersion": "4.8.0.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1382,8 +1315,8 @@
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
@@ -1392,50 +1325,68 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.1.6",
-          "Microsoft.Azure.DurableTask.AzureStorage": "1.17.4",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.0.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
-          "Microsoft.DurableTask.Grpc": "1.1.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/netcoreapp3.1/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
-            "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.13.5.0"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
         "dependencies": {
-          "Azure.Messaging.EventGrid": "4.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Grpc.Tools": "2.68.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "Microsoft.DurableTask.AzureManagedBackend": "0.4.2-alpha",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.400.224.38002"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+        "dependencies": {
+          "Azure.Messaging.EventGrid": "4.21.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1444,25 +1395,25 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Azure.Storage.Files.DataLake": "12.18.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           }
         }
       },
@@ -1473,7 +1424,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -1482,97 +1433,118 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
         "dependencies": {
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Kusto.dll": {
-            "assemblyVersion": "1.0.10.0",
-            "fileVersion": "1.0.10.0"
+            "assemblyVersion": "1.0.11.0",
+            "fileVersion": "1.0.11.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
+          "MySql.Data": "8.0.33",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Net.Http": "4.3.4",
+          "System.Runtime.Caching": "8.0.1",
+          "System.Text.Json": "8.0.4",
+          "morelinq": "4.1.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.MySql.dll": {
+            "assemblyVersion": "1.0.31.0",
+            "fileVersion": "1.0.31.0"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
         "dependencies": {
           "Azure.AI.OpenAI": "1.0.0-beta.15",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.0-preview",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.dll": {
-            "assemblyVersion": "0.16.0.0",
-            "fileVersion": "0.16.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
         "dependencies": {
-          "Azure.Search.Documents": "11.5.1",
+          "Azure.Search.Documents": "11.6.0",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.AzureAISearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "MongoDB.Driver": "2.25.0"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "MongoDB.Driver": "2.29.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.CosmosDBSearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.Kusto.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "RabbitMQ.Client": "5.1.2",
           "System.Json": "4.5.0"
         },
@@ -1586,8 +1558,8 @@
       "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1598,121 +1570,119 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
         "dependencies": {
           "Grpc.AspNetCore": "2.49.0",
-          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37"
+          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.39"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.Rpc.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Sendgrid": "9.10.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
-          "Google.Protobuf": "3.24.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.37",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.ServiceBus": "7.18.2",
+          "Google.Protobuf": "3.28.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "MessagePack": "2.5.192",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9123.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.0",
-          "morelinq": "3.4.2"
+          "System.Runtime.Caching": "8.0.1",
+          "morelinq": "4.1.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.169.0",
-            "fileVersion": "3.1.169.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Twilio": "5.6.3"
         },
         "runtime": {
@@ -1722,9 +1692,26 @@
           }
         }
       },
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Azure.Messaging.WebPubSub": "1.4.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebPubSub.Common": "1.4.0",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "Microsoft.IdentityModel.Tokens": "7.6.3"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.24.47903"
+          }
+        }
+      },
       "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "WindowsAzure.Storage": "9.3.1"
         },
         "runtime": {
@@ -1734,28 +1721,31 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
+      "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
         "dependencies": {
-          "Microsoft.CodeAnalysis": "3.3.1",
-          "Microsoft.CodeAnalysis.CSharp": "3.3.1",
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Collections.Immutable": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.14492.0"
+            "fileVersion": "1.0.22000.0"
           }
         }
       },
@@ -1764,11 +1754,24 @@
           "System.Runtime.Loader": "4.3.0"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+      "Microsoft.Azure.WebPubSub.Common/1.4.0": {
+        "dependencies": {
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Encodings.Web": "8.0.0",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.47402"
+          }
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces/10.0.0-preview.2.25163.2": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "assemblyVersion": "10.0.0.0",
+            "fileVersion": "10.0.25.16302"
           }
         }
       },
@@ -1780,383 +1783,53 @@
           }
         }
       },
-      "Microsoft.CodeAnalysis/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.3.1",
-          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "3.3.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.Analyzers/2.9.4": {},
-      "Microsoft.CodeAnalysis.Common/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "2.9.4",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Memory": "4.5.5",
-          "System.Reflection.Metadata": "1.6.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encoding.CodePages": "4.5.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.3.1",
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.VisualBasic/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.VisualBasic.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.VisualBasic.Workspaces/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Microsoft.CodeAnalysis.VisualBasic": "3.3.1",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.Workspaces.Common/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "System.Composition": "1.0.31"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
       "Microsoft.CSharp/4.7.0": {},
-      "Microsoft.Data.SqlClient/5.2.1": {
+      "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
-          "runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll": {
+          "runtimes/win/lib/net8.0/Microsoft.Data.SqlClient.dll": {
             "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
+            "fileVersion": "5.22.24240.6"
           }
         },
         "resources": {
-          "lib/net6.0/de/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/de/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "de"
           },
-          "lib/net6.0/es/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/es/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "es"
           },
-          "lib/net6.0/fr/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/fr/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "fr"
           },
-          "lib/net6.0/it/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/it/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "it"
           },
-          "lib/net6.0/ja/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ja/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ja"
           },
-          "lib/net6.0/ko/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ko/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ko"
           },
-          "lib/net6.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "pt-BR"
           },
-          "lib/net6.0/ru/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ru/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ru"
           },
-          "lib/net6.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hans"
           },
-          "lib/net6.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hant"
           }
         }
@@ -2170,14 +1843,14 @@
       },
       "Microsoft.DotNet.PlatformAbstractions/2.1.0": {
         "dependencies": {
-          "System.AppContext": "4.1.0",
+          "System.AppContext": "4.3.0",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.IO.FileSystem": "4.3.0",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
         },
         "runtime": {
           "lib/netstandard1.3/Microsoft.DotNet.PlatformAbstractions.dll": {
@@ -2186,101 +1859,133 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.1.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.1.0.0",
-            "fileVersion": "1.1.0.4758"
+          "lib/net6.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Data.SqlClient": "5.2.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.IdentityModel.Tokens.Jwt": "7.5.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.DurableTask.SqlServer": "1.3.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.4": {
+      "Microsoft.Extensions.Azure/1.11.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.4.0",
-            "fileVersion": "1.700.424.31303"
+          "lib/net8.0/Microsoft.Extensions.Azure.dll": {
+            "assemblyVersion": "1.11.0.0",
+            "fileVersion": "1.1100.25.16402"
           }
         }
       },
-      "Microsoft.Extensions.Configuration/2.2.0": {
+      "Microsoft.Extensions.Caching.Abstractions/1.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Primitives": "7.0.0",
+          "System.Collections": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
+      "Microsoft.Extensions.Caching.Memory/1.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "1.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0",
+          "System.Linq": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration/3.1.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
-      "Microsoft.Extensions.Configuration.FileExtensions/2.2.0": {
+      "Microsoft.Extensions.Configuration.FileExtensions/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Json/2.1.0": {
+      "Microsoft.Extensions.Configuration.Json/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection/6.0.0": {
+      "Microsoft.Extensions.DependencyInjection/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -2296,137 +2001,128 @@
           }
         }
       },
-      "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
+      "Microsoft.Extensions.FileProviders.Abstractions/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
-      "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
+      "Microsoft.Extensions.FileProviders.Physical/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileSystemGlobbing": "2.2.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "3.1.0"
         }
       },
-      "Microsoft.Extensions.FileSystemGlobbing/2.2.0": {},
+      "Microsoft.Extensions.FileSystemGlobbing/3.1.0": {},
       "Microsoft.Extensions.Hosting/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0"
+          "Microsoft.Extensions.Logging": "7.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Http/3.1.32": {
+      "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging/6.0.0": {
+      "Microsoft.Extensions.Logging/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.Logging.Abstractions/7.0.0": {},
+      "Microsoft.Extensions.Logging.ApplicationInsights/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.Extensions.Logging": "7.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.ApplicationInsights.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
       "Microsoft.Extensions.Logging.Configuration/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "2.1.0"
         }
       },
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
-      "Microsoft.Extensions.Options/6.0.0": {
+      "Microsoft.Extensions.Options/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Primitives/6.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
+      "Microsoft.Extensions.Primitives/7.0.0": {},
       "Microsoft.FASTER.Core/2.6.5": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "System.Interactive.Async": "6.0.1",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/FASTER.core.dll": {
+          "lib/net7.0/FASTER.core.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Identity.Client/4.61.3": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "7.6.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
       "Microsoft.IdentityModel.Abstractions/7.6.3": {
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Abstractions.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Abstractions.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
-          }
-        }
-      },
-      "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-        "dependencies": {
-          "NETStandard.Library": "2.0.1",
-          "System.Runtime.Serialization.Json": "4.0.2",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
-          },
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
           }
         }
       },
@@ -2435,7 +2131,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2446,7 +2142,7 @@
           "Microsoft.IdentityModel.Abstractions": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Logging.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Logging.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2481,7 +2177,7 @@
           "Microsoft.IdentityModel.Logging": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Tokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Tokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2497,14 +2193,14 @@
       },
       "Microsoft.Net.Http.Headers/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1"
         }
       },
-      "Microsoft.NET.Sdk.Functions/4.4.0": {
+      "Microsoft.NET.Sdk.Functions/4.6.0": {
         "dependencies": {
           "Microsoft.Azure.Functions.Analyzers": "1.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "3.0.6",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator": "4.0.1",
@@ -2514,7 +2210,15 @@
           "System.Text.RegularExpressions": "4.3.1"
         }
       },
-      "Microsoft.NETCore.Platforms/2.1.2": {},
+      "Microsoft.NET.StringTools/17.6.3": {
+        "runtime": {
+          "lib/net7.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
+        }
+      },
+      "Microsoft.NETCore.Platforms/3.1.9": {},
       "Microsoft.NETCore.Targets/1.1.3": {},
       "Microsoft.SqlServer.Server/1.0.0": {
         "runtime": {
@@ -2524,11 +2228,11 @@
           }
         }
       },
-      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
         "runtime": {
           "lib/net6.0/Microsoft.SqlServer.TransactSql.ScriptDom.dll": {
             "assemblyVersion": "16.1.0.0",
-            "fileVersion": "16.1.9123.0"
+            "fileVersion": "16.1.9135.0"
           }
         },
         "resources": {
@@ -2575,7 +2279,7 @@
       },
       "Microsoft.Win32.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.win.Microsoft.Win32.Primitives": "4.3.0"
@@ -2587,39 +2291,50 @@
           "System.Security.Principal.Windows": "5.0.0"
         }
       },
-      "MongoDB.Bson/2.25.0": {
+      "Microsoft.Win32.SystemEvents/4.7.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp3.0/Microsoft.Win32.SystemEvents.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "MongoDB.Bson/2.29.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Bson.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver/2.25.0": {
+      "MongoDB.Driver/2.29.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Driver.Core": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Driver.Core": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver.Core/2.25.0": {
+      "MongoDB.Driver.Core/2.29.0": {
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.100.14",
           "DnsClient": "1.6.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0",
           "SharpCompress": "0.30.1",
           "Snappier": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -2627,16 +2342,16 @@
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.Core.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Libmongocrypt/1.8.2": {
+      "MongoDB.Libmongocrypt/1.12.0": {
         "runtime": {
           "lib/netstandard2.1/MongoDB.Libmongocrypt.dll": {
-            "assemblyVersion": "1.8.2.0",
-            "fileVersion": "1.8.2.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         },
         "native": {
@@ -2645,11 +2360,49 @@
           }
         }
       },
-      "morelinq/3.4.2": {
+      "morelinq/4.1.0": {
         "runtime": {
-          "lib/net6.0/MoreLinq.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.4.2.0"
+          "lib/net8.0/MoreLinq.dll": {
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
+          }
+        }
+      },
+      "MySql.Data/8.0.33": {
+        "dependencies": {
+          "Google.Protobuf": "3.28.2",
+          "K4os.Compression.LZ4.Streams": "1.3.5",
+          "Portable.BouncyCastle": "1.9.0",
+          "System.Buffers": "4.5.1",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Runtime.Loader": "4.3.0",
+          "System.Security.Permissions": "4.7.0",
+          "System.Text.Encoding.CodePages": "4.4.0",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/net7.0/MySql.Data.dll": {
+            "assemblyVersion": "8.0.33.0",
+            "fileVersion": "8.0.33.0"
+          }
+        },
+        "native": {
+          "runtimes/win-x64/native/comerr64.dll": {
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/gssapi64.dll": {
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/k5sprt64.dll": {
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/krb5_64.dll": {
+            "fileVersion": "4.1.0.0"
+          },
+          "runtimes/win-x64/native/krbcc64.dll": {
+            "fileVersion": "4.1.0.0"
           }
         }
       },
@@ -2669,9 +2422,52 @@
           }
         }
       },
-      "NETStandard.Library/2.0.1": {
+      "NETStandard.Library/1.6.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2"
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.Compression.ZipFile": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Net.Http": "4.3.4",
+          "System.Net.Primitives": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.1",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Timer": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0"
         }
       },
       "Newtonsoft.Json/13.0.3": {
@@ -2684,7 +2480,7 @@
       },
       "Newtonsoft.Json.Bson/1.0.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -2696,12 +2492,20 @@
       },
       "Pipelines.Sockets.Unofficial/2.2.8": {
         "dependencies": {
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         },
         "runtime": {
           "lib/net5.0/Pipelines.Sockets.Unofficial.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "2.2.8.1080"
+          }
+        }
+      },
+      "Portable.BouncyCastle/1.9.0": {
+        "runtime": {
+          "lib/netstandard2.0/BouncyCastle.Crypto.dll": {
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.1"
           }
         }
       },
@@ -2737,24 +2541,31 @@
       "runtime.any.System.Text.Encoding/4.3.0": {},
       "runtime.any.System.Text.Encoding.Extensions/4.3.0": {},
       "runtime.any.System.Threading.Tasks/4.3.0": {},
+      "runtime.any.System.Threading.Timer/4.3.0": {},
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.native.System/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
+      "runtime.native.System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "runtime.native.System.Net.Http/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+      "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
         "dependencies": {
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.1"
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
         }
       },
       "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
@@ -2773,7 +2584,7 @@
       },
       "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
-      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {},
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {},
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
@@ -2783,6 +2594,19 @@
         "dependencies": {
           "System.Runtime": "4.3.1",
           "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.win.System.Console/4.3.1": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.3.0": {},
@@ -2854,15 +2678,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2884,7 +2708,7 @@
       },
       "StackExchange.Redis/2.7.4": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
         },
         "runtime": {
@@ -2894,21 +2718,29 @@
           }
         }
       },
-      "System.AppContext/4.1.0": {
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
+      "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
         }
       },
       "System.Buffers/4.5.1": {},
-      "System.ClientModel/1.0.0": {
+      "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.24.5302"
+            "assemblyVersion": "1.1.0.0",
+            "fileVersion": "1.100.24.46703"
           }
         }
       },
@@ -2922,7 +2754,7 @@
       },
       "System.Collections/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Collections": "4.3.0"
@@ -2942,17 +2774,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Collections.Immutable.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -2975,173 +2797,62 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Composition/1.0.31": {
+      "System.Configuration.ConfigurationManager/8.0.1": {
         "dependencies": {
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Convention": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Composition.TypedParts": "1.0.31"
-        }
-      },
-      "System.Composition.AttributedModel/1.0.31": {
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.1"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.AttributedModel.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Convention/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Threading": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Convention.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Hosting/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Threading": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Hosting.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Runtime/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Runtime.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.TypedParts/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.TypedParts.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Configuration.ConfigurationManager/8.0.0": {
-        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
-          "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
+          "lib/net8.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
           }
+        }
+      },
+      "System.Console/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.win.System.Console": "4.3.1"
         }
       },
       "System.Diagnostics.Debug/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.win.System.Diagnostics.Debug": "4.3.0"
         }
       },
-      "System.Diagnostics.DiagnosticSource/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
+      "System.Diagnostics.DiagnosticSource/8.0.0": {},
+      "System.Diagnostics.EventLog/8.0.1": {
         "runtime": {
-          "lib/net6.0/System.Diagnostics.DiagnosticSource.dll": {
+          "runtimes/win/lib/net8.0/System.Diagnostics.EventLog.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
-      "System.Diagnostics.EventLog/6.0.0": {},
-      "System.Diagnostics.Process/4.3.0": {
+      "System.Diagnostics.PerformanceCounter/4.7.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.Win32.Registry": "5.0.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Thread": "4.3.0",
-          "System.Threading.ThreadPool": "4.3.0",
-          "runtime.native.System": "4.3.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Principal.Windows": "5.0.0"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp2.0/System.Diagnostics.PerformanceCounter.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
         }
       },
       "System.Diagnostics.Tools/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Diagnostics.Tools": "4.3.0"
@@ -3149,7 +2860,7 @@
       },
       "System.Diagnostics.TraceSource/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3162,10 +2873,22 @@
       },
       "System.Diagnostics.Tracing/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Diagnostics.Tracing": "4.3.0"
+        }
+      },
+      "System.Drawing.Common/4.7.3": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.Win32.SystemEvents": "4.7.0"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp3.0/System.Drawing.Common.dll": {
+            "assemblyVersion": "4.0.2.3",
+            "fileVersion": "4.700.21.51508"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
@@ -3187,17 +2910,10 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Formats.Asn1/6.0.1": {
-        "runtime": {
-          "lib/net6.0/System.Formats.Asn1.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3224.31407"
-          }
-        }
-      },
+      "System.Formats.Asn1/6.0.1": {},
       "System.Globalization/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Globalization": "4.3.0"
@@ -3205,7 +2921,7 @@
       },
       "System.Globalization.Calendars/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3214,7 +2930,7 @@
       },
       "System.Globalization.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Globalization": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3228,7 +2944,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/System.IdentityModel.Tokens.Jwt.dll": {
+          "lib/net8.0/System.IdentityModel.Tokens.Jwt.dll": {
             "assemblyVersion": "7.5.1.0",
             "fileVersion": "7.5.1.50405"
           }
@@ -3247,7 +2963,7 @@
       },
       "System.IO/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0",
@@ -3255,9 +2971,41 @@
           "runtime.any.System.IO": "4.3.0"
         }
       },
+      "System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "System.Buffers": "4.5.1",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile/4.3.0": {
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
       "System.IO.FileSystem/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.IO.FileSystem.Primitives": "4.3.0",
@@ -3266,6 +3014,12 @@
           "System.Text.Encoding": "4.3.0",
           "System.Threading.Tasks": "4.3.0",
           "runtime.win.System.IO.FileSystem": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.AccessControl/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "System.IO.FileSystem.Primitives/4.3.0": {
@@ -3281,7 +3035,7 @@
           }
         }
       },
-      "System.IO.Pipelines/5.0.1": {},
+      "System.IO.Pipelines/6.0.3": {},
       "System.Json/4.5.0": {
         "runtime": {
           "lib/netstandard2.0/System.Json.dll": {
@@ -3301,7 +3055,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3332,21 +3086,17 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/1.0.2": {
-        "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
-          "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+          "lib/net6.0/System.Memory.Data.dll": {
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
       "System.Net.Http/4.3.4": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
@@ -3361,11 +3111,11 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.OpenSsl": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0",
@@ -3376,7 +3126,7 @@
       },
       "System.Net.NameResolution/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Tracing": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3394,30 +3144,30 @@
       },
       "System.Net.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0",
           "runtime.win.System.Net.Primitives": "4.3.0"
         }
       },
+      "System.Net.ServerSentEvents/10.0.0-preview.1.25080.5": {
+        "runtime": {
+          "lib/net8.0/System.Net.ServerSentEvents.dll": {
+            "assemblyVersion": "10.0.0.0",
+            "fileVersion": "10.0.25.8005"
+          }
+        }
+      },
       "System.Net.Sockets/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Net.Primitives": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Threading.Tasks": "4.3.0",
           "runtime.win.System.Net.Sockets": "4.3.0"
-        }
-      },
-      "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-        "runtime": {
-          "lib/netcoreapp2.1/System.Net.WebSockets.WebSocketProtocol.dll": {
-            "assemblyVersion": "4.0.0.2",
-            "fileVersion": "4.6.27129.4"
-          }
         }
       },
       "System.Numerics.Vectors/4.5.0": {},
@@ -3430,37 +3180,9 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Private.DataContractSerialization/4.1.1": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
-        }
-      },
       "System.Private.Uri/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
@@ -3536,7 +3258,7 @@
       },
       "System.Reflection/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
@@ -3570,7 +3292,7 @@
       },
       "System.Reflection.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3580,7 +3302,7 @@
       "System.Reflection.Metadata/1.6.0": {},
       "System.Reflection.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Reflection.Primitives": "4.3.0"
@@ -3589,7 +3311,7 @@
       "System.Reflection.TypeExtensions/4.7.0": {},
       "System.Resources.ResourceManager/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Reflection": "4.3.0",
@@ -3599,26 +3321,26 @@
       },
       "System.Runtime/4.3.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "runtime.any.System.Runtime": "4.3.0"
         }
       },
-      "System.Runtime.Caching/8.0.0": {
+      "System.Runtime.Caching/8.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1"
         },
         "runtime": {
-          "runtimes/win/lib/net6.0/System.Runtime.Caching.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+          "runtimes/win/lib/net8.0/System.Runtime.Caching.dll": {
+            "assemblyVersion": "8.0.0.1",
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
       "System.Runtime.CompilerServices.Unsafe/6.0.0": {},
       "System.Runtime.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.win.System.Runtime.Extensions": "4.3.0"
@@ -3626,7 +3348,7 @@
       },
       "System.Runtime.Handles/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Runtime.Handles": "4.3.0"
@@ -3634,7 +3356,7 @@
       },
       "System.Runtime.InteropServices/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
@@ -3643,10 +3365,10 @@
           "runtime.any.System.Runtime.InteropServices": "4.3.0"
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
           "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.InteropServices": "4.3.0",
@@ -3669,23 +3391,10 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Json/4.0.2": {
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Private.DataContractSerialization": "4.1.1",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
       "System.Security.AccessControl/6.0.0": {},
-      "System.Security.Cryptography.Algorithms/4.3.1": {
+      "System.Security.Cryptography.Algorithms/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3697,7 +3406,7 @@
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.Apple": "4.3.1",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
@@ -3708,7 +3417,7 @@
       },
       "System.Security.Cryptography.Csp/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3716,7 +3425,7 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3725,7 +3434,7 @@
       },
       "System.Security.Cryptography.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Collections.Concurrent": "4.3.0",
           "System.Linq": "4.3.0",
@@ -3749,7 +3458,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3769,15 +3478,15 @@
       },
       "System.Security.Cryptography.ProtectedData/8.0.0": {
         "runtime": {
-          "lib/net6.0/System.Security.Cryptography.ProtectedData.dll": {
+          "lib/net8.0/System.Security.Cryptography.ProtectedData.dll": {
             "assemblyVersion": "8.0.0.0",
             "fileVersion": "8.0.23.53103"
           }
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.3.2": {
+      "System.Security.Cryptography.X509Certificates/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3791,7 +3500,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Cng": "5.0.0",
           "System.Security.Cryptography.Csp": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
@@ -3804,51 +3513,45 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
+      "System.Security.Permissions/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Windows.Extensions": "4.7.0"
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/System.Security.Permissions.dll": {
+            "assemblyVersion": "4.0.3.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
       "System.Security.Principal.Windows/5.0.0": {},
       "System.Text.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Text.Encoding": "4.3.0"
         }
       },
-      "System.Text.Encoding.CodePages/4.5.1": {
+      "System.Text.Encoding.CodePages/4.4.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.NETCore.Platforms": "3.1.9"
         }
       },
       "System.Text.Encoding.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0",
           "runtime.any.System.Text.Encoding.Extensions": "4.3.0"
         }
       },
-      "System.Text.Encodings.Web/8.0.0": {
+      "System.Text.Encodings.Web/8.0.0": {},
+      "System.Text.Json/8.0.4": {
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Encodings.Web.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
-      "System.Text.Json/8.0.1": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "8.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Json.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.123.58001"
-          }
         }
       },
       "System.Text.RegularExpressions/4.3.1": {
@@ -3862,10 +3565,10 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels/4.7.1": {},
+      "System.Threading.Channels/6.0.0": {},
       "System.Threading.Overlapped/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0"
@@ -3873,7 +3576,7 @@
       },
       "System.Threading.Tasks/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Threading.Tasks": "4.3.0"
@@ -3881,19 +3584,27 @@
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
       "System.Threading.Tasks.Extensions/4.5.4": {},
-      "System.Threading.Thread/4.3.0": {
+      "System.Threading.Timer/4.3.0": {
         "dependencies": {
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Threading.ThreadPool/4.3.0": {
-        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
-          "System.Runtime.Handles": "4.3.0"
+          "runtime.any.System.Threading.Timer": "4.3.0"
         }
       },
       "System.ValueTuple/4.5.0": {},
-      "System.Xml.ReaderWriter/4.0.11": {
+      "System.Windows.Extensions/4.7.0": {
+        "dependencies": {
+          "System.Drawing.Common": "4.7.3"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp3.0/System.Windows.Extensions.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "System.Xml.ReaderWriter/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
@@ -3912,46 +3623,27 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "System.Xml.XmlDocument/4.0.1": {
+      "System.Xml.XDocument/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Extensions": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11"
-        }
-      },
-      "System.Xml.XmlSerializer/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1"
+          "System.Xml.ReaderWriter": "4.3.0"
         }
       },
       "Twilio/5.6.3": {
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "7.6.3",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Specialized": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -3965,7 +3657,7 @@
       },
       "WindowsAzure.Storage/9.3.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -3977,7 +3669,7 @@
       },
       "ZstdSharp.Port/0.7.3": {
         "runtime": {
-          "lib/net6.0/ZstdSharp.dll": {
+          "lib/net7.0/ZstdSharp.dll": {
             "assemblyVersion": "0.7.3.0",
             "fileVersion": "0.7.3.0"
           }
@@ -4027,12 +3719,12 @@
       "path": "azure.ai.openai/1.0.0-beta.15",
       "hashPath": "azure.ai.openai.1.0.0-beta.15.nupkg.sha512"
     },
-    "Azure.Core/1.41.0": {
+    "Azure.Core/1.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7OO8rPCVSvXj2IQET3NkRf8hU2ZDCCvCIUhlrE089qkLNpNfWufJnBwHRKLAOWF3bhKBGJS/9hPBgjJ8kupUIg==",
-      "path": "azure.core/1.41.0",
-      "hashPath": "azure.core.1.41.0.nupkg.sha512"
+      "sha512": "sha512-YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+      "path": "azure.core/1.44.1",
+      "hashPath": "azure.core.1.44.1.nupkg.sha512"
     },
     "Azure.Core.Amqp/1.3.1": {
       "type": "package",
@@ -4041,19 +3733,19 @@
       "path": "azure.core.amqp/1.3.1",
       "hashPath": "azure.core.amqp.1.3.1.nupkg.sha512"
     },
-    "Azure.Data.Tables/12.8.3": {
+    "Azure.Data.Tables/12.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2wAUXLS1ebTnV+qm9qc1z1MZIPC3as2WJt9bEgL08oC1wlT5UhaW78PlYgTld89p/YWCawJycHtBwVx+SWIuLw==",
-      "path": "azure.data.tables/12.8.3",
-      "hashPath": "azure.data.tables.12.8.3.nupkg.sha512"
+      "sha512": "sha512-d5529gg24alnMKbE8Aw7NY3q9dxFvzfhCMW+TtQA7GGIqASFSIh+536p2qdyJNPEQDFYtqfoLqIBlP9IGqgLfA==",
+      "path": "azure.data.tables/12.9.1",
+      "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.0": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
-      "path": "azure.identity/1.12.0",
-      "hashPath": "azure.identity.1.12.0.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -4062,40 +3754,54 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.9.2": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KAC79xzlOUrtQ0mlrPqijznfmlKeraiqavtZ3RfbV+8ukJf9C5fFSZCMSqq9N/2+eUkW3G4wJSchMXAyf+jxow==",
-      "path": "azure.messaging.eventhubs/5.9.2",
-      "hashPath": "azure.messaging.eventhubs.5.9.2.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-c0ROPOBgzQ8PLvhG9YNBaq+zMMXRWCLr1C/oPgJqxQMsGxHRfuxvYWNvxTVYe96caiBaGkDDLAUb3wsIWJaw2w==",
+      "path": "azure.messaging.eventhubs.processor/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Search.Documents/11.5.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Vg+1mtM3LXVYwKQ+DDi7Wd/Rf2Ajo6rl5/7bFPfouUMBe/cNg71TIU62PY/eEtKfUI3Y7wdFXNcgGkpUG+OVnw==",
-      "path": "azure.search.documents/11.5.1",
-      "hashPath": "azure.search.documents.11.5.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.21.0": {
+    "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W1aSEH11crU3CscfuICUPXScTO9nKwSof3YFsdxmbdi+P+JARYzntkGJuZ685gvmyUse7isBNncNlVEjB5LT0g==",
-      "path": "azure.storage.blobs/12.21.0",
-      "hashPath": "azure.storage.blobs.12.21.0.nupkg.sha512"
+      "sha512": "sha512-27PpgpaTtwOXXP08ZKAt612S/D0ZXINPpR2JTPurbuVPy+eHj1RDvoyJPGsZkHXnk9nVNR6zAu45YBf/8llgOw==",
+      "path": "azure.messaging.webpubsub/1.4.0",
+      "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.20.0": {
+    "Azure.Search.Documents/11.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-C0uTY4E1NSGiNf/dlLMQ/d85a2CDazEg4YYtNJOYnLSb8ZXJ5RBPHYGW7a46kN5Xn5Bc9BKMvs8fME285TfEpw==",
-      "path": "azure.storage.common/12.20.0",
-      "hashPath": "azure.storage.common.12.20.0.nupkg.sha512"
+      "sha512": "sha512-M7WLx3ANLPHymfqb4Nwk4EwcWWRiHqdvnxJ7RH857baAbkEZ3FYVCRJmHgxH+ROpYOTVSx30uJzsa573/cdD8A==",
+      "path": "azure.search.documents/11.6.0",
+      "hashPath": "azure.search.documents.11.6.0.nupkg.sha512"
+    },
+    "Azure.Storage.Blobs/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
+    },
+    "Azure.Storage.Common/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
     "Azure.Storage.Files.DataLake/12.18.0": {
       "type": "package",
@@ -4104,12 +3810,12 @@
       "path": "azure.storage.files.datalake/12.18.0",
       "hashPath": "azure.storage.files.datalake.12.18.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.19.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+EXqf4aTyshZDpi/DBgffEX0CJMbvs9fHTZX4EMPBPc4WHyXCNs2oKelJes1pdHLRwTUVJ3jGdK1kU/IB5lJJw==",
-      "path": "azure.storage.queues/12.19.0",
-      "hashPath": "azure.storage.queues.12.19.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -4132,33 +3838,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4167,12 +3873,12 @@
       "path": "dnsclient/1.6.1",
       "hashPath": "dnsclient.1.6.1.nupkg.sha512"
     },
-    "Google.Protobuf/3.24.3": {
+    "Google.Protobuf/3.28.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HX8KHRTJPUcC4KOvEobKBNlMpHGYmK+3X73xPq+OUE2M5dLYvpGhp9qQQWt2jASgTUbxI1yHaGeBqFYiECBupw==",
-      "path": "google.protobuf/3.24.3",
-      "hashPath": "google.protobuf.3.24.3.nupkg.sha512"
+      "sha512": "sha512-Z86ZKAB+v1B/m0LTM+EVamvZlYw/g3VND3/Gs4M/+aDIxa2JE9YPKjDxTpf0gv2sh26hrve3eI03brxBmzn92g==",
+      "path": "google.protobuf/3.28.2",
+      "hashPath": "google.protobuf.3.28.2.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -4202,19 +3908,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-cL1/2f8kc8lsAGNdfCU25deedXVehhLA6GXKLLN4hAWx16XN7BmjYn3gFU+FBpir5yJynvDTHEypr3Tl0j7x/Q==",
+      "path": "grpc.core.api/2.67.0",
+      "hashPath": "grpc.core.api.2.67.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-ofTjJQfegWkVlk5R4k/LlwpcucpsBzntygd4iAeuKd/eLMkmBWoXN+xcjYJ5IibAahRpIJU461jABZvT6E9dwA==",
+      "path": "grpc.net.client/2.67.0",
+      "hashPath": "grpc.net.client.2.67.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4223,33 +3929,61 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-gazn1cD2Eol0/W5ZJRV4PYbNrxJ9oMs8pGYux5S9E4MymClvl7aqYSmpqgmWAUWvziRqK9K+yt3cjCMfQ3x/5A==",
+      "path": "grpc.net.common/2.67.0",
+      "hashPath": "grpc.net.common.2.67.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.49.0": {
+    "Grpc.Tools/2.68.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fvA8M6m+cKR5cCwVfKNyUtC8/immoNiNGXW8rwLmwb4y4XRFtQJyN9dmGCJNh1mt0cb9LjSSiAZwmSfMgmE2Ng==",
-      "path": "grpc.tools/2.49.0",
-      "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
+      "sha512": "sha512-BZ96s7ijKAhJoRpIK+pqCeLaGaSwyc5/CAZFwgCcBuAnkU2naYvH0P6qnYCkl0pWDY/JBOnE2RvX9IvRX1Yc5Q==",
+      "path": "grpc.tools/2.68.1",
+      "hashPath": "grpc.tools.2.68.1.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "K4os.Compression.LZ4/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-TS4mqlT0X1OlnvOGNfl02QdVUhuqgWuCnn7UxupIa7C9Pb6qlQ5yZA2sPhRh0OSmVULaQU64KV4wJuu//UyVQQ==",
+      "path": "k4os.compression.lz4/1.3.5",
+      "hashPath": "k4os.compression.lz4.1.3.5.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "K4os.Compression.LZ4.Streams/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-M0NufZI8ym3mm6F6HMSPz1jw7TJGdY74fjAtbIXATmnAva/8xLz50eQZJI9tf9mMeHUaFDg76N1BmEh8GR5zeA==",
+      "path": "k4os.compression.lz4.streams/1.3.5",
+      "hashPath": "k4os.compression.lz4.streams.1.3.5.nupkg.sha512"
+    },
+    "K4os.Hash.xxHash/1.0.8": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Wp2F7BamQ2Q/7Hk834nV9vRQapgcr8kgv9Jvfm8J3D0IhDqZMMl+a2yxUq5ltJitvXvQfB8W6K4F4fCbw/P6YQ==",
+      "path": "k4os.hash.xxhash/1.0.8",
+      "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
+    },
+    "librdkafka.redist/2.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+    },
+    "MessagePack/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -4257,6 +3991,48 @@
       "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
       "path": "microsoft.applicationinsights/2.22.0",
       "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.AspNetCore/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-d+7MB4YdUMc9Mtq2u6C7TritzC0eKfHkhGmlnNckDDQiOQuk9IHMPxUmPBRMm/tn+db8fI/BYno9jGxLhI+SZw==",
+      "path": "microsoft.applicationinsights.aspnetcore/2.21.0",
+      "hashPath": "microsoft.applicationinsights.aspnetcore.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.DependencyCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+      "path": "microsoft.applicationinsights.dependencycollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.dependencycollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.EventCounterCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MfF9IKxx9UhaYHVFQ1VKw0LYvBhkjZtPNUmCTYlGws0N7D2EaupmeIj/EWalqP47sQRedR9+VzARsONcwH8OCA==",
+      "path": "microsoft.applicationinsights.eventcountercollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.eventcountercollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-RcckSVkfu+NkDie6/HyM6AVLHmTMVZrUrYnDeJdvRByOc2a+DqTM6KXMtsTHW/5+K7DT9QK5ZrZdi0YbBW8PVA==",
+      "path": "microsoft.applicationinsights.perfcountercollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.perfcountercollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Xbhss7dqbKyE5PENm1lRA9oxzhKEouKGMzgNqJ9xTHPZiogDwKVMK02qdbVhvaXKf9zG8RvvIpM5tnGR5o+Onw==",
+      "path": "microsoft.applicationinsights.windowsserver/2.21.0",
+      "hashPath": "microsoft.applicationinsights.windowsserver.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7D4oq+9YyagEPx+0kNNOXdG6c7IDM/2d+637nAYKFqdWhNN0IqHZEed0DuG28waj7hBSLM9lBO+B8qQqgfE4rw==",
+      "path": "microsoft.applicationinsights.windowsserver.telemetrychannel/2.21.0",
+      "hashPath": "microsoft.applicationinsights.windowsserver.telemetrychannel.2.21.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -4334,20 +4110,6 @@
       "sha512": "sha512-Nxs7Z1q3f1STfLYKJSVXCs1iBl+Ya6E8o4Oy1bCxJ/rNI44E/0f6tbsrVqAWfB7jlnJfyaAtIalBVxPKUPQb4Q==",
       "path": "microsoft.aspnetcore.http.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.2.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-jq2OPhIdCCjkcdZGVd4NMRwDG+A/3yUx2mgR3Bd4z+HXNZMbQzOQnL4hw6YFLsyBjHNnJc17fyeKSyV3DlKLEg==",
-      "path": "microsoft.aspnetcore.http.connections/1.0.15",
-      "hashPath": "microsoft.aspnetcore.http.connections.1.0.15.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-vllvIeTpVzCDs5kPEdICbvcmxLmRAlJUxG6bG55tf29Wfp/ehHQza5P14S1hFl4Ff7kuxJw5VoqSUHD0gaJMKg==",
-      "path": "microsoft.aspnetcore.http.connections.common/1.0.4",
-      "hashPath": "microsoft.aspnetcore.http.connections.common.1.0.4.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
       "type": "package",
@@ -4447,33 +4209,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tzRdyQ0qrMJ5YS0qsXfmhVd/kr25IzLpayoIAvU1yi27wqsqxXVPADDEv0S9PaS7xn6bpMFit8kZw92IICDSWg==",
-      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.1",
-      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.1.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-qTACI0wePgAKCH+YKrMgChyfqJpjwgGZEtSuwBw6TjWLQ66THGasleia/7EZz2t2eAjwWxw8RA/D8ODrBqpj9A==",
+      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -4489,68 +4230,54 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/mBhUF82NJq1mNr2u/7LkP3oDPqtw9jpH8Xo2yYxjwpIX3REK9bvgH1hqcBOLQTZIMGRDqjq6W/pEEzLqH1iZg==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.1.6",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.1.6.nupkg.sha512"
+      "sha512": "sha512-+zLlvMq5Bh1ifxCj27AapYc97muyS3+6y6clIFEBgm0uHAlPDWcvjz06gTp+sLiIMCUWSPRcC3RhzG+V84ZLqQ==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.2.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GxG4vMxZkZGj912TCtDO4RetqSrKprCO+pQAea/f5ouQzN+rB3aqYRV/TC+E8t9+F6dXFlZWFRZZvapj1RIJlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/1.17.4",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.1.17.4.nupkg.sha512"
+      "sha512": "sha512-U8PW868Ao+T4QMnXFBHqJgUefPBePK7SHOH3UpN1apqdsDksGrQuE/n+8jCEcv7EbpjCJSMqdoQKnZTMVbBZKg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.0.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/2.17.1": {
+    "Microsoft.Azure.DurableTask.Core/3.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zKtXC0wxGxOoAGPi5B0TT0f6mqjave2USL/Q7rJOwf+xVg+axiYpU4kad5muvzib4IeikOBfqWqs/xOFOKqR6w==",
-      "path": "microsoft.azure.durabletask.core/2.17.1",
-      "hashPath": "microsoft.azure.durabletask.core.2.17.1.nupkg.sha512"
+      "sha512": "sha512-KqAF02yugJC2hsDBfE4mhjiXAOj4JvKDYs/9GSrxuO/TLXbDY1Nx7meSpFw0E4Jp3kZiIH6UgHOAtHi0mnGCnw==",
+      "path": "microsoft.azure.durabletask.core/3.0.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o+65IPewJLhkuPIvziQxgsan6g3nJ981CWX3xtkHNiSnQqqA9WeUIxjA8ZYYyU1wJLj32CvPmVIyaALK9ejr2Q==",
-      "path": "microsoft.azure.durabletask.netherite/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.1.5.4.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tPosZ6BcmQ8Rg6RDAjGpV71+HzEHPWuPDk+n7GVBtdUTBUasv4ndWcRuW5QYKzLchqUVobLSxrtJLDZRaono/A==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.1.5.4.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-U5PEuRFxw6Jgsu1oc2BwNEFkIVH8PCAWuG8D0zeaF3V/nwKmvsAw3r0N1HR29UHO1WQtCOIl2Vh6yuA0BqxEBw==",
-      "path": "microsoft.azure.eventhubs/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.4.3.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-8zRsNRdPQAWAkASAI3r5SPEHJK/qXdje4KkjZUCNbPXdb+IXcfNno8esV5w34mxiUN59S9mTstZLzWC2VOUqlw==",
-      "path": "microsoft.azure.eventhubs.processor/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.processor.4.3.2.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -4573,68 +4300,61 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.KeyVault.Core/3.0.3": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.0.0-beta423": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-amP4gG7tMficBHRuTaCJpdiPGZyfrLHqYth0D4Yp3lu7Z7XQfEau0/BWNSuvpdZJKWW8M/wmFyI07vTA6EF88A==",
-      "path": "microsoft.azure.keyvault.core/3.0.3",
-      "hashPath": "microsoft.azure.keyvault.core.3.0.3.nupkg.sha512"
+      "sha512": "sha512-KdwGg1+gw3QVXfqa24BS6HT9IftRgnI6afaJBED4ib62XGyQ1hYbv7JBeicXmN8IhwzqLPZgUz/JLQsRCHHShg==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.0.0-beta423",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.0.0-beta423.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RyJsnaSMlwTPLFw8LfEZfff72JwxG+oBNQoI4NM0paAbx5N1Klx0SAAQQvG5oNlIstBgTeImH5sytndbVZIeLg==",
-      "path": "microsoft.azure.kusto.cloud.platform/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.3.nupkg.sha512"
+      "sha512": "sha512-g3gf2XSGf5i3o59ros3dkAuyHh57DvKPIrLe7OBj/3UhD0wbf7pro/RCdBu8urQpeOSdUxXcPbaAueGYXRdW1g==",
+      "path": "microsoft.azure.kusto.cloud.platform/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5owQ2zf16iGrm7hsjNozG0y8dYLQ33VgPeIr3or9xV4pUdWDNMk1QHQkwtl2kKvR7BnSvJvWjiWPJqddbcsv9g==",
-      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.3.nupkg.sha512"
+      "sha512": "sha512-y43GEkrl3eLDSKTl7fJs1JO0V5yc+uNej9J9lJjSPs7Y7Js3/nCsF9vkMSnytNSg1UH7sfENXSSwBQLSe+iAeA==",
+      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Data/12.2.3": {
+    "Microsoft.Azure.Kusto.Data/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-a55PhqueiSMpCAIa96XMUdN1TL73M5rtSsQLzvd8RtAAK7oUhtriy3tLCt0sN643s3w2EdTJEa0GcYHrYQem1w==",
-      "path": "microsoft.azure.kusto.data/12.2.3",
-      "hashPath": "microsoft.azure.kusto.data.12.2.3.nupkg.sha512"
+      "sha512": "sha512-b0yRwFDTRORnyAq7mRUbIFt6K9RsgAHoZrSlGe4CxMDQX0t7+70j//3NHN3vzLQdmQn3SDkTs569wErZbcfrGQ==",
+      "path": "microsoft.azure.kusto.data/12.2.7",
+      "hashPath": "microsoft.azure.kusto.data.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+    "Microsoft.Azure.Kusto.Ingest/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2/5l1EC5Imn7dOHkYY/n0t/06lvqIsYdm6+EuFWcIVSULGN7YNt9qnHzzlLLJHfkwnDEhy0ZP9LMmtT1+97fdQ==",
-      "path": "microsoft.azure.kusto.ingest/12.2.3",
-      "hashPath": "microsoft.azure.kusto.ingest.12.2.3.nupkg.sha512"
+      "sha512": "sha512-x5oTbesbMDVvmN6POpFF0frvh/bnHUtaKynlUxLTivmWUcZq8dw1rgQjnhX+YwfQWEg6fNSlJgpb58BZFV7qug==",
+      "path": "microsoft.azure.kusto.ingest/12.2.7",
+      "hashPath": "microsoft.azure.kusto.ingest.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ywpQaK1klu1IoX4VUf+TBmU4kR71aWNI6O5rEIJU8z28L2xhJhnIm7k2Nf1Zu/PygeuOtt5g0QPCk5+lLltbeQ==",
-      "path": "microsoft.azure.services.appauthentication/1.0.3",
-      "hashPath": "microsoft.azure.services.appauthentication.1.0.3.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -4650,33 +4370,19 @@
       "path": "microsoft.azure.stackexchangeredis/2.0.0",
       "hashPath": "microsoft.azure.stackexchangeredis.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Blob/11.2.3": {
+    "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gM48FyiinUQq+fiUFHf0hGwQaTug4b+zYcYjbZ1KpxC3RkSgOd3twL9Yv9MqpvTkMcexGLwtELYIBhaTQ3zd9A==",
-      "path": "microsoft.azure.storage.blob/11.2.3",
-      "hashPath": "microsoft.azure.storage.blob.11.2.3.nupkg.sha512"
+      "sha512": "sha512-EOigHt+kjrpbg53s8SYn4dlTpZG9IgWPNrdmcdSG8c7U8qKZvcF4BwZtF7ETy3KGir2NtIpJaIc7dUm2+k9/GA==",
+      "path": "microsoft.azure.webjobs/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Common/11.2.3": {
+    "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WqX0ckhXQSUIBEq6wd2xgFz3KPjIONfDdgNg1ClQYxYTvuXQv3g3cnL9DGXCvuxEFZNPk0BJdQeW+uZwGqdDjw==",
-      "path": "microsoft.azure.storage.common/11.2.3",
-      "hashPath": "microsoft.azure.storage.common.11.2.3.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-H/Al/2UOXef8Qqwvsm3Dur9JStz1xvV/UXb0GDys5YPx+qpWDS/U203b/+EUPLeZeuvGTnmcOFtnZzvxMuDamQ==",
-      "path": "microsoft.azure.webjobs/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.3.0.39.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs.Core/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O1RDMe2mBGZI4q4IUns+mxsfCjaMej4FzicMLqvnN5Ti5E3mSo+/kqDbEZzXA/RqnuLIOk+DhvFg/rwKhqEaow==",
-      "path": "microsoft.azure.webjobs.core/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.39.nupkg.sha512"
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
+      "path": "microsoft.azure.webjobs.core/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
       "type": "package",
@@ -4692,12 +4398,12 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WaL+NcxoETT+w7T7hxzSLYhu8wwymlr/9UOXjr0/ZgH2lM+zrOOQIOmB23xh9jUsqIJSm+B9xvgd65Iy1HbVqg==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.0.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4706,12 +4412,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7SPfaLdUnRmN4dajBQEZ4Yei0IzTCL/z7zYkEio0hb3vX9M+XXcWw1exBb3S83yvzOYCFlFYSGDREicYvPxmhg==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/2.13.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.2.13.5.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4720,12 +4426,19 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-P7xUepplf/Tz2YD+Y0qXv0FloYVxPNGs0KuHXphiTB/ZZGUl+QPKiBfV24LhOca6NpcUhyymYtIWUdoWwMGJXA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.2.nupkg.sha512"
+      "sha512": "sha512-uiluTugaUmj+GUhDzkEm+0W18LXLWukVGpwqYqzmxwcYirjsOefl9IMHL3aLazNIF63IyDf8/4/60BbqpEtg7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/0.4.2-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.0.4.2-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -4734,12 +4447,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Lr9MGqAVZdFTmuG8NHdJUIY/SkIrl1thrOmhhdtbQwuFF040pVF6GYyU0UyNisGLax7CaD5ly0MayTV7Psi8sQ==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/0.1.54-rc",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.1.54-rc.nupkg.sha512"
+      "sha512": "sha512-vrgRqOPjkyOF/MDectRoNpbYvTOlsmggG/Qf8ERULdFCXSb1jJKftdNfEot/mz8fBzm2MyGkOP0ilyJzOLyVmQ==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/0.2.9-rc",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.2.9-rc.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -4748,47 +4461,54 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qYD7VIvXk9DQFGtmKkH4wO0SLkoitacfhIcGLO3WUQT7QdZXE15odDsEkWjMhPovoHnkmGCYFjQnAjuL4uKa4Q==",
-      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.10-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.10-preview.nupkg.sha512"
+      "sha512": "sha512-PNNDW4ktUIsTyZWrFdHMrLTQdtAqHyjOibK8sLL6O9qI/emN/VdFFewnmpZfBisLIPnc/5WUKW66KZuyOYA+SQ==",
+      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.11-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.11-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZYBel0IbpiCpryN9u30bBWcFboI8yerraXljCFYJGJZAp5UTcGVjuQmsOfSKUs+6We6yJTFEzFG3CfELjbBNvg==",
-      "path": "microsoft.azure.webjobs.extensions.openai/0.16.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.16.0-alpha.nupkg.sha512"
+      "sha512": "sha512-c6zx4iVHSwV7p2fotzWvxw+Ttrn7gXh/EjVkh2tdQ2g0TgD1E8I08s8j2PoCqww6ke9awIdq3+R/RwG7CwRrRg==",
+      "path": "microsoft.azure.webjobs.extensions.mysql/1.0.31-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.mysql.1.0.31-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3dRX/RvGTzrbPXMVXK0uHZHolzsPr+vhE+vwV+G6h5CRD2tHyf8iJBAmgpO/vOIertM52SZhSDuyCOGfFxOUiQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.3.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.3.0-alpha.nupkg.sha512"
+      "sha512": "sha512-HupnrqbRfod2J9d93SxfjdlNUGM+LwjL9wgYa29Gzfs40gQ2X+bBPnXyLYmYSnEhhlqPV6yToilb+4D9c0uOOg==",
+      "path": "microsoft.azure.webjobs.extensions.openai/0.18.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.18.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vOVQ8OJfd5PZ2zPhs7HPo6lO+xYf+347VOgaIZjQop7TnQQTLqr/2TxcAyIVyS02qH29xsrlmpRrEoOnTE85MQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.2.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.2.0-alpha.nupkg.sha512"
+      "sha512": "sha512-h+zjHJbJgpL0J/h9DEZBxpRXV/0ws/bVwD3V77WaG7219CzhJqSouw1xPZkEISESIEwBF9ZSDaXwq4DQZdqjAw==",
+      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.4.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.4.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JB88Fukr0wMkrGso7eS+7w+jzqJSOi/T7Cbc16BXob5CtDu012fQZ9qm3xVgGBm6yV8MulMc6LAgTSO0kuI2NA==",
-      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.15.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.15.0-alpha.nupkg.sha512"
+      "sha512": "sha512-lyirO2ZWuTTY25dnWuKzcbq0dFn4BlPJ4w21rRvIsKe0RYylV2I45Kfq2yn76Wa6qjLOVc6rg6sTWfbYjKksFA==",
+      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.3.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.3.0-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PyDCInGcaIjzurx5W0fHbcreTR+54JUBMKjFIoLXp9G23InBPxHPNcjYfA2FSa0P1jMJHddDGOdNRKL2ho7s5A==",
+      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.16.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.16.0-alpha.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
       "type": "package",
@@ -4804,61 +4524,61 @@
       "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
       "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6tybd5xeTeBEOSy+CjfmDOkc8Xwwb73nmG/rQdInNiPuPX6hl9vTkHeEQATOeG4Sv7t+oJQZPPdT6ZprypmMaQ==",
-      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.37.nupkg.sha512"
+      "sha512": "sha512-ZTC2+g7/zBqOLvCr9/g0eE08Z68RE8MT5IuC90q2JcM6it4Kqckc3TvR3SilzloDr1/9EOa1wvlxfC57o8bmWA==",
+      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YDOLY05g9RaZHVCLRDlRaQ1LH7e3QvCXTV4N050kK7C3med6taVlrorE3Yy6XMi3AG6CqZlC8LbgnNCIQRIHHw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.169-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.169-preview.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W5VzuQKK41J0HIQr3Eij6ghxtcZOmARjYARRFIB4tDo3eutw8Lr7mKfr5iyEyHAC4MOTSKeIgknY99MaZC7GqA==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h6NX6pd8eX1pkClh4Dxys357aLJCffVAUJMsK1xvjrOlwaityPZRNqMJJ/BCrAXqqn9hqFF1tmcS8DgD2wI7WA==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UAKPp/fm6m2GvYMDjoF8MLudIprgPxuaaaCsBJID49G1ectgFJdp9CuexFWcUx4eHOdTVjqTdomByz9PglsKQw==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.1.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -4867,6 +4587,13 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-J5dRt7gSNkWfdN7kxnt+vP4ActPRYo2+/eLnXK1c/kgiKqqcwS+552EOm2B7dEpEP1d6/eMLeu5Kz3grXSkwjw==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsubforsocketio/1.0.0-beta.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsubforsocketio.1.0.0-beta.4.nupkg.sha512"
+    },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
       "serviceable": true,
@@ -4874,19 +4601,19 @@
       "path": "microsoft.azure.webjobs.host.storage/3.0.14",
       "hashPath": "microsoft.azure.webjobs.host.storage.3.0.14.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KG+ZD6u3KKBBv5bet6r1EeLrP6mNFRoPVWuGUToQTZwpTLlPffouag94JR5IxAJA3DxMQl0A0mV+Qkhg9VorCA==",
-      "path": "microsoft.azure.webjobs.rpc.core/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.37.nupkg.sha512"
+      "sha512": "sha512-sMPOTH6hlAuaiK3EYbf1SfYON8j+Hxl3IL7ZAJX51m9SI5RI0sUR7QPfiwIG0h4Z0BHpfybQXl0so07JbxBqyA==",
+      "path": "microsoft.azure.webjobs.rpc.core/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
+    "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-b2wKKtCrpdLbiQBudEPQ04cFCbwFHw8Bi2c/4CRYS2Qcm1Zs21NO37tvZZM/SGbtS2fxgvQhP/wiySYCKydZaQ==",
-      "path": "microsoft.azure.webjobs.script.abstractions/1.0.0-preview",
-      "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.0-preview.nupkg.sha512"
+      "sha512": "sha512-U/aVn/i0P9MdPsca9TrLmTlKuGOJ8okTdifrBeNviwd80Xbv/+dIM/GGReQXaVVtUM5/SlbUHRAhvA9w0yuEyA==",
+      "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
+      "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator/4.0.1": {
       "type": "package",
@@ -4895,12 +4622,19 @@
       "path": "microsoft.azure.webjobs.script.extensionsmetadatagenerator/4.0.1",
       "hashPath": "microsoft.azure.webjobs.script.extensionsmetadatagenerator.4.0.1.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+    "Microsoft.Azure.WebPubSub.Common/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
-      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
+      "sha512": "sha512-51j7iQ6l5NG8SyieJk2zVKMBff8TzDFnGmIWOIPD2U3V5BMzvyYL0gvzgDe+KRkYPNMxzwPwp+IiYE4kNqBQBA==",
+      "path": "microsoft.azure.webpubsub.common/1.4.0",
+      "hashPath": "microsoft.azure.webpubsub.common.1.4.0.nupkg.sha512"
+    },
+    "Microsoft.Bcl.AsyncInterfaces/10.0.0-preview.2.25163.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hoItOloGu4xv8DfHwnNvsfOU1I0ER6HoTDUq2tqir9noTJoRKMeXb+0qH+rScwQlDZ7vwuyLbQappOUCfBWpJA==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.0-preview.2.25163.2",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.0-preview.2.25163.2.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4909,62 +4643,6 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CodeAnalysis/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-BoPeZD+BFE5x/qu28RnelX7hoCnPDbOZkwymrUnslrZjzj8B155gP/GjrI6m66oUOk2Yh1lxlUs+BRFZOPMBnQ==",
-      "path": "microsoft.codeanalysis/3.3.1",
-      "hashPath": "microsoft.codeanalysis.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Analyzers/2.9.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-alIJhS0VUg/7x5AsHEoovh/wRZ0RfCSS7k5pDSqpRLTyuMTtRgj6OJJPRApRhJHOGYYsLakf1hKeXFoDwKwNkg==",
-      "path": "microsoft.codeanalysis.analyzers/2.9.4",
-      "hashPath": "microsoft.codeanalysis.analyzers.2.9.4.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Common/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-N5yQdGy+M4kimVG7hwCeGTCfgYjK2o5b/Shumkb/rCC+/SAkvP1HUAYK+vxPFS7dLJNtXLRsmPHKj3fnyNWnrw==",
-      "path": "microsoft.codeanalysis.common/3.3.1",
-      "hashPath": "microsoft.codeanalysis.common.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.CSharp/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-WDUIhTHem38H6VJ98x2Ssq0fweakJHnHYl7vbG8ARnsAwLoJKCQCy78EeY1oRrCKG42j0v6JVljKkeqSDA28UA==",
-      "path": "microsoft.codeanalysis.csharp/3.3.1",
-      "hashPath": "microsoft.codeanalysis.csharp.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.CSharp.Workspaces/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-dHs/UyfLgzsVC4FjTi/x+H+yQifgOnpe3rSN8GwkHWjnidePZ3kSqr1JHmFDf5HTQEydYwrwCAfQ0JSzhsEqDA==",
-      "path": "microsoft.codeanalysis.csharp.workspaces/3.3.1",
-      "hashPath": "microsoft.codeanalysis.csharp.workspaces.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.VisualBasic/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-F7fc/G+0ocOYkKSCJ7Y8Q7eAEkAdG5RYODI9FtSl2Hm8zIDBVA3NccCm98gaOvCamLfMHYqeOjpb3yJnnw3m/w==",
-      "path": "microsoft.codeanalysis.visualbasic/3.3.1",
-      "hashPath": "microsoft.codeanalysis.visualbasic.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.VisualBasic.Workspaces/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Oi4AUxMKAYpx7nHNh7jUO8X18JFCzwtIfu/yDzGzOBpo50591AF7EEdv99geAEidGtmJqbzQ6uRk5dEOL+7F/Q==",
-      "path": "microsoft.codeanalysis.visualbasic.workspaces/3.3.1",
-      "hashPath": "microsoft.codeanalysis.visualbasic.workspaces.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Workspaces.Common/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-NfBz3b5hFSbO+7xsCNryD+p8axsIJFTG7qM3jvMTC/MqYrU6b8E1b6JoRj5rJSOBB+pSunk+CMqyGQTOWHeDUg==",
-      "path": "microsoft.codeanalysis.workspaces.common/3.3.1",
-      "hashPath": "microsoft.codeanalysis.workspaces.common.3.3.1.nupkg.sha512"
-    },
     "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
@@ -4972,12 +4650,12 @@
       "path": "microsoft.csharp/4.7.0",
       "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
-    "Microsoft.Data.SqlClient/5.2.1": {
+    "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ojg2XWmih4ubPPtrhRqqXk0SM6wC2ZSTkNNEAlYBhMo4IsRHjLazFc0abzcZCNfw1JyWcqY7vGutWTv8ZaFD9g==",
-      "path": "microsoft.data.sqlclient/5.2.1",
-      "hashPath": "microsoft.data.sqlclient.5.2.1.nupkg.sha512"
+      "sha512": "sha512-mtoeRMh7F/OA536c/Cnh8L4H0uLSKB5kSmoi54oN7Fp0hNJDy22IqyMhaMH4PkDCqI7xL//Fvg9ldtuPHG0h5g==",
+      "path": "microsoft.data.sqlclient/5.2.2",
+      "hashPath": "microsoft.data.sqlclient.5.2.2.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient.SNI.runtime/5.2.0": {
       "type": "package",
@@ -4993,47 +4671,61 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.1.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-O0hn+DEl5Ui4DZOs/yDBTtJHvTd9niT6AW0CGn40VoScStWXYuhBmYiMYQj+fCIn/tWLzw2NqYan8DsVNZX4KA==",
-      "path": "microsoft.durabletask.grpc/1.1.0",
-      "hashPath": "microsoft.durabletask.grpc.1.1.0.nupkg.sha512"
+      "sha512": "sha512-r6m2ZM9F94jS38gbdlkt78YCL3KURRYuerBPZWk0pl2eRTZoPQCLDC9XHxuwnXNv3994z5VofcWtAiVgMl1mPg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/0.4.2-alpha",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.0.4.2-alpha.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-B28jkMmT1d0z5J4IBzBcNyFfTRSQzhaHHvr1JvYN2aaapVvN/zrRD98b5utVCjBX77tdZxKINoKu18GwLdwIKQ==",
-      "path": "microsoft.durabletask.sqlserver/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YLDAWgwwRmz5tN2IJQqVRHIFObPOmkQQ6NR+lMO+CvQiOWiPxdb2wrT1wh9rQ2xp0gYDy+neUuXdIZLDrqdfLQ==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.3.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.7.4": {
+    "Microsoft.Extensions.Azure/1.11.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AVYk0jKLZa1d0r89cNs5pCgPAQMe1uco6g0FIuzyc7eEOccd+TjXGXiRkTNQibf8wYrCd15Qt+xvcKTmGR0sZg==",
-      "path": "microsoft.extensions.azure/1.7.4",
-      "hashPath": "microsoft.extensions.azure.1.7.4.nupkg.sha512"
+      "sha512": "sha512-j6Vb858BgfAbzuv0UQxOvn8jPo8i+96Kkacu1q0RwQi+fAwVljL8WmI0oZX4CCLUsJCs1yzbpJCaS7MYPPCUjw==",
+      "path": "microsoft.extensions.azure/1.11.0",
+      "hashPath": "microsoft.extensions.azure.1.11.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration/2.2.0": {
+    "Microsoft.Extensions.Caching.Abstractions/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nOP8R1mVb/6mZtm2qgAJXn/LFm/2kMjHDAg/QJLFG6CuWYJtaD3p1BwQhufBVvRzL9ceJ/xF0SQ0qsI2GkDQAA==",
-      "path": "microsoft.extensions.configuration/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.2.2.0.nupkg.sha512"
+      "sha512": "sha512-IxlFDVOchL6tdR05bk7EiJvMtvZrVkZXBhkbXqc3GxOHOrHFGcN+92WoWFPeBpdpy8ot/Px5ZdXzt7k+2n1Bdg==",
+      "path": "microsoft.extensions.caching.abstractions/1.0.0",
+      "hashPath": "microsoft.extensions.caching.abstractions.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
+    "Microsoft.Extensions.Caching.Memory/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-65MrmXCziWaQFrI0UHkQbesrX5wTwf9XPjY5yFm/VkgJKFJ5gqvXRoXjIZcf2wLi5ZlwGz/oMYfyURVCWbM5iw==",
-      "path": "microsoft.extensions.configuration.abstractions/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-6+7zTufCnZ+tfrUo7RbIRR3LB0BxwOwxfXuo0IbLyIvgoToGpWuz5wYEDfCYNOvpig9tY8FA0I1uRHYmITMXMQ==",
+      "path": "microsoft.extensions.caching.memory/1.0.0",
+      "hashPath": "microsoft.extensions.caching.memory.1.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+      "path": "microsoft.extensions.configuration/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.3.1.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.Abstractions/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ESz6bVoDQX7sgWdKHF6G9Pq672T8k+19AFb/txDXwdz7MoqaNQj2/in3agm/3qae9V+WvQZH86LLTNVo0it8vQ==",
+      "path": "microsoft.extensions.configuration.abstractions/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration.Binder/2.2.0": {
       "type": "package",
@@ -5049,33 +4741,33 @@
       "path": "microsoft.extensions.configuration.environmentvariables/2.2.0",
       "hashPath": "microsoft.extensions.configuration.environmentvariables.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.FileExtensions/2.2.0": {
+    "Microsoft.Extensions.Configuration.FileExtensions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-H1qCpWBC8Ed4tguTR/qYkbb3F6DI5Su3t8xyFo3/5MzAd8PwPpHzgX8X04KbBxKmk173Pb64x7xMHarczVFQUA==",
-      "path": "microsoft.extensions.configuration.fileextensions/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.fileextensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OjRJIkVxUFiVkr9a39AqVThft9QHoef4But5pDCydJOXJ4D/SkmzuW1tm6J2IXynxj6qfeAz9QTnzQAvOcGvzg==",
+      "path": "microsoft.extensions.configuration.fileextensions/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.fileextensions.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.Json/2.1.0": {
+    "Microsoft.Extensions.Configuration.Json/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9OCdAv7qiRtRlXQnECxW9zINUK8bYPKbNp5x8FQaLZbm/flv7mPvo1muZ1nsKGMZF4uL4Bl6nHw2v1fi3MqQ1Q==",
-      "path": "microsoft.extensions.configuration.json/2.1.0",
-      "hashPath": "microsoft.extensions.configuration.json.2.1.0.nupkg.sha512"
+      "sha512": "sha512-gBpBE1GoaCf1PKYC7u0Bd4mVZ/eR2bnOvn7u8GBXEy3JGar6sC3UVpVfTB9w+biLPtzcukZynBG9uchSBbLTNQ==",
+      "path": "microsoft.extensions.configuration.json/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.json.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
-      "path": "microsoft.extensions.dependencyinjection/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
+      "sha512": "sha512-elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
+      "path": "microsoft.extensions.dependencyinjection/7.0.0",
+      "hashPath": "microsoft.extensions.dependencyinjection.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5084,26 +4776,26 @@
       "path": "microsoft.extensions.dependencymodel/2.1.0",
       "hashPath": "microsoft.extensions.dependencymodel.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
+    "Microsoft.Extensions.FileProviders.Abstractions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EcnaSsPTqx2MGnHrmWOD0ugbuuqVT8iICqSqPzi45V5/MA1LjUNb0kwgcxBGqizV1R+WeBK7/Gw25Jzkyk9bIw==",
-      "path": "microsoft.extensions.fileproviders.abstractions/2.2.0",
-      "hashPath": "microsoft.extensions.fileproviders.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-G3iBMOnn3tETEUvkE9J3a23wQpRkiXZp73zR0XNlicjLFhkeWW1FCaC2bTjrgHhPi2KO6x0BXnHvVuJPIlygBQ==",
+      "path": "microsoft.extensions.fileproviders.abstractions/3.1.0",
+      "hashPath": "microsoft.extensions.fileproviders.abstractions.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
+    "Microsoft.Extensions.FileProviders.Physical/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tbDHZnBJkjYd9NjlRZ9ondDiv1Te3KYCTW2RWpR1B0e1Z8+EnFRo7qNnHkkSCixLdlPZzhjlX24d/PixQ7w2dA==",
-      "path": "microsoft.extensions.fileproviders.physical/2.2.0",
-      "hashPath": "microsoft.extensions.fileproviders.physical.2.2.0.nupkg.sha512"
+      "sha512": "sha512-KsvgrYp2fhNXoD9gqSu8jPK9Sbvaa7SqNtsLqHugJkCwFmgRvdz76z6Jz2tlFlC7wyMTZxwwtRF8WAorRQWTEA==",
+      "path": "microsoft.extensions.fileproviders.physical/3.1.0",
+      "hashPath": "microsoft.extensions.fileproviders.physical.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileSystemGlobbing/2.2.0": {
+    "Microsoft.Extensions.FileSystemGlobbing/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZSsHZp3PyW6vk37tDEdypjgGlNtpJ0EixBMOfUod2Thx7GtwfFSAQXUQx8a8BN8vfWKGGMbp7jPWdoHx/At4wQ==",
-      "path": "microsoft.extensions.filesystemglobbing/2.2.0",
-      "hashPath": "microsoft.extensions.filesystemglobbing.2.2.0.nupkg.sha512"
+      "sha512": "sha512-tK5HZOmVv0kUYkonMjuSsxR0CBk+Rd/69QU3eOMv9FvODGZ2d0SR+7R+n8XIgBcCCoCHJBSsI4GPRaoN3Le4rA==",
+      "path": "microsoft.extensions.filesystemglobbing/3.1.0",
+      "hashPath": "microsoft.extensions.filesystemglobbing.3.1.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Hosting/2.1.0": {
       "type": "package",
@@ -5119,26 +4811,33 @@
       "path": "microsoft.extensions.hosting.abstractions/2.2.0",
       "hashPath": "microsoft.extensions.hosting.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Http/3.1.32": {
+    "Microsoft.Extensions.Http/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0ZNzmbaeKQMQQH8CZ1QVKC26nJ+jOn1AjSrVWKEb9sqX8cgElMbWUtvOXN21BI6IHedS+uhVuzJLQN3Ny46AKw==",
-      "path": "microsoft.extensions.http/3.1.32",
-      "hashPath": "microsoft.extensions.http.3.1.32.nupkg.sha512"
+      "sha512": "sha512-15+pa2G0bAMHbHewaQIdr/y6ag2H3yh4rd9hTXavtWDzQBkvpe2RMqFg8BxDpcQWssmjmBApGPcw93QRz6YcMg==",
+      "path": "microsoft.extensions.http/6.0.0",
+      "hashPath": "microsoft.extensions.http.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging/6.0.0": {
+    "Microsoft.Extensions.Logging/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
-      "path": "microsoft.extensions.logging/6.0.0",
-      "hashPath": "microsoft.extensions.logging.6.0.0.nupkg.sha512"
+      "sha512": "sha512-Nw2muoNrOG5U5qa2ZekXwudUn2BJcD41e65zwmDHb1fQegTX66UokLWZkJRpqSSHXDOWZ5V0iqhbxOEky91atA==",
+      "path": "microsoft.extensions.logging/7.0.0",
+      "hashPath": "microsoft.extensions.logging.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging.Abstractions/6.0.0": {
+    "Microsoft.Extensions.Logging.Abstractions/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA==",
-      "path": "microsoft.extensions.logging.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.logging.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw==",
+      "path": "microsoft.extensions.logging.abstractions/7.0.0",
+      "hashPath": "microsoft.extensions.logging.abstractions.7.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.ApplicationInsights/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
+      "path": "microsoft.extensions.logging.applicationinsights/2.21.0",
+      "hashPath": "microsoft.extensions.logging.applicationinsights.2.21.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Logging.Configuration/2.1.0": {
       "type": "package",
@@ -5154,12 +4853,12 @@
       "path": "microsoft.extensions.objectpool/2.2.0",
       "hashPath": "microsoft.extensions.objectpool.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Options/6.0.0": {
+    "Microsoft.Extensions.Options/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
-      "path": "microsoft.extensions.options/6.0.0",
-      "hashPath": "microsoft.extensions.options.6.0.0.nupkg.sha512"
+      "sha512": "sha512-lP1yBnTTU42cKpMozuafbvNtQ7QcBjr/CcK3bYOGEMH55Fjt+iecXjT6chR7vbgCMqy3PG3aNQSZgo/EuY/9qQ==",
+      "path": "microsoft.extensions.options/7.0.0",
+      "hashPath": "microsoft.extensions.options.7.0.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
       "type": "package",
@@ -5168,12 +4867,12 @@
       "path": "microsoft.extensions.options.configurationextensions/2.1.0",
       "hashPath": "microsoft.extensions.options.configurationextensions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Primitives/6.0.0": {
+    "Microsoft.Extensions.Primitives/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
-      "path": "microsoft.extensions.primitives/6.0.0",
-      "hashPath": "microsoft.extensions.primitives.6.0.0.nupkg.sha512"
+      "sha512": "sha512-um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q==",
+      "path": "microsoft.extensions.primitives/7.0.0",
+      "hashPath": "microsoft.extensions.primitives.7.0.0.nupkg.sha512"
     },
     "Microsoft.FASTER.Core/2.6.5": {
       "type": "package",
@@ -5182,19 +4881,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.61.3": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
-      "path": "microsoft.identity.client/4.61.3",
-      "hashPath": "microsoft.identity.client.4.61.3.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
-      "path": "microsoft.identity.client.extensions.msal/4.61.3",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.61.3.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/7.6.3": {
       "type": "package",
@@ -5202,13 +4901,6 @@
       "sha512": "sha512-EycYJUD/3cZw/b6TioXOpmETjv9OX5/VRk0Tc26x6I+SxxLNxx6ymivwo2dfYeiimqg5d3k88VXnrxc7HJch6Q==",
       "path": "microsoft.identitymodel.abstractions/7.6.3",
       "hashPath": "microsoft.identitymodel.abstractions.7.6.3.nupkg.sha512"
-    },
-    "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TNsJJMiRnkeby1ovThVoV9yFsPWjAdluwOA+Nf0LtSsBVVrKQv8Qp4kYOgyNwMVj+pDwbhXISySk+4HyHVWNZQ==",
-      "path": "microsoft.identitymodel.clients.activedirectory/3.14.2",
-      "hashPath": "microsoft.identitymodel.clients.activedirectory.3.14.2.nupkg.sha512"
     },
     "Microsoft.IdentityModel.JsonWebTokens/7.6.3": {
       "type": "package",
@@ -5259,19 +4951,26 @@
       "path": "microsoft.net.http.headers/2.2.0",
       "hashPath": "microsoft.net.http.headers.2.2.0.nupkg.sha512"
     },
-    "Microsoft.NET.Sdk.Functions/4.4.0": {
+    "Microsoft.NET.Sdk.Functions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
-      "path": "microsoft.net.sdk.functions/4.4.0",
-      "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+      "sha512": "sha512-jDnf2TZ5JcBQY9BhI5hzRsbsu+EzJuz22GzmHmV9iGFFBraD3MaOTsoHxtS5kpd9qX3qCv7I7HuNjUSiH3nTZg==",
+      "path": "microsoft.net.sdk.functions/4.6.0",
+      "hashPath": "microsoft.net.sdk.functions.4.6.0.nupkg.sha512"
     },
-    "Microsoft.NETCore.Platforms/2.1.2": {
+    "Microsoft.NET.StringTools/17.6.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mOJy3M0UN+LUG21dLGMxaWZEP6xYpQEpLuvuEQBaownaX4YuhH6NmNUlN9si+vNkAS6dwJ//N1O4DmLf2CikVg==",
-      "path": "microsoft.netcore.platforms/2.1.2",
-      "hashPath": "microsoft.netcore.platforms.2.1.2.nupkg.sha512"
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
+    },
+    "Microsoft.NETCore.Platforms/3.1.9": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-e+/BrhryHoMojWlbcPJAFcShpk3JYvsMfrmoM26dnvHARWR6vtmGbfHppZcANVqf7DUBDIRxlZXcWg7v/9e1TQ==",
+      "path": "microsoft.netcore.platforms/3.1.9",
+      "hashPath": "microsoft.netcore.platforms.3.1.9.nupkg.sha512"
     },
     "Microsoft.NETCore.Targets/1.1.3": {
       "type": "package",
@@ -5287,12 +4986,12 @@
       "path": "microsoft.sqlserver.server/1.0.0",
       "hashPath": "microsoft.sqlserver.server.1.0.0.nupkg.sha512"
     },
-    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v1I3SV+EqPHBM+RGrB5LyEc2z74t8WRYFmB0BmSc7EMBDUxFgmJ5oentkf9hPkUFfesha9spB0jci4hDtrCE3Q==",
-      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9123.0",
-      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9123.0.nupkg.sha512"
+      "sha512": "sha512-Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g==",
+      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9135.0",
+      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9135.0.nupkg.sha512"
     },
     "Microsoft.Win32.Primitives/4.3.0": {
       "type": "package",
@@ -5308,40 +5007,54 @@
       "path": "microsoft.win32.registry/5.0.0",
       "hashPath": "microsoft.win32.registry.5.0.0.nupkg.sha512"
     },
-    "MongoDB.Bson/2.25.0": {
+    "Microsoft.Win32.SystemEvents/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xQx/qtC2nu9oGiyNqAwfiDpUMweLi0nID677cyKykpwmj5AVMrnd//UwmcmuX95178DeY6rf7cjmA613TQXPiA==",
-      "path": "mongodb.bson/2.25.0",
-      "hashPath": "mongodb.bson.2.25.0.nupkg.sha512"
+      "sha512": "sha512-mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+      "path": "microsoft.win32.systemevents/4.7.0",
+      "hashPath": "microsoft.win32.systemevents.4.7.0.nupkg.sha512"
     },
-    "MongoDB.Driver/2.25.0": {
+    "MongoDB.Bson/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dMqnZTV6MuvoEI4yFtSvKJdAoN6NeyAEvG8aoxnrLIVd7bR84QxLgpsM1nhK17qkOcIx/IrpMIfrvp5iMnYGBg==",
-      "path": "mongodb.driver/2.25.0",
-      "hashPath": "mongodb.driver.2.25.0.nupkg.sha512"
+      "sha512": "sha512-wz8UtxdjnknHRJuMatTRr2QMlh7k9457BRfaDQxl+OiKV01vMzm1K0/jTvQJqORV5eba6HrCAzMJzj7nnt5cag==",
+      "path": "mongodb.bson/2.29.0",
+      "hashPath": "mongodb.bson.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Driver.Core/2.25.0": {
+    "MongoDB.Driver/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oN4nLgO5HQEThTg/zqeoHqaO2+q64DBVb4r7BvhaFb0p0TM9jZKnCKvh1EA8d9E9swIz0CgvMrvL1mPyRCZzag==",
-      "path": "mongodb.driver.core/2.25.0",
-      "hashPath": "mongodb.driver.core.2.25.0.nupkg.sha512"
+      "sha512": "sha512-1IfTnHX8G2SsXIHDz80OVSmcdL95vzzWXGGucR45k7+TUOcWVhiqYcc13ckRXl4NVxn4UTRrrKl+92xvjwWrRA==",
+      "path": "mongodb.driver/2.29.0",
+      "hashPath": "mongodb.driver.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Libmongocrypt/1.8.2": {
+    "MongoDB.Driver.Core/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-z/8JCULSHM1+mzkau0ivIkU9kIn8JEFFSkmYTSaMaWMMHt96JjUtMKuXxeGNGSnHZ5290ZPKIlQfjoWFk2sKog==",
-      "path": "mongodb.libmongocrypt/1.8.2",
-      "hashPath": "mongodb.libmongocrypt.1.8.2.nupkg.sha512"
+      "sha512": "sha512-3M7gdmuLEay4Wc/q4zm/oA5KT4E62SsRBiq3prpT3tGEPkfstr3N3fYRbzYNu8TJgeyS0q5OPe4zI4yi6/GemQ==",
+      "path": "mongodb.driver.core/2.29.0",
+      "hashPath": "mongodb.driver.core.2.29.0.nupkg.sha512"
     },
-    "morelinq/3.4.2": {
+    "MongoDB.Libmongocrypt/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q==",
-      "path": "morelinq/3.4.2",
-      "hashPath": "morelinq.3.4.2.nupkg.sha512"
+      "sha512": "sha512-B1X51jrtNacKvxKoaqWeknYeJfQS5aWf6BmVLT5JZerz3AUXFzv8edPskJYqBc3kLy1J2PWzMqqsnyb9g8FtcA==",
+      "path": "mongodb.libmongocrypt/1.12.0",
+      "hashPath": "mongodb.libmongocrypt.1.12.0.nupkg.sha512"
+    },
+    "morelinq/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tkUeXp5dWNVP47MIhVEsIQk4DaN2oM/owIAnHblNOiwDQ5RB7oKreqZ7a+z+AEdyNgzLSkj6Pv0D0rY6Gh1/Ng==",
+      "path": "morelinq/4.1.0",
+      "hashPath": "morelinq.4.1.0.nupkg.sha512"
+    },
+    "MySql.Data/8.0.33": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mW+A9tc0s+3E3+XYe80aJmr/AvZoKBZG44w13AdVf4+1iRDwgdL6eLMPZgHyQFGwdLwNvQNPKegcOE4rRDuv8Q==",
+      "path": "mysql.data/8.0.33",
+      "hashPath": "mysql.data.8.0.33.nupkg.sha512"
     },
     "ncrontab.signed/3.3.0": {
       "type": "package",
@@ -5350,12 +5063,12 @@
       "path": "ncrontab.signed/3.3.0",
       "hashPath": "ncrontab.signed.3.3.0.nupkg.sha512"
     },
-    "NETStandard.Library/2.0.1": {
+    "NETStandard.Library/1.6.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
-      "path": "netstandard.library/2.0.1",
-      "hashPath": "netstandard.library.2.0.1.nupkg.sha512"
+      "sha512": "sha512-WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+      "path": "netstandard.library/1.6.1",
+      "hashPath": "netstandard.library.1.6.1.nupkg.sha512"
     },
     "Newtonsoft.Json/13.0.3": {
       "type": "package",
@@ -5377,6 +5090,13 @@
       "sha512": "sha512-zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ==",
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
+    },
+    "Portable.BouncyCastle/1.9.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw==",
+      "path": "portable.bouncycastle/1.9.0",
+      "hashPath": "portable.bouncycastle.1.9.0.nupkg.sha512"
     },
     "RabbitMQ.Client/5.1.2": {
       "type": "package",
@@ -5497,6 +5217,13 @@
       "path": "runtime.any.system.threading.tasks/4.3.0",
       "hashPath": "runtime.any.system.threading.tasks.4.3.0.nupkg.sha512"
     },
+    "runtime.any.System.Threading.Timer/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-w4ehZJ+AwXYmGwYu+rMvym6RvMaRiUEQR1u6dwcyuKHxz8Heu/mO9AG1MquEgTyucnhv3M43X0iKpDOoN17C0w==",
+      "path": "runtime.any.system.threading.timer/4.3.0",
+      "hashPath": "runtime.any.system.threading.timer.4.3.0.nupkg.sha512"
+    },
     "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
       "serviceable": true,
@@ -5525,6 +5252,13 @@
       "path": "runtime.native.system/4.3.0",
       "hashPath": "runtime.native.system.4.3.0.nupkg.sha512"
     },
+    "runtime.native.System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+      "path": "runtime.native.system.io.compression/4.3.0",
+      "hashPath": "runtime.native.system.io.compression.4.3.0.nupkg.sha512"
+    },
     "runtime.native.System.Net.Http/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5532,12 +5266,12 @@
       "path": "runtime.native.system.net.http/4.3.0",
       "hashPath": "runtime.native.system.net.http.4.3.0.nupkg.sha512"
     },
-    "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UPrVPlqPRSVZaB4ADmbsQ77KXn9ORiWXyA1RP2W2+byCh3bhgT1bQz0jbeOoog9/2oTQ5wWZSDSMeb74MjezcA==",
-      "path": "runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+      "path": "runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5560,12 +5294,12 @@
       "path": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2",
       "hashPath": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg.sha512"
     },
-    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-t15yGf5r6vMV1rB5O6TgfXKChtCaN3niwFw44M2ImX3eZ8yzueplqMqXPCbWzoBDHJVz9fE+9LFUGCsUmS2Jgg==",
-      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ==",
+      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5609,6 +5343,13 @@
       "path": "runtime.win.microsoft.win32.primitives/4.3.0",
       "hashPath": "runtime.win.microsoft.win32.primitives.4.3.0.nupkg.sha512"
     },
+    "runtime.win.System.Console/4.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vHPXC3B18dxhyipVce8xQT1MQv1o5srYZqBlCNu9p9MNjhgGOntdQh/Xh2X4o7M2F839YUcQiGwu8Q498FyDjg==",
+      "path": "runtime.win.system.console/4.3.1",
+      "hashPath": "runtime.win.system.console.4.3.1.nupkg.sha512"
+    },
     "runtime.win.System.Diagnostics.Debug/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5651,12 +5392,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "SharpCompress/0.30.1": {
       "type": "package",
@@ -5679,12 +5420,19 @@
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
     },
-    "System.AppContext/4.1.0": {
+    "starkbank-ecdsa/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
-      "path": "system.appcontext/4.1.0",
-      "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
+    },
+    "System.AppContext/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+      "path": "system.appcontext/4.3.0",
+      "hashPath": "system.appcontext.4.3.0.nupkg.sha512"
     },
     "System.Buffers/4.5.1": {
       "type": "package",
@@ -5693,12 +5441,12 @@
       "path": "system.buffers/4.5.1",
       "hashPath": "system.buffers.4.5.1.nupkg.sha512"
     },
-    "System.ClientModel/1.0.0": {
+    "System.ClientModel/1.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I3CVkvxeqFYjIVEP59DnjbeoGNfo/+SZrCLpRz2v/g0gpCHaEMPtWSY0s9k/7jR1rAsLNg2z2u1JRB76tPjnIw==",
-      "path": "system.clientmodel/1.0.0",
-      "hashPath": "system.clientmodel.1.0.0.nupkg.sha512"
+      "sha512": "sha512-UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+      "path": "system.clientmodel/1.1.0",
+      "hashPath": "system.clientmodel.1.1.0.nupkg.sha512"
     },
     "System.CodeDom/4.4.0": {
       "type": "package",
@@ -5749,54 +5497,19 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Composition/1.0.31": {
+    "System.Configuration.ConfigurationManager/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I+D26qpYdoklyAVUdqwUBrEIckMNjAYnuPJy/h9dsQItpQwVREkDFs4b4tkBza0kT2Yk48Lcfsv2QQ9hWsh9Iw==",
-      "path": "system.composition/1.0.31",
-      "hashPath": "system.composition.1.0.31.nupkg.sha512"
+      "sha512": "sha512-gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+      "path": "system.configuration.configurationmanager/8.0.1",
+      "hashPath": "system.configuration.configurationmanager.8.0.1.nupkg.sha512"
     },
-    "System.Composition.AttributedModel/1.0.31": {
+    "System.Console/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NHWhkM3ZkspmA0XJEsKdtTt1ViDYuojgSND3yHhTzwxepiwqZf+BCWuvCbjUt4fe0NxxQhUDGJ5km6sLjo9qnQ==",
-      "path": "system.composition.attributedmodel/1.0.31",
-      "hashPath": "system.composition.attributedmodel.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Convention/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GLjh2Ju71k6C0qxMMtl4efHa68NmWeIUYh4fkUI8xbjQrEBvFmRwMDFcylT8/PR9SQbeeL48IkFxU/+gd0nYEQ==",
-      "path": "system.composition.convention/1.0.31",
-      "hashPath": "system.composition.convention.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Hosting/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-fN1bT4RX4vUqjbgoyuJFVUizAl2mYF5VAb+bVIxIYZSSc0BdnX+yGAxcavxJuDDCQ1K+/mdpgyEFc8e9ikjvrg==",
-      "path": "system.composition.hosting/1.0.31",
-      "hashPath": "system.composition.hosting.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Runtime/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-0LEJN+2NVM89CE4SekDrrk5tHV5LeATltkp+9WNYrR+Huiyt0vaCqHbbHtVAjPyeLWIc8dOz/3kthRBj32wGQg==",
-      "path": "system.composition.runtime/1.0.31",
-      "hashPath": "system.composition.runtime.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.TypedParts/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-0Zae/FtzeFgDBBuILeIbC/T9HMYbW4olAmi8XqqAGosSOWvXfiQLfARZEhiGd0LVXaYgXr0NhxiU1LldRP1fpQ==",
-      "path": "system.composition.typedparts/1.0.31",
-      "hashPath": "system.composition.typedparts.1.0.31.nupkg.sha512"
-    },
-    "System.Configuration.ConfigurationManager/8.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
-      "path": "system.configuration.configurationmanager/8.0.0",
-      "hashPath": "system.configuration.configurationmanager.8.0.0.nupkg.sha512"
+      "sha512": "sha512-DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
+      "path": "system.console/4.3.0",
+      "hashPath": "system.console.4.3.0.nupkg.sha512"
     },
     "System.Diagnostics.Debug/4.3.0": {
       "type": "package",
@@ -5812,19 +5525,19 @@
       "path": "system.diagnostics.diagnosticsource/8.0.0",
       "hashPath": "system.diagnostics.diagnosticsource.8.0.0.nupkg.sha512"
     },
-    "System.Diagnostics.EventLog/6.0.0": {
+    "System.Diagnostics.EventLog/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw==",
-      "path": "system.diagnostics.eventlog/6.0.0",
-      "hashPath": "system.diagnostics.eventlog.6.0.0.nupkg.sha512"
+      "sha512": "sha512-n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg==",
+      "path": "system.diagnostics.eventlog/8.0.1",
+      "hashPath": "system.diagnostics.eventlog.8.0.1.nupkg.sha512"
     },
-    "System.Diagnostics.Process/4.3.0": {
+    "System.Diagnostics.PerformanceCounter/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-J0wOX07+QASQblsfxmIMFc9Iq7KTXYL3zs2G/Xc704Ylv3NpuVdo6gij6V3PGiptTxqsK0K7CdXenRvKUnkA2g==",
-      "path": "system.diagnostics.process/4.3.0",
-      "hashPath": "system.diagnostics.process.4.3.0.nupkg.sha512"
+      "sha512": "sha512-kE9szT4i3TYT9bDE/BPfzg9/BL6enMiZlcUmnUEBrhRtxWvurKoa8qhXkLTRhrxMzBqaDleWlRfIPE02tulU+w==",
+      "path": "system.diagnostics.performancecounter/4.7.0",
+      "hashPath": "system.diagnostics.performancecounter.4.7.0.nupkg.sha512"
     },
     "System.Diagnostics.Tools/4.3.0": {
       "type": "package",
@@ -5846,6 +5559,13 @@
       "sha512": "sha512-rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
       "path": "system.diagnostics.tracing/4.3.0",
       "hashPath": "system.diagnostics.tracing.4.3.0.nupkg.sha512"
+    },
+    "System.Drawing.Common/4.7.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-B3+wwhAeoUQ6KeshWSq3IRLQiMoqPEzSHzyVyxTI/EbYuqIp90lXrRISlip2AF+5tj74ycIVPpnRY4M424HahA==",
+      "path": "system.drawing.common/4.7.3",
+      "hashPath": "system.drawing.common.4.7.3.nupkg.sha512"
     },
     "System.Dynamic.Runtime/4.0.11": {
       "type": "package",
@@ -5903,12 +5623,33 @@
       "path": "system.io/4.3.0",
       "hashPath": "system.io.4.3.0.nupkg.sha512"
     },
+    "System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+      "path": "system.io.compression/4.3.0",
+      "hashPath": "system.io.compression.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Compression.ZipFile/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
+      "path": "system.io.compression.zipfile/4.3.0",
+      "hashPath": "system.io.compression.zipfile.4.3.0.nupkg.sha512"
+    },
     "System.IO.FileSystem/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
       "path": "system.io.filesystem/4.3.0",
       "hashPath": "system.io.filesystem.4.3.0.nupkg.sha512"
+    },
+    "System.IO.FileSystem.AccessControl/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vMToiarpU81LR1/KZtnT7VDPvqAZfw9oOS5nY6pPP78nGYz3COLsQH3OfzbR+SjTgltd31R6KmKklz/zDpTmzw==",
+      "path": "system.io.filesystem.accesscontrol/4.7.0",
+      "hashPath": "system.io.filesystem.accesscontrol.4.7.0.nupkg.sha512"
     },
     "System.IO.FileSystem.Primitives/4.3.0": {
       "type": "package",
@@ -5924,12 +5665,12 @@
       "path": "system.io.hashing/6.0.0",
       "hashPath": "system.io.hashing.6.0.0.nupkg.sha512"
     },
-    "System.IO.Pipelines/5.0.1": {
+    "System.IO.Pipelines/6.0.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg==",
-      "path": "system.io.pipelines/5.0.1",
-      "hashPath": "system.io.pipelines.5.0.1.nupkg.sha512"
+      "sha512": "sha512-ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw==",
+      "path": "system.io.pipelines/6.0.3",
+      "hashPath": "system.io.pipelines.6.0.3.nupkg.sha512"
     },
     "System.Json/4.5.0": {
       "type": "package",
@@ -5966,12 +5707,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/1.0.2": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JGkzeqgBsiZwKJZ1IxPNsDFZDhUvuEdX8L8BDC8N3KOj+6zMcNU28CNN59TpZE/VJYy9cP+5M+sbxtWJx3/xtw==",
-      "path": "system.memory.data/1.0.2",
-      "hashPath": "system.memory.data.1.0.2.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5994,19 +5735,19 @@
       "path": "system.net.primitives/4.3.0",
       "hashPath": "system.net.primitives.4.3.0.nupkg.sha512"
     },
+    "System.Net.ServerSentEvents/10.0.0-preview.1.25080.5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WXlkTQNLx+O4Ys5lMZNjGOUsuMXjL8nbmBGCWR0np0EKasGZmmfMXmzm9xT22arIS74uhRb/z8Y5l5C4Ceur9Q==",
+      "path": "system.net.serversentevents/10.0.0-preview.1.25080.5",
+      "hashPath": "system.net.serversentevents.10.0.0-preview.1.25080.5.nupkg.sha512"
+    },
     "System.Net.Sockets/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
       "path": "system.net.sockets/4.3.0",
       "hashPath": "system.net.sockets.4.3.0.nupkg.sha512"
-    },
-    "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O8RIMEVeOFzT8fscu6MDc4y+0LfnlXdqGovb0rJHBNVKhwn6BsNJmTY1oYUZPPsMfcc5OP20WpX4vj/aK8n98g==",
-      "path": "system.net.websockets.websocketprotocol/4.5.3",
-      "hashPath": "system.net.websockets.websocketprotocol.4.5.3.nupkg.sha512"
     },
     "System.Numerics.Vectors/4.5.0": {
       "type": "package",
@@ -6021,13 +5762,6 @@
       "sha512": "sha512-bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
       "path": "system.objectmodel/4.3.0",
       "hashPath": "system.objectmodel.4.3.0.nupkg.sha512"
-    },
-    "System.Private.DataContractSerialization/4.1.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-lcqFBUaCZxPiUkA4dlSOoPZGtZsAuuElH2XHgLwGLxd7ZozWetV5yiz0qGAV2AUYOqw97MtZBjbLMN16Xz4vXA==",
-      "path": "system.private.datacontractserialization/4.1.1",
-      "hashPath": "system.private.datacontractserialization.4.1.1.nupkg.sha512"
     },
     "System.Private.Uri/4.3.0": {
       "type": "package",
@@ -6155,12 +5889,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/8.0.0": {
+    "System.Runtime.Caching/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4TmlmvGp4kzZomm7J2HJn6IIx0UUrQyhBDyb5O1XiunZlQImXW+B8b7W/sTPcXhSf9rp5NR5aDtQllwbB5elOQ==",
-      "path": "system.runtime.caching/8.0.0",
-      "hashPath": "system.runtime.caching.8.0.0.nupkg.sha512"
+      "sha512": "sha512-tdl7Q47P09UpRu0C/OQsGJU6GacBzzk4vfp5My9rodD+BchrxmajORnTthH8RxPUTPrIoVDJmLyvJcGxB267nQ==",
+      "path": "system.runtime.caching/8.0.1",
+      "hashPath": "system.runtime.caching.8.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -6190,12 +5924,12 @@
       "path": "system.runtime.interopservices/4.3.0",
       "hashPath": "system.runtime.interopservices.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+    "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWPhJxc453RCa8Z29O91EmfGeZIHX1ZH2A8L6lYQVSaKzku2DfArSfMEb1/MYYzPQRJZeu0c9dmYeJKxW5Fgng==",
-      "path": "system.runtime.interopservices.runtimeinformation/4.0.0",
-      "hashPath": "system.runtime.interopservices.runtimeinformation.4.0.0.nupkg.sha512"
+      "sha512": "sha512-cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+      "path": "system.runtime.interopservices.runtimeinformation/4.3.0",
+      "hashPath": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg.sha512"
     },
     "System.Runtime.Loader/4.3.0": {
       "type": "package",
@@ -6211,20 +5945,6 @@
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.Serialization.Json/4.0.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-+7DIJhnKYgCzUgcLbVTtRQb2l1M0FP549XFlFkQM5lmNiUBl44AfNbx4bz61xA8PzLtlYwfmif4JJJW7MPPnjg==",
-      "path": "system.runtime.serialization.json/4.0.2",
-      "hashPath": "system.runtime.serialization.json.4.0.2.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
     "System.Security.AccessControl/6.0.0": {
       "type": "package",
       "serviceable": true,
@@ -6232,12 +5952,12 @@
       "path": "system.security.accesscontrol/6.0.0",
       "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.Algorithms/4.3.1": {
+    "System.Security.Cryptography.Algorithms/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DVUblnRfnarrI5olEC2B/OCsJQd0anjVaObQMndHSc43efbc88/RMOlDyg/EyY0ix5ecyZMXS8zMksb5ukebZA==",
-      "path": "system.security.cryptography.algorithms/4.3.1",
-      "hashPath": "system.security.cryptography.algorithms.4.3.1.nupkg.sha512"
+      "sha512": "sha512-W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+      "path": "system.security.cryptography.algorithms/4.3.0",
+      "hashPath": "system.security.cryptography.algorithms.4.3.0.nupkg.sha512"
     },
     "System.Security.Cryptography.Cng/5.0.0": {
       "type": "package",
@@ -6281,12 +6001,19 @@
       "path": "system.security.cryptography.protecteddata/8.0.0",
       "hashPath": "system.security.cryptography.protecteddata.8.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.X509Certificates/4.3.2": {
+    "System.Security.Cryptography.X509Certificates/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uwlfOnvJd7rXRvP3aV126Q9XebIIEGEaZ245Rd5/ZwOg7U7AU+AmpE0vRh2F0DFjfOTuk7MAexv4nYiNP/RYnQ==",
-      "path": "system.security.cryptography.x509certificates/4.3.2",
-      "hashPath": "system.security.cryptography.x509certificates.4.3.2.nupkg.sha512"
+      "sha512": "sha512-t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+      "path": "system.security.cryptography.x509certificates/4.3.0",
+      "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Permissions/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dkOV6YYVBnYRa15/yv004eCGRBVADXw8qRbbNiCn/XpdJSUXkkUeIvdvFHkvnko4CdKMqG8yRHC4ox83LSlMsQ==",
+      "path": "system.security.permissions/4.7.0",
+      "hashPath": "system.security.permissions.4.7.0.nupkg.sha512"
     },
     "System.Security.Principal.Windows/5.0.0": {
       "type": "package",
@@ -6302,12 +6029,12 @@
       "path": "system.text.encoding/4.3.0",
       "hashPath": "system.text.encoding.4.3.0.nupkg.sha512"
     },
-    "System.Text.Encoding.CodePages/4.5.1": {
+    "System.Text.Encoding.CodePages/4.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w==",
-      "path": "system.text.encoding.codepages/4.5.1",
-      "hashPath": "system.text.encoding.codepages.4.5.1.nupkg.sha512"
+      "sha512": "sha512-6JX7ZdaceBiLKLkYt8zJcp4xTJd1uYyXXEkPw6mnlUIjh1gZPIVKPtRXPmY5kLf6DwZmf5YLwR3QUrRonl7l0A==",
+      "path": "system.text.encoding.codepages/4.4.0",
+      "hashPath": "system.text.encoding.codepages.4.4.0.nupkg.sha512"
     },
     "System.Text.Encoding.Extensions/4.3.0": {
       "type": "package",
@@ -6323,12 +6050,12 @@
       "path": "system.text.encodings.web/8.0.0",
       "hashPath": "system.text.encodings.web.8.0.0.nupkg.sha512"
     },
-    "System.Text.Json/8.0.1": {
+    "System.Text.Json/8.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
-      "path": "system.text.json/8.0.1",
-      "hashPath": "system.text.json.8.0.1.nupkg.sha512"
+      "sha512": "sha512-bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
+      "path": "system.text.json/8.0.4",
+      "hashPath": "system.text.json.8.0.4.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",
@@ -6344,12 +6071,12 @@
       "path": "system.threading/4.3.0",
       "hashPath": "system.threading.4.3.0.nupkg.sha512"
     },
-    "System.Threading.Channels/4.7.1": {
+    "System.Threading.Channels/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6akRtHK/wab3246t4p5v3HQrtQk8LboOt5T4dtpNgsp3zvDeM4/Gx8V12t0h+c/W9/enUrilk8n6EQqdQorZAA==",
-      "path": "system.threading.channels/4.7.1",
-      "hashPath": "system.threading.channels.4.7.1.nupkg.sha512"
+      "sha512": "sha512-TY8/9+tI0mNaUMgntOxxaq2ndTkdXqLSxvPmas7XEqOlv9lQtB7wLjYGd756lOaO7Dvb5r/WXhluM+0Xe87v5Q==",
+      "path": "system.threading.channels/6.0.0",
+      "hashPath": "system.threading.channels.6.0.0.nupkg.sha512"
     },
     "System.Threading.Overlapped/4.3.0": {
       "type": "package",
@@ -6379,19 +6106,12 @@
       "path": "system.threading.tasks.extensions/4.5.4",
       "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
     },
-    "System.Threading.Thread/4.3.0": {
+    "System.Threading.Timer/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
-      "path": "system.threading.thread/4.3.0",
-      "hashPath": "system.threading.thread.4.3.0.nupkg.sha512"
-    },
-    "System.Threading.ThreadPool/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-k/+g4b7vjdd4aix83sTgC9VG6oXYKAktSfNIJUNGxPEj7ryEOfzHHhfnmsZvjxawwcD9HyWXKCXmPjX8U4zeSw==",
-      "path": "system.threading.threadpool/4.3.0",
-      "hashPath": "system.threading.threadpool.4.3.0.nupkg.sha512"
+      "sha512": "sha512-Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+      "path": "system.threading.timer/4.3.0",
+      "hashPath": "system.threading.timer.4.3.0.nupkg.sha512"
     },
     "System.ValueTuple/4.5.0": {
       "type": "package",
@@ -6400,26 +6120,26 @@
       "path": "system.valuetuple/4.5.0",
       "hashPath": "system.valuetuple.4.5.0.nupkg.sha512"
     },
-    "System.Xml.ReaderWriter/4.0.11": {
+    "System.Windows.Extensions/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
-      "path": "system.xml.readerwriter/4.0.11",
-      "hashPath": "system.xml.readerwriter.4.0.11.nupkg.sha512"
+      "sha512": "sha512-CeWTdRNfRaSh0pm2gDTJFwVaXfTq6Xwv/sA887iwPTneW7oMtMlpvDIO+U60+3GWTB7Aom6oQwv5VZVUhQRdPQ==",
+      "path": "system.windows.extensions/4.7.0",
+      "hashPath": "system.windows.extensions.4.7.0.nupkg.sha512"
     },
-    "System.Xml.XmlDocument/4.0.1": {
+    "System.Xml.ReaderWriter/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2eZu6IP+etFVBBFUFzw2w6J21DqIN5eL9Y8r8JfJWUmV28Z5P0SNU01oCisVHQgHsDhHPnmq2s1hJrJCFZWloQ==",
-      "path": "system.xml.xmldocument/4.0.1",
-      "hashPath": "system.xml.xmldocument.4.0.1.nupkg.sha512"
+      "sha512": "sha512-GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+      "path": "system.xml.readerwriter/4.3.0",
+      "hashPath": "system.xml.readerwriter.4.3.0.nupkg.sha512"
     },
-    "System.Xml.XmlSerializer/4.0.11": {
+    "System.Xml.XDocument/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FrazwwqfIXTfq23mfv4zH+BjqkSFNaNFBtjzu3I9NRmG8EELYyrv/fJnttCIwRMFRR/YKXF1hmsMmMEnl55HGw==",
-      "path": "system.xml.xmlserializer/4.0.11",
-      "hashPath": "system.xml.xmlserializer.4.0.11.nupkg.sha512"
+      "sha512": "sha512-5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+      "path": "system.xml.xdocument/4.3.0",
+      "hashPath": "system.xml.xdocument.4.3.0.nupkg.sha512"
     },
     "Twilio/5.6.3": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -1,40 +1,44 @@
 {
   "runtimeTarget": {
-    "name": ".NETCoreApp,Version=v6.0/win-x86",
+    "name": ".NETCoreApp,Version=v8.0/win-x86",
     "signature": ""
   },
   "compilationOptions": {},
   "targets": {
-    ".NETCoreApp,Version=v6.0": {},
-    ".NETCoreApp,Version=v6.0/win-x86": {
+    ".NETCoreApp,Version=v8.0": {},
+    ".NETCoreApp,Version=v8.0/win-x86": {
       "extensions/1.0.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "1.5.4",
+          "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.0.0-beta423",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.2",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "0.4.2-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.1.54-rc",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.10-Preview",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.3.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.2.0-alpha",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.15.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "0.2.9-rc",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.11-Preview",
+          "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.31-preview",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch": "0.4.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.3.0-alpha",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.16.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
-          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.0.3",
-          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.4",
-          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "1.14.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.169-preview",
-          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1",
+          "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.5",
+          "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.376",
+          "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.3.0",
-          "Microsoft.NET.Sdk.Functions": "4.4.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0-beta.4",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.5.1",
+          "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
         },
@@ -78,9 +82,9 @@
       },
       "Azure.AI.OpenAI/1.0.0-beta.15": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.ClientModel": "1.0.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.ClientModel": "1.1.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.AI.OpenAI.dll": {
@@ -89,21 +93,21 @@
           }
         }
       },
-      "Azure.Core/1.41.0": {
+      "Azure.Core/1.44.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.ClientModel": "1.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.ClientModel": "1.1.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Core.dll": {
-            "assemblyVersion": "1.41.0.0",
-            "fileVersion": "1.4100.24.36109"
+            "assemblyVersion": "1.44.1.0",
+            "fileVersion": "1.4400.124.50905"
           }
         }
       },
@@ -111,7 +115,7 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.5",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Core.Amqp.dll": {
@@ -120,40 +124,39 @@
           }
         }
       },
-      "Azure.Data.Tables/12.8.3": {
+      "Azure.Data.Tables/12.9.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Data.Tables.dll": {
-            "assemblyVersion": "12.8.3.0",
-            "fileVersion": "12.800.324.10602"
+            "assemblyVersion": "12.9.1.0",
+            "fileVersion": "12.900.124.46702"
           }
         }
       },
-      "Azure.Identity/1.12.0": {
+      "Azure.Identity/1.13.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
           "System.Memory": "4.5.5",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Text.Json": "8.0.1",
+          "System.Text.Json": "8.0.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Identity.dll": {
-            "assemblyVersion": "1.12.0.0",
-            "fileVersion": "1.1200.24.31701"
+            "assemblyVersion": "1.13.1.0",
+            "fileVersion": "1.1300.124.52405"
           }
         }
       },
       "Azure.Messaging.EventGrid/4.21.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Core": "1.44.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventGrid.dll": {
@@ -162,82 +165,112 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.9.2": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Threading.Channels": "4.7.1",
+          "System.Threading.Channels": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.9.2.0",
-            "fileVersion": "5.900.223.30602"
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
-      "Azure.Messaging.ServiceBus/7.18.1": {
+      "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.Amqp": "2.6.7",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.41401"
+          }
+        }
+      },
+      "Azure.Messaging.ServiceBus/7.18.2": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "System.Memory.Data": "1.0.2"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.ServiceBus.dll": {
-            "assemblyVersion": "7.18.1.0",
-            "fileVersion": "7.1800.124.38102"
+            "assemblyVersion": "7.18.2.0",
+            "fileVersion": "7.1800.224.50802"
           }
         }
       },
-      "Azure.Search.Documents/11.5.1": {
+      "Azure.Messaging.WebPubSub/1.4.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Channels": "4.7.1"
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Azure.Messaging.WebPubSub.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.40602"
+          }
+        }
+      },
+      "Azure.Search.Documents/11.6.0": {
+        "dependencies": {
+          "Azure.Core": "1.44.1",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Search.Documents.dll": {
-            "assemblyVersion": "11.5.1.0",
-            "fileVersion": "11.500.123.57802"
+            "assemblyVersion": "11.6.0.0",
+            "fileVersion": "11.600.24.36703"
           }
         }
       },
-      "Azure.Storage.Blobs/12.21.0": {
+      "Azure.Storage.Blobs/12.23.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.21.0.0",
-            "fileVersion": "12.2100.24.36603"
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.24.56203"
           }
         }
       },
-      "Azure.Storage.Common/12.20.0": {
+      "Azure.Storage.Common/12.23.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.20.0.0",
-            "fileVersion": "12.2000.24.36603"
+          "lib/net8.0/Azure.Storage.Common.dll": {
+            "assemblyVersion": "12.23.0.0",
+            "fileVersion": "12.2300.25.16105"
           }
         }
       },
       "Azure.Storage.Files.DataLake/12.18.0": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Common": "12.23.0",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/Azure.Storage.Files.DataLake.dll": {
@@ -246,22 +279,21 @@
           }
         }
       },
-      "Azure.Storage.Queues/12.19.0": {
+      "Azure.Storage.Queues/12.22.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.20.0",
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "Azure.Storage.Common": "12.23.0",
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
-          "lib/net6.0/Azure.Storage.Queues.dll": {
-            "assemblyVersion": "12.19.0.0",
-            "fileVersion": "12.1900.24.36603"
+          "lib/net8.0/Azure.Storage.Queues.dll": {
+            "assemblyVersion": "12.22.0.0",
+            "fileVersion": "12.2200.25.16105"
           }
         }
       },
       "Castle.Core/5.0.0": {
         "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
+          "System.Diagnostics.EventLog": "8.0.1"
         },
         "runtime": {
           "lib/net6.0/Castle.Core.dll": {
@@ -284,7 +316,7 @@
       "CloudNative.CloudEvents.SystemTextJson/2.6.0": {
         "dependencies": {
           "CloudNative.CloudEvents": "2.6.0",
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.1/CloudNative.CloudEvents.SystemTextJson.dll": {
@@ -293,58 +325,58 @@
           }
         }
       },
-      "Confluent.Kafka/1.9.0": {
+      "Confluent.Kafka/2.4.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
-          "librdkafka.redist": "1.9.0"
+          "librdkafka.redist": "2.4.0"
         },
         "runtime": {
-          "lib/net5.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+          "lib/net6.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/1.9.0": {
+      "Confluent.SchemaRegistry/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Net.Http": "4.3.4"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
         "dependencies": {
           "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Google.Protobuf": "3.24.3",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Google.Protobuf": "3.28.2",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.0"
+            "assemblyVersion": "2.4.0.0",
+            "fileVersion": "2.4.0.0"
           }
         }
       },
@@ -359,27 +391,27 @@
           }
         }
       },
-      "Google.Protobuf/3.24.3": {
+      "Google.Protobuf/3.28.2": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.24.3.0",
-            "fileVersion": "3.24.3.0"
+            "assemblyVersion": "3.28.2.0",
+            "fileVersion": "3.28.2.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
+          "Google.Protobuf": "3.28.2",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.49.0"
+          "Grpc.Tools": "2.68.1"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0"
+          "Grpc.Net.Common": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -391,7 +423,7 @@
           "Grpc.Net.ClientFactory": "2.49.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
+          "lib/net7.0/Grpc.AspNetCore.Server.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
@@ -399,7 +431,7 @@
       },
       "Grpc.Core/2.46.6": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0",
+          "Grpc.Core.Api": "2.67.0",
           "System.Memory": "4.5.5"
         },
         "runtime": {
@@ -414,60 +446,86 @@
           }
         }
       },
-      "Grpc.Core.Api/2.52.0": {
-        "dependencies": {
-          "System.Memory": "4.5.5"
-        },
+      "Grpc.Core.Api/2.67.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.52.0": {
+      "Grpc.Net.Client/2.67.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.52.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Grpc.Net.Common": "2.67.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Client.dll": {
+          "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.52.0",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.ClientFactory.dll": {
+          "lib/net7.0/Grpc.Net.ClientFactory.dll": {
             "assemblyVersion": "2.0.0.0",
             "fileVersion": "2.49.0.0"
           }
         }
       },
-      "Grpc.Net.Common/2.52.0": {
+      "Grpc.Net.Common/2.67.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.52.0"
+          "Grpc.Core.Api": "2.67.0"
         },
         "runtime": {
-          "lib/net6.0/Grpc.Net.Common.dll": {
+          "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.52.0.0"
+            "fileVersion": "2.67.0.0"
           }
         }
       },
-      "Grpc.Tools/2.49.0": {},
-      "librdkafka.redist/1.9.0": {
+      "Grpc.Tools/2.68.1": {},
+      "K4os.Compression.LZ4/1.3.5": {
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Compression.LZ4.Streams/1.3.5": {
+        "dependencies": {
+          "K4os.Compression.LZ4": "1.3.5",
+          "K4os.Hash.xxHash": "1.0.8",
+          "System.IO.Pipelines": "6.0.3"
+        },
+        "runtime": {
+          "lib/net6.0/K4os.Compression.LZ4.Streams.dll": {
+            "assemblyVersion": "1.3.5.0",
+            "fileVersion": "1.3.5.0"
+          }
+        }
+      },
+      "K4os.Hash.xxHash/1.0.8": {
+        "runtime": {
+          "lib/net6.0/K4os.Hash.xxHash.dll": {
+            "assemblyVersion": "1.0.8.0",
+            "fileVersion": "1.0.8.0"
+          }
+        }
+      },
+      "librdkafka.redist/2.4.0": {
         "native": {
-          "runtimes/win-x86/native/libcrypto-1_1.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x86/native/libcrypto-3.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/libcurl.dll": {
-            "fileVersion": "7.82.0.0"
+            "fileVersion": "7.86.0.0"
           },
           "runtimes/win-x86/native/librdkafka.dll": {
             "fileVersion": "0.0.0.0"
@@ -475,8 +533,8 @@
           "runtimes/win-x86/native/librdkafkacpp.dll": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/win-x86/native/libssl-1_1.dll": {
-            "fileVersion": "1.1.1.14"
+          "runtimes/win-x86/native/libssl-3.dll": {
+            "fileVersion": "3.0.8.0"
           },
           "runtimes/win-x86/native/msvcp140.dll": {
             "fileVersion": "14.29.30040.0"
@@ -485,25 +543,30 @@
             "fileVersion": "14.29.30040.0"
           },
           "runtimes/win-x86/native/zlib1.dll": {
-            "fileVersion": "1.2.12.0"
+            "fileVersion": "1.2.13.0"
           },
           "runtimes/win-x86/native/zstd.dll": {
             "fileVersion": "1.5.2.0"
           }
         }
       },
-      "MessagePack/1.9.11": {
+      "MessagePack/2.5.192": {
         "dependencies": {
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
+          "MessagePack.Annotations": "2.5.192",
+          "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
-          "lib/netstandard2.0/MessagePack.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.11.48492"
+          "lib/net6.0/MessagePack.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
+          }
+        }
+      },
+      "MessagePack.Annotations/2.5.192": {
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.Annotations.dll": {
+            "assemblyVersion": "2.5.0.0",
+            "fileVersion": "2.5.192.54228"
           }
         }
       },
@@ -515,6 +578,90 @@
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
             "assemblyVersion": "2.22.0.997",
             "fileVersion": "2.22.0.997"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.AspNetCore/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.EventCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Microsoft.AspNetCore.Hosting": "2.2.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.21.0",
+          "System.Text.Encodings.Web": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.ApplicationInsights.AspNetCore.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.DependencyCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.EventCounterCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.EventCounterCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.Extensions.Caching.Memory": "1.0.0",
+          "System.Diagnostics.PerformanceCounter": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.PerfCounterCollector.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.WindowsServer.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AI.ServerTelemetryChannel.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
           }
         }
       },
@@ -533,8 +680,8 @@
       "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
@@ -546,8 +693,8 @@
       },
       "Microsoft.AspNetCore.Authorization/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
@@ -559,7 +706,7 @@
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         }
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
@@ -567,14 +714,14 @@
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Configuration": "2.2.0",
+          "Microsoft.Extensions.Configuration": "3.1.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reflection.Metadata": "1.6.0"
         }
@@ -589,7 +736,7 @@
       "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
         }
       },
       "Microsoft.AspNetCore.Http/2.2.2": {
@@ -597,7 +744,7 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0"
         }
       },
@@ -607,36 +754,17 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
-        }
-      },
-      "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
       "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Buffers": "4.5.1"
         }
       },
       "Microsoft.AspNetCore.Http.Features/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.JsonPatch/2.2.0": {
@@ -668,10 +796,10 @@
           "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -698,16 +826,16 @@
       },
       "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing/2.2.2": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
           "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.ObjectPool": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
@@ -720,7 +848,7 @@
           "Microsoft.AspNetCore.Hosting": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Https": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1"
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
@@ -730,8 +858,8 @@
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.2.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
@@ -763,38 +891,11 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Buffers": "4.5.1"
-        }
-      },
-      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-        "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.SignalR.Common": "1.1.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {
-            "assemblyVersion": "1.1.5.0",
-            "fileVersion": "1.1.5.19109"
-          }
-        }
-      },
-      "Microsoft.AspNetCore.WebSockets/2.1.7": {
-        "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3"
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
       "Microsoft.AspNetCore.WebUtilities/2.2.0": {
@@ -811,46 +912,48 @@
           }
         }
       },
-      "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+      "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
+          "Azure.Core": "1.44.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Core.NewtonsoftJson.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.21.5702"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.23.61406"
           }
         }
       },
-      "Microsoft.Azure.Cosmos/3.41.0": {
+      "Microsoft.Azure.Cosmos/3.44.1": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Azure.Core": "1.44.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "8.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Memory": "4.5.5",
+          "System.Net.Http": "4.3.4",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks.Extensions": "4.5.4",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Client.dll": {
-            "assemblyVersion": "3.41.0.0",
-            "fileVersion": "3.41.0.0"
+            "assemblyVersion": "3.44.1.0",
+            "fileVersion": "3.44.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Core.dll": {
             "assemblyVersion": "2.11.0.0",
             "fileVersion": "2.11.0.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Direct.dll": {
-            "assemblyVersion": "3.34.4.0",
-            "fileVersion": "3.34.4.0"
+            "assemblyVersion": "3.36.1.0",
+            "fileVersion": "3.36.1.0"
           },
           "lib/netstandard2.0/Microsoft.Azure.Cosmos.Serialization.HybridRow.dll": {
             "assemblyVersion": "1.1.0.0",
@@ -858,37 +961,40 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.1.0.0",
-            "fileVersion": "0.1.6.6114"
+            "assemblyVersion": "0.2.0.0",
+            "fileVersion": "0.2.0.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
         "dependencies": {
-          "Azure.Data.Tables": "12.8.3",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "WindowsAzure.Storage": "9.3.1"
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "1.17.0.0",
-            "fileVersion": "1.17.4.42221"
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.1.54820"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/2.17.1": {
+      "Microsoft.Azure.DurableTask.Core/3.0.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Newtonsoft.Json": "13.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Reactive.Compatibility": "4.4.1",
@@ -896,80 +1002,47 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "2.17.0.0",
-            "fileVersion": "2.17.1.6114"
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.42734"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+      "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.EventHubs.Processor": "4.3.2",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
+          "Azure.Core": "1.44.1",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Messaging.EventHubs.Processor": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
           "Microsoft.FASTER.Core": "2.6.5",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Threading.Channels": "4.7.1"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
-        "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.DurableTask.Netherite": "1.5.4",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5"
-        },
-        "runtime": {
-          "lib/netcoreapp3.1/DurableTask.Netherite.AzureFunctions.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.5.4.43907"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.Amqp": "2.6.7",
-          "Microsoft.Azure.Services.AppAuthentication": "1.0.3",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
-          }
-        }
-      },
-      "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-        "dependencies": {
-          "Microsoft.Azure.EventHubs": "4.3.2",
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "Microsoft.Azure.Storage.Blob": "11.2.3",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.EventHubs.Processor.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.300.221.25602"
+          "lib/netstandard2.0/DurableTask.Netherite.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
+          }
+        }
+      },
+      "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4"
+        },
+        "runtime": {
+          "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.0.6060"
           }
         }
       },
       "Microsoft.Azure.Functions.Analyzers/1.0.0": {},
       "Microsoft.Azure.Functions.Extensions/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.dll": {
@@ -980,7 +1053,7 @@
       },
       "Microsoft.Azure.Functions.Extensions.Dapr.Core/0.17.0-preview01": {
         "dependencies": {
-          "System.Text.Json": "8.0.1"
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.Functions.Extensions.Dapr.Core.dll": {
@@ -989,250 +1062,134 @@
           }
         }
       },
-      "Microsoft.Azure.KeyVault.Core/3.0.3": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.0.0-beta423": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1"
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
+          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "System.Drawing.Common": "4.7.3",
+          "System.Net.Http": "4.3.4",
+          "System.Net.ServerSentEvents": "10.0.0-preview.1.25080.5",
+          "System.Text.RegularExpressions": "4.3.1"
         },
         "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.KeyVault.Core.dll": {
-            "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.0.3.0"
+          "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1",
           "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
           "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
           "System.Security.Principal.Windows": "5.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+      "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1"
         },
         "runtime": {
           "lib/net6.0/Kusto.Cloud.Platform.Msal.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Data/12.2.3": {
+      "Microsoft.Azure.Kusto.Data/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.3",
-          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Microsoft.Azure.Kusto.Cloud.Platform": "12.2.7",
+          "Microsoft.Azure.Kusto.Cloud.Platform.Msal": "12.2.7",
+          "Microsoft.Identity.Client": "4.66.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.66.1",
+          "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Data.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+      "Microsoft.Azure.Kusto.Ingest/12.2.7": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Common": "12.20.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.CSharp": "4.7.0",
-          "Microsoft.IO.RecyclableMemoryStream": "3.0.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "Microsoft.IdentityModel.Abstractions": "7.6.3",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "Microsoft.IdentityModel.Logging": "7.6.3",
-          "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Net.Http": "4.3.4",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Security.AccessControl": "6.0.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
-          "System.Security.Cryptography.Cng": "5.0.0",
-          "System.Security.Cryptography.Encoding": "4.3.0",
-          "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.ProtectedData": "8.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.IO.RecyclableMemoryStream": "3.0.0"
         },
         "runtime": {
           "lib/net6.0/Kusto.Ingest.dll": {
-            "assemblyVersion": "12.2.3.0",
-            "fileVersion": "12.2.3.0"
+            "assemblyVersion": "12.2.7.0",
+            "fileVersion": "12.2.7.0"
           }
         }
       },
-      "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+      "Microsoft.Azure.SignalR/1.29.0": {
         "dependencies": {
-          "Microsoft.IdentityModel.Clients.ActiveDirectory": "3.14.2",
-          "NETStandard.Library": "2.0.1",
-          "System.Diagnostics.Process": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.4/Microsoft.Azure.Services.AppAuthentication.dll": {
-            "assemblyVersion": "1.0.3.0",
-            "fileVersion": "1.0.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.SignalR/1.25.2": {
-        "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.SignalR.Common.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Common.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           },
-          "lib/net6.0/Microsoft.Azure.SignalR.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Management/1.25.2": {
+      "Microsoft.Azure.SignalR.Management/1.29.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Azure.Core.NewtonsoftJson": "1.0.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Extensions.Http": "3.1.32",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Extensions.Http": "6.0.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/net5.0/Microsoft.Azure.SignalR.Management.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+          "lib/net8.0/Microsoft.Azure.SignalR.Management.dll": {
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
-      "Microsoft.Azure.SignalR.Protocols/1.25.2": {
+      "Microsoft.Azure.SignalR.Protocols/1.29.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.AspNetCore.Connections.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.Http.Connections.Common": "1.0.4",
-          "Microsoft.AspNetCore.WebSockets": "2.1.7",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.Http": "3.1.32",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0",
-          "Newtonsoft.Json": "13.0.3",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1",
-          "System.IO.Pipelines": "5.0.1",
           "System.Memory": "4.5.5",
-          "System.Net.WebSockets.WebSocketProtocol": "4.5.3",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.SignalR.Protocols.dll": {
-            "assemblyVersion": "1.25.2.0",
-            "fileVersion": "1.25.2.0"
+            "assemblyVersion": "1.29.0.0",
+            "fileVersion": "1.29.0.0"
           }
         }
       },
@@ -1250,8 +1207,8 @@
       },
       "Microsoft.Azure.StackExchangeRedis/2.0.0": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Identity.Client": "4.66.1",
           "StackExchange.Redis": "2.7.4"
         },
         "runtime": {
@@ -1261,69 +1218,44 @@
           }
         }
       },
-      "Microsoft.Azure.Storage.Blob/11.2.3": {
+      "Microsoft.Azure.WebJobs/3.0.41": {
         "dependencies": {
-          "Microsoft.Azure.Storage.Common": "11.2.3",
-          "NETStandard.Library": "2.0.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Blob.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.Storage.Common/11.2.3": {
-        "dependencies": {
-          "Microsoft.Azure.KeyVault.Core": "3.0.3",
-          "NETStandard.Library": "2.0.1",
-          "Newtonsoft.Json": "13.0.3"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.Storage.Common.dll": {
-            "assemblyVersion": "11.2.3.0",
-            "fileVersion": "11.2.3.0"
-          }
-        }
-      },
-      "Microsoft.Azure.WebJobs/3.0.39": {
-        "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.39",
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Microsoft.Azure.WebJobs.Core": "3.0.41",
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.2.0",
-          "Microsoft.Extensions.Configuration.Json": "2.1.0",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
           "Microsoft.Extensions.Hosting": "2.1.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Microsoft.Extensions.Logging.Configuration": "2.1.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Memory.Data": "1.0.2",
+          "System.Memory.Data": "6.0.1",
           "System.Threading.Tasks.Dataflow": "4.8.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.39": {
+      "Microsoft.Azure.WebJobs.Core/3.0.41": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0",
-          "System.Memory.Data": "1.0.2"
+          "System.Memory.Data": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
-            "assemblyVersion": "3.0.39.0",
-            "fileVersion": "3.0.39.0"
+            "assemblyVersion": "3.0.41.0",
+            "fileVersion": "3.0.41.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Host.Storage": "3.0.14",
           "ncrontab.signed": "3.3.0"
         },
@@ -1337,7 +1269,7 @@
       "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents/1.0.1": {
         "dependencies": {
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -1349,17 +1281,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
         "dependencies": {
-          "Microsoft.Azure.Cosmos": "3.41.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
+          "Microsoft.Azure.Cosmos": "3.44.1",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.8.0.0",
-            "fileVersion": "4.8.0.0"
+            "assemblyVersion": "4.9.0.0",
+            "fileVersion": "4.9.0.0"
           }
         }
       },
@@ -1371,8 +1304,8 @@
           "Microsoft.AspNetCore.Routing": "2.2.2",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Dapr.dll": {
@@ -1381,50 +1314,68 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
-          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "2.2.1",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.1.6",
-          "Microsoft.Azure.DurableTask.AzureStorage": "1.17.4",
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.2.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.0.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
-          "Microsoft.DurableTask.Grpc": "1.1.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
-          "Microsoft.Extensions.Http": "3.1.32"
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "Microsoft.Extensions.Http": "6.0.0"
         },
         "runtime": {
-          "lib/netcoreapp3.1/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
-            "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.13.5.0"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.4.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
         "dependencies": {
-          "Azure.Messaging.EventGrid": "4.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Grpc.Tools": "2.68.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "Microsoft.DurableTask.AzureManagedBackend": "0.4.2-alpha",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.400.224.38002"
+          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+        "dependencies": {
+          "Azure.Messaging.EventGrid": "4.21.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventGrid.dll": {
+            "assemblyVersion": "3.4.4.0",
+            "fileVersion": "3.400.425.16403"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.9.2",
-          "Azure.Storage.Blobs": "12.21.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.EventHubs": "5.11.5",
+          "Azure.Storage.Blobs": "12.23.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
@@ -1433,25 +1384,25 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Azure.Storage.Files.DataLake": "12.18.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "0.1.54.0",
-            "fileVersion": "0.1.54.0"
+            "assemblyVersion": "0.2.9.0",
+            "fileVersion": "0.2.9.0"
           }
         }
       },
@@ -1462,7 +1413,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -1471,97 +1422,118 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
         "dependencies": {
-          "Confluent.Kafka": "1.9.0",
-          "Confluent.SchemaRegistry": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "1.9.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "1.9.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Confluent.Kafka": "2.4.0",
+          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "3.9.0.0",
-            "fileVersion": "3.9.0.0"
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
         "dependencies": {
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Kusto.dll": {
-            "assemblyVersion": "1.0.10.0",
-            "fileVersion": "1.0.10.0"
+            "assemblyVersion": "1.0.11.0",
+            "fileVersion": "1.0.11.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
+          "MySql.Data": "8.0.33",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Net.Http": "4.3.4",
+          "System.Runtime.Caching": "8.0.1",
+          "System.Text.Json": "8.0.4",
+          "morelinq": "4.1.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.MySql.dll": {
+            "assemblyVersion": "1.0.31.0",
+            "fileVersion": "1.0.31.0"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
         "dependencies": {
           "Azure.AI.OpenAI": "1.0.0-beta.15",
-          "Azure.Data.Tables": "12.8.3",
-          "Azure.Identity": "1.12.0",
+          "Azure.Data.Tables": "12.9.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.0-preview",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.dll": {
-            "assemblyVersion": "0.16.0.0",
-            "fileVersion": "0.16.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
         "dependencies": {
-          "Azure.Search.Documents": "11.5.1",
+          "Azure.Search.Documents": "11.6.0",
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.AzureAISearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha",
-          "MongoDB.Driver": "2.25.0"
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha",
+          "MongoDB.Driver": "2.29.0"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.CosmosDBSearch.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+      "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
         "dependencies": {
           "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.Kusto.Data": "12.2.3",
-          "Microsoft.Azure.Kusto.Ingest": "12.2.3",
-          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.16.0-alpha"
+          "Microsoft.Azure.Kusto.Data": "12.2.7",
+          "Microsoft.Azure.Kusto.Ingest": "12.2.7",
+          "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.18.0-alpha"
         },
         "runtime": {
           "lib/netstandard2.1/WebJobs.Extensions.OpenAI.Kusto.dll": {
-            "assemblyVersion": "0.15.0.0",
-            "fileVersion": "0.15.0.0"
+            "assemblyVersion": "0.18.0.0",
+            "fileVersion": "0.18.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "RabbitMQ.Client": "5.1.2",
           "System.Json": "4.5.0"
         },
@@ -1575,8 +1547,8 @@
       "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0",
           "Newtonsoft.Json": "13.0.3",
           "StackExchange.Redis": "2.7.4"
         },
@@ -1587,121 +1559,119 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+      "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
         "dependencies": {
           "Grpc.AspNetCore": "2.49.0",
-          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37"
+          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.39"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.Rpc.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+      "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Sendgrid": "9.10.0"
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "SendGrid": "9.29.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SendGrid.dll": {
-            "assemblyVersion": "3.0.3.0",
-            "fileVersion": "3.0.3.0"
+            "assemblyVersion": "3.1.0.0",
+            "fileVersion": "3.1.0.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+      "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
         "dependencies": {
-          "Azure.Messaging.ServiceBus": "7.18.1",
-          "Google.Protobuf": "3.24.3",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.37",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Messaging.ServiceBus": "7.18.2",
+          "Google.Protobuf": "3.28.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
-            "assemblyVersion": "5.16.4.0",
-            "fileVersion": "5.1600.424.40802"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.ServiceBus.dll": {
+            "assemblyVersion": "5.16.5.0",
+            "fileVersion": "5.1600.525.16402"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
         "dependencies": {
-          "MessagePack": "1.9.11",
-          "Microsoft.AspNetCore.Http.Connections": "1.0.15",
-          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "1.1.5",
-          "Microsoft.Azure.Functions.Extensions": "1.1.0",
-          "Microsoft.Azure.SignalR": "1.25.2",
-          "Microsoft.Azure.SignalR.Management": "1.25.2",
-          "Microsoft.Azure.SignalR.Protocols": "1.25.2",
+          "MessagePack": "2.5.192",
+          "Microsoft.Azure.SignalR": "1.29.0",
+          "Microsoft.Azure.SignalR.Management": "1.29.0",
+          "Microsoft.Azure.SignalR.Protocols": "1.29.0",
           "Microsoft.Azure.SignalR.Serverless.Protocols": "1.10.0",
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
-          "Microsoft.Extensions.Azure": "1.7.4",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
-            "assemblyVersion": "1.14.0.0",
-            "fileVersion": "1.1400.24.28101"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.SignalRService.dll": {
+            "assemblyVersion": "2.0.1.0",
+            "fileVersion": "2.0.125.16401"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Data.SqlClient": "5.2.1",
-          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9123.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.0",
-          "morelinq": "3.4.2"
+          "System.Runtime.Caching": "8.0.1",
+          "morelinq": "4.1.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.169.0",
-            "fileVersion": "3.1.169.0"
+            "assemblyVersion": "3.1.376.0",
+            "fileVersion": "3.1.376.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.1",
-          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.1"
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
+          "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4"
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.21.0",
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Blobs": "12.23.0",
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
         "dependencies": {
-          "Azure.Storage.Queues": "12.19.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
-          "Microsoft.Extensions.Azure": "1.7.4"
+          "Azure.Storage.Queues": "12.22.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.11.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
-            "assemblyVersion": "5.3.1.0",
-            "fileVersion": "5.300.124.36701"
+          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.Storage.Queues.dll": {
+            "assemblyVersion": "5.3.4.0",
+            "fileVersion": "5.300.425.11101"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Twilio": "5.6.3"
         },
         "runtime": {
@@ -1711,9 +1681,26 @@
           }
         }
       },
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+        "dependencies": {
+          "Azure.Identity": "1.13.1",
+          "Azure.Messaging.WebPubSub": "1.4.0",
+          "Microsoft.AspNetCore.Http": "2.2.2",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebPubSub.Common": "1.4.0",
+          "Microsoft.Extensions.Azure": "1.11.0",
+          "Microsoft.IdentityModel.Tokens": "7.6.3"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.24.47903"
+          }
+        }
+      },
       "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "WindowsAzure.Storage": "9.3.1"
         },
         "runtime": {
@@ -1723,28 +1710,31 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.39"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
-            "assemblyVersion": "3.0.37.0",
-            "fileVersion": "3.0.37.0"
+            "assemblyVersion": "3.0.39.0",
+            "fileVersion": "3.0.39.0"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
+      "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
         "dependencies": {
-          "Microsoft.CodeAnalysis": "3.3.1",
-          "Microsoft.CodeAnalysis.CSharp": "3.3.1",
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Collections.Immutable": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.14492.0"
+            "fileVersion": "1.0.22000.0"
           }
         }
       },
@@ -1753,11 +1743,24 @@
           "System.Runtime.Loader": "4.3.0"
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+      "Microsoft.Azure.WebPubSub.Common/1.4.0": {
+        "dependencies": {
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Encodings.Web": "8.0.0",
+          "System.Text.Json": "8.0.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Azure.WebPubSub.Common.dll": {
+            "assemblyVersion": "1.4.0.0",
+            "fileVersion": "1.400.24.47402"
+          }
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces/10.0.0-preview.2.25163.2": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "assemblyVersion": "10.0.0.0",
+            "fileVersion": "10.0.25.16302"
           }
         }
       },
@@ -1769,383 +1772,53 @@
           }
         }
       },
-      "Microsoft.CodeAnalysis/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "3.3.1",
-          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "3.3.1"
-        }
-      },
-      "Microsoft.CodeAnalysis.Analyzers/2.9.4": {},
-      "Microsoft.CodeAnalysis.Common/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "2.9.4",
-          "System.Collections.Immutable": "8.0.0",
-          "System.Memory": "4.5.5",
-          "System.Reflection.Metadata": "1.6.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encoding.CodePages": "4.5.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.CSharp.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.CSharp.Workspaces/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.CSharp": "3.3.1",
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.CSharp.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.CSharp.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.VisualBasic/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.VisualBasic.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.VisualBasic.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.VisualBasic.Workspaces/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "Microsoft.CodeAnalysis.VisualBasic": "3.3.1",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "3.3.1"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.VisualBasic.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
-      "Microsoft.CodeAnalysis.Workspaces.Common/3.3.1": {
-        "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "3.3.1",
-          "System.Composition": "1.0.31"
-        },
-        "runtime": {
-          "lib/netstandard2.0/Microsoft.CodeAnalysis.Workspaces.dll": {
-            "assemblyVersion": "3.3.0.0",
-            "fileVersion": "3.300.119.46211"
-          }
-        },
-        "resources": {
-          "lib/netstandard2.0/cs/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "cs"
-          },
-          "lib/netstandard2.0/de/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "de"
-          },
-          "lib/netstandard2.0/es/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "es"
-          },
-          "lib/netstandard2.0/fr/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "fr"
-          },
-          "lib/netstandard2.0/it/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "it"
-          },
-          "lib/netstandard2.0/ja/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ja"
-          },
-          "lib/netstandard2.0/ko/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ko"
-          },
-          "lib/netstandard2.0/pl/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "pl"
-          },
-          "lib/netstandard2.0/pt-BR/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "pt-BR"
-          },
-          "lib/netstandard2.0/ru/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "ru"
-          },
-          "lib/netstandard2.0/tr/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "tr"
-          },
-          "lib/netstandard2.0/zh-Hans/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "zh-Hans"
-          },
-          "lib/netstandard2.0/zh-Hant/Microsoft.CodeAnalysis.Workspaces.resources.dll": {
-            "locale": "zh-Hant"
-          }
-        }
-      },
       "Microsoft.CSharp/4.7.0": {},
-      "Microsoft.Data.SqlClient/5.2.1": {
+      "Microsoft.Data.SqlClient/5.2.2": {
         "dependencies": {
-          "Azure.Identity": "1.12.0",
+          "Azure.Identity": "1.13.1",
           "Microsoft.Data.SqlClient.SNI.runtime": "5.2.0",
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.SqlServer.Server": "1.0.0",
-          "System.Configuration.ConfigurationManager": "8.0.0",
-          "System.Runtime.Caching": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.Caching": "8.0.1"
         },
         "runtime": {
-          "runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll": {
+          "runtimes/win/lib/net8.0/Microsoft.Data.SqlClient.dll": {
             "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.21.24152.3"
+            "fileVersion": "5.22.24240.6"
           }
         },
         "resources": {
-          "lib/net6.0/de/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/de/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "de"
           },
-          "lib/net6.0/es/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/es/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "es"
           },
-          "lib/net6.0/fr/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/fr/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "fr"
           },
-          "lib/net6.0/it/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/it/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "it"
           },
-          "lib/net6.0/ja/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ja/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ja"
           },
-          "lib/net6.0/ko/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ko/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ko"
           },
-          "lib/net6.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/pt-BR/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "pt-BR"
           },
-          "lib/net6.0/ru/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/ru/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "ru"
           },
-          "lib/net6.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hans/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hans"
           },
-          "lib/net6.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
+          "lib/net8.0/zh-Hant/Microsoft.Data.SqlClient.resources.dll": {
             "locale": "zh-Hant"
           }
         }
@@ -2159,14 +1832,14 @@
       },
       "Microsoft.DotNet.PlatformAbstractions/2.1.0": {
         "dependencies": {
-          "System.AppContext": "4.1.0",
+          "System.AppContext": "4.3.0",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.IO.FileSystem": "4.3.0",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
         },
         "runtime": {
           "lib/netstandard1.3/Microsoft.DotNet.PlatformAbstractions.dll": {
@@ -2175,101 +1848,133 @@
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.1.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
         "dependencies": {
-          "Google.Protobuf": "3.24.3",
-          "Grpc.Net.Client": "2.52.0"
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Google.Protobuf": "3.28.2",
+          "Grpc.Net.Client": "2.67.0",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.1.0.0",
-            "fileVersion": "1.1.0.4758"
+          "lib/net6.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.2.63069"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.3.0": {
+      "Microsoft.DurableTask.SqlServer/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "2.17.1",
-          "Microsoft.Data.SqlClient": "5.2.1",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Azure.DurableTask.Core": "3.0.0",
+          "Microsoft.Data.SqlClient": "5.2.2",
+          "Microsoft.IdentityModel.JsonWebTokens": "7.6.3",
           "SemanticVersion": "2.1.0",
-          "System.Threading.Channels": "4.7.1"
+          "System.IdentityModel.Tokens.Jwt": "7.5.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "2.13.5",
-          "Microsoft.DurableTask.SqlServer": "1.3.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.0.4",
+          "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.6010"
+          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.1.5512"
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.4": {
+      "Microsoft.Extensions.Azure/1.11.0": {
         "dependencies": {
-          "Azure.Core": "1.41.0",
-          "Azure.Identity": "1.12.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Azure.Core": "1.44.1",
+          "Azure.Identity": "1.13.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.4.0",
-            "fileVersion": "1.700.424.31303"
+          "lib/net8.0/Microsoft.Extensions.Azure.dll": {
+            "assemblyVersion": "1.11.0.0",
+            "fileVersion": "1.1100.25.16402"
           }
         }
       },
-      "Microsoft.Extensions.Configuration/2.2.0": {
+      "Microsoft.Extensions.Caching.Abstractions/1.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Primitives": "7.0.0",
+          "System.Collections": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
+      "Microsoft.Extensions.Caching.Memory/1.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "1.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0",
+          "System.Linq": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration/3.1.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions/3.1.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Binder/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
-      "Microsoft.Extensions.Configuration.FileExtensions/2.2.0": {
+      "Microsoft.Extensions.Configuration.FileExtensions/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0"
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0"
         }
       },
-      "Microsoft.Extensions.Configuration.Json/2.1.0": {
+      "Microsoft.Extensions.Configuration.Json/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.1.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection/6.0.0": {
+      "Microsoft.Extensions.DependencyInjection/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
+        }
+      },
       "Microsoft.Extensions.DependencyModel/2.1.0": {
         "dependencies": {
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
@@ -2285,137 +1990,128 @@
           }
         }
       },
-      "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
+      "Microsoft.Extensions.FileProviders.Abstractions/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
-      "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
+      "Microsoft.Extensions.FileProviders.Physical/3.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.FileSystemGlobbing": "2.2.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "3.1.0"
         }
       },
-      "Microsoft.Extensions.FileSystemGlobbing/2.2.0": {},
+      "Microsoft.Extensions.FileSystemGlobbing/3.1.0": {},
       "Microsoft.Extensions.Hosting/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "2.2.0",
+          "Microsoft.Extensions.Configuration": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "3.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging": "6.0.0"
+          "Microsoft.Extensions.Logging": "7.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "2.2.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.1.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Http/3.1.32": {
+      "Microsoft.Extensions.Http/6.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging/6.0.0": {
+      "Microsoft.Extensions.Logging/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "6.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0",
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
+          "Microsoft.Extensions.DependencyInjection": "7.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions/6.0.0": {},
+      "Microsoft.Extensions.Logging.Abstractions/7.0.0": {},
+      "Microsoft.Extensions.Logging.ApplicationInsights/2.21.0": {
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.Extensions.Logging": "7.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.ApplicationInsights.dll": {
+            "assemblyVersion": "2.21.0.429",
+            "fileVersion": "2.21.0.429"
+          }
+        }
+      },
       "Microsoft.Extensions.Logging.Configuration/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "2.1.0"
         }
       },
       "Microsoft.Extensions.ObjectPool/2.2.0": {},
-      "Microsoft.Extensions.Options/6.0.0": {
+      "Microsoft.Extensions.Options/7.0.0": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Primitives": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "2.2.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0",
           "Microsoft.Extensions.Configuration.Binder": "2.2.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
-          "Microsoft.Extensions.Options": "6.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "7.0.0"
         }
       },
-      "Microsoft.Extensions.Primitives/6.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
+      "Microsoft.Extensions.Primitives/7.0.0": {},
       "Microsoft.FASTER.Core/2.6.5": {
         "dependencies": {
-          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging": "7.0.0",
           "System.Interactive.Async": "6.0.1",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
-          "lib/net6.0/FASTER.core.dll": {
+          "lib/net7.0/FASTER.core.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "1.0.0.0"
           }
         }
       },
-      "Microsoft.Identity.Client/4.61.3": {
+      "Microsoft.Identity.Client/4.66.1": {
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "7.6.3",
           "System.Diagnostics.DiagnosticSource": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
-      "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+      "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
         "dependencies": {
-          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client": "4.66.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Identity.Client.Extensions.Msal.dll": {
-            "assemblyVersion": "4.61.3.0",
-            "fileVersion": "4.61.3.0"
+            "assemblyVersion": "4.66.1.0",
+            "fileVersion": "4.66.1.0"
           }
         }
       },
       "Microsoft.IdentityModel.Abstractions/7.6.3": {
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Abstractions.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Abstractions.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
-          }
-        }
-      },
-      "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-        "dependencies": {
-          "NETStandard.Library": "2.0.1",
-          "System.Runtime.Serialization.Json": "4.0.2",
-          "System.Runtime.Serialization.Primitives": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
-          },
-          "lib/netstandard1.3/Microsoft.IdentityModel.Clients.ActiveDirectory.dll": {
-            "assemblyVersion": "3.14.2.11",
-            "fileVersion": "3.14.40721.918"
           }
         }
       },
@@ -2424,7 +2120,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.JsonWebTokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2435,7 +2131,7 @@
           "Microsoft.IdentityModel.Abstractions": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Logging.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Logging.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2470,7 +2166,7 @@
           "Microsoft.IdentityModel.Logging": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.IdentityModel.Tokens.dll": {
+          "lib/net8.0/Microsoft.IdentityModel.Tokens.dll": {
             "assemblyVersion": "7.6.3.0",
             "fileVersion": "7.6.3.50709"
           }
@@ -2486,14 +2182,14 @@
       },
       "Microsoft.Net.Http.Headers/2.2.0": {
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "6.0.0",
+          "Microsoft.Extensions.Primitives": "7.0.0",
           "System.Buffers": "4.5.1"
         }
       },
-      "Microsoft.NET.Sdk.Functions/4.4.0": {
+      "Microsoft.NET.Sdk.Functions/4.6.0": {
         "dependencies": {
           "Microsoft.Azure.Functions.Analyzers": "1.0.0",
-          "Microsoft.Azure.WebJobs": "3.0.39",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "3.0.6",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator": "4.0.1",
@@ -2503,7 +2199,15 @@
           "System.Text.RegularExpressions": "4.3.1"
         }
       },
-      "Microsoft.NETCore.Platforms/2.1.2": {},
+      "Microsoft.NET.StringTools/17.6.3": {
+        "runtime": {
+          "lib/net7.0/Microsoft.NET.StringTools.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "17.6.3.22601"
+          }
+        }
+      },
+      "Microsoft.NETCore.Platforms/3.1.9": {},
       "Microsoft.NETCore.Targets/1.1.3": {},
       "Microsoft.SqlServer.Server/1.0.0": {
         "runtime": {
@@ -2513,11 +2217,11 @@
           }
         }
       },
-      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+      "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
         "runtime": {
           "lib/net6.0/Microsoft.SqlServer.TransactSql.ScriptDom.dll": {
             "assemblyVersion": "16.1.0.0",
-            "fileVersion": "16.1.9123.0"
+            "fileVersion": "16.1.9135.0"
           }
         },
         "resources": {
@@ -2564,7 +2268,7 @@
       },
       "Microsoft.Win32.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.win.Microsoft.Win32.Primitives": "4.3.0"
@@ -2576,39 +2280,50 @@
           "System.Security.Principal.Windows": "5.0.0"
         }
       },
-      "MongoDB.Bson/2.25.0": {
+      "Microsoft.Win32.SystemEvents/4.7.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp3.0/Microsoft.Win32.SystemEvents.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "MongoDB.Bson/2.29.0": {
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Bson.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver/2.25.0": {
+      "MongoDB.Driver/2.29.0": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Driver.Core": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2"
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Driver.Core": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0"
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Driver.Core/2.25.0": {
+      "MongoDB.Driver.Core/2.29.0": {
         "dependencies": {
           "AWSSDK.SecurityToken": "3.7.100.14",
           "DnsClient": "1.6.1",
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
-          "MongoDB.Bson": "2.25.0",
-          "MongoDB.Libmongocrypt": "1.8.2",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
+          "MongoDB.Bson": "2.29.0",
+          "MongoDB.Libmongocrypt": "1.12.0",
           "SharpCompress": "0.30.1",
           "Snappier": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -2616,16 +2331,16 @@
         },
         "runtime": {
           "lib/netstandard2.1/MongoDB.Driver.Core.dll": {
-            "assemblyVersion": "2.25.0.0",
-            "fileVersion": "2.25.0.0"
+            "assemblyVersion": "2.29.0.0",
+            "fileVersion": "2.29.0.0"
           }
         }
       },
-      "MongoDB.Libmongocrypt/1.8.2": {
+      "MongoDB.Libmongocrypt/1.12.0": {
         "runtime": {
           "lib/netstandard2.1/MongoDB.Libmongocrypt.dll": {
-            "assemblyVersion": "1.8.2.0",
-            "fileVersion": "1.8.2.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         },
         "native": {
@@ -2634,11 +2349,32 @@
           }
         }
       },
-      "morelinq/3.4.2": {
+      "morelinq/4.1.0": {
         "runtime": {
-          "lib/net6.0/MoreLinq.dll": {
-            "assemblyVersion": "3.4.2.0",
-            "fileVersion": "3.4.2.0"
+          "lib/net8.0/MoreLinq.dll": {
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
+          }
+        }
+      },
+      "MySql.Data/8.0.33": {
+        "dependencies": {
+          "Google.Protobuf": "3.28.2",
+          "K4os.Compression.LZ4.Streams": "1.3.5",
+          "Portable.BouncyCastle": "1.9.0",
+          "System.Buffers": "4.5.1",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Runtime.Loader": "4.3.0",
+          "System.Security.Permissions": "4.7.0",
+          "System.Text.Encoding.CodePages": "4.4.0",
+          "System.Text.Json": "8.0.4",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        },
+        "runtime": {
+          "lib/net7.0/MySql.Data.dll": {
+            "assemblyVersion": "8.0.33.0",
+            "fileVersion": "8.0.33.0"
           }
         }
       },
@@ -2658,9 +2394,52 @@
           }
         }
       },
-      "NETStandard.Library/2.0.1": {
+      "NETStandard.Library/1.6.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2"
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.AppContext": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Console": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.Compression.ZipFile": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Net.Http": "4.3.4",
+          "System.Net.Primitives": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.1",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Timer": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0"
         }
       },
       "Newtonsoft.Json/13.0.3": {
@@ -2673,7 +2452,7 @@
       },
       "Newtonsoft.Json.Bson/1.0.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -2685,12 +2464,20 @@
       },
       "Pipelines.Sockets.Unofficial/2.2.8": {
         "dependencies": {
-          "System.IO.Pipelines": "5.0.1"
+          "System.IO.Pipelines": "6.0.3"
         },
         "runtime": {
           "lib/net5.0/Pipelines.Sockets.Unofficial.dll": {
             "assemblyVersion": "1.0.0.0",
             "fileVersion": "2.2.8.1080"
+          }
+        }
+      },
+      "Portable.BouncyCastle/1.9.0": {
+        "runtime": {
+          "lib/netstandard2.0/BouncyCastle.Crypto.dll": {
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.1"
           }
         }
       },
@@ -2726,24 +2513,31 @@
       "runtime.any.System.Text.Encoding/4.3.0": {},
       "runtime.any.System.Text.Encoding.Extensions/4.3.0": {},
       "runtime.any.System.Threading.Tasks/4.3.0": {},
+      "runtime.any.System.Threading.Timer/4.3.0": {},
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.native.System/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
+      "runtime.native.System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
       "runtime.native.System.Net.Http/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
-      "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+      "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
         "dependencies": {
-          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.1"
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
         }
       },
       "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
@@ -2762,7 +2556,7 @@
       },
       "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
-      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {},
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {},
       "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
       "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {},
@@ -2772,6 +2566,19 @@
         "dependencies": {
           "System.Runtime": "4.3.1",
           "System.Runtime.InteropServices": "4.3.0"
+        }
+      },
+      "runtime.win.System.Console/4.3.1": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
         }
       },
       "runtime.win.System.Diagnostics.Debug/4.3.0": {},
@@ -2843,15 +2650,15 @@
           }
         }
       },
-      "Sendgrid/9.10.0": {
+      "SendGrid/9.29.3": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Newtonsoft.Json": "13.0.3",
+          "starkbank-ecdsa": "1.3.3"
         },
         "runtime": {
           "lib/netstandard2.0/SendGrid.dll": {
-            "assemblyVersion": "9.10.0.0",
-            "fileVersion": "9.10.0.0"
+            "assemblyVersion": "9.29.3.0",
+            "fileVersion": "9.29.3.0"
           }
         }
       },
@@ -2873,7 +2680,7 @@
       },
       "StackExchange.Redis/2.7.4": {
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8"
         },
         "runtime": {
@@ -2883,21 +2690,29 @@
           }
         }
       },
-      "System.AppContext/4.1.0": {
+      "starkbank-ecdsa/1.3.3": {
+        "runtime": {
+          "lib/netstandard2.1/StarkbankEcdsa.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          }
+        }
+      },
+      "System.AppContext/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
         }
       },
       "System.Buffers/4.5.1": {},
-      "System.ClientModel/1.0.0": {
+      "System.ClientModel/1.1.0": {
         "dependencies": {
-          "System.Memory.Data": "1.0.2",
-          "System.Text.Json": "8.0.1"
+          "System.Memory.Data": "6.0.1",
+          "System.Text.Json": "8.0.4"
         },
         "runtime": {
           "lib/net6.0/System.ClientModel.dll": {
-            "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.24.5302"
+            "assemblyVersion": "1.1.0.0",
+            "fileVersion": "1.100.24.46703"
           }
         }
       },
@@ -2911,7 +2726,7 @@
       },
       "System.Collections/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Collections": "4.3.0"
@@ -2931,17 +2746,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Collections.Immutable.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -2964,173 +2769,62 @@
         }
       },
       "System.ComponentModel.Annotations/4.4.0": {},
-      "System.Composition/1.0.31": {
+      "System.Configuration.ConfigurationManager/8.0.1": {
         "dependencies": {
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Convention": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Composition.TypedParts": "1.0.31"
-        }
-      },
-      "System.Composition.AttributedModel/1.0.31": {
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.1"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.AttributedModel.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Convention/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Threading": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Convention.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Hosting/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Threading": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Hosting.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.Runtime/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.Runtime.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Composition.TypedParts/1.0.31": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0"
-        },
-        "runtime": {
-          "lib/netstandard1.0/System.Composition.TypedParts.dll": {
-            "assemblyVersion": "1.0.31.0",
-            "fileVersion": "4.6.24705.1"
-          }
-        }
-      },
-      "System.Configuration.ConfigurationManager/8.0.0": {
-        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
           "System.Security.Cryptography.ProtectedData": "8.0.0"
         },
         "runtime": {
-          "lib/net6.0/System.Configuration.ConfigurationManager.dll": {
+          "lib/net8.0/System.Configuration.ConfigurationManager.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
           }
+        }
+      },
+      "System.Console/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3",
+          "System.IO": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.win.System.Console": "4.3.1"
         }
       },
       "System.Diagnostics.Debug/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.win.System.Diagnostics.Debug": "4.3.0"
         }
       },
-      "System.Diagnostics.DiagnosticSource/8.0.0": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
+      "System.Diagnostics.DiagnosticSource/8.0.0": {},
+      "System.Diagnostics.EventLog/8.0.1": {
         "runtime": {
-          "lib/net6.0/System.Diagnostics.DiagnosticSource.dll": {
+          "runtimes/win/lib/net8.0/System.Diagnostics.EventLog.dll": {
             "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
-      "System.Diagnostics.EventLog/6.0.0": {},
-      "System.Diagnostics.Process/4.3.0": {
+      "System.Diagnostics.PerformanceCounter/4.7.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.Win32.Registry": "5.0.0",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.IO.FileSystem": "4.3.0",
-          "System.IO.FileSystem.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Thread": "4.3.0",
-          "System.Threading.ThreadPool": "4.3.0",
-          "runtime.native.System": "4.3.0"
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Principal.Windows": "5.0.0"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp2.0/System.Diagnostics.PerformanceCounter.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.700.19.56404"
+          }
         }
       },
       "System.Diagnostics.Tools/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Diagnostics.Tools": "4.3.0"
@@ -3138,7 +2832,7 @@
       },
       "System.Diagnostics.TraceSource/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3151,10 +2845,22 @@
       },
       "System.Diagnostics.Tracing/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Diagnostics.Tracing": "4.3.0"
+        }
+      },
+      "System.Drawing.Common/4.7.3": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.Win32.SystemEvents": "4.7.0"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp3.0/System.Drawing.Common.dll": {
+            "assemblyVersion": "4.0.2.3",
+            "fileVersion": "4.700.21.51508"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.11": {
@@ -3176,17 +2882,10 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Formats.Asn1/6.0.1": {
-        "runtime": {
-          "lib/net6.0/System.Formats.Asn1.dll": {
-            "assemblyVersion": "6.0.0.0",
-            "fileVersion": "6.0.3224.31407"
-          }
-        }
-      },
+      "System.Formats.Asn1/6.0.1": {},
       "System.Globalization/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Globalization": "4.3.0"
@@ -3194,7 +2893,7 @@
       },
       "System.Globalization.Calendars/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3203,7 +2902,7 @@
       },
       "System.Globalization.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Globalization": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3217,7 +2916,7 @@
           "Microsoft.IdentityModel.Tokens": "7.6.3"
         },
         "runtime": {
-          "lib/net6.0/System.IdentityModel.Tokens.Jwt.dll": {
+          "lib/net8.0/System.IdentityModel.Tokens.Jwt.dll": {
             "assemblyVersion": "7.5.1.0",
             "fileVersion": "7.5.1.50405"
           }
@@ -3236,7 +2935,7 @@
       },
       "System.IO/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0",
@@ -3244,9 +2943,41 @@
           "runtime.any.System.IO": "4.3.0"
         }
       },
+      "System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "System.Buffers": "4.5.1",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        }
+      },
+      "System.IO.Compression.ZipFile/4.3.0": {
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.IO": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.1",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
       "System.IO.FileSystem/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.IO.FileSystem.Primitives": "4.3.0",
@@ -3255,6 +2986,12 @@
           "System.Text.Encoding": "4.3.0",
           "System.Threading.Tasks": "4.3.0",
           "runtime.win.System.IO.FileSystem": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.AccessControl/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Security.Principal.Windows": "5.0.0"
         }
       },
       "System.IO.FileSystem.Primitives/4.3.0": {
@@ -3270,7 +3007,7 @@
           }
         }
       },
-      "System.IO.Pipelines/5.0.1": {},
+      "System.IO.Pipelines/6.0.3": {},
       "System.Json/4.5.0": {
         "runtime": {
           "lib/netstandard2.0/System.Json.dll": {
@@ -3290,7 +3027,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.0-preview.2.25163.2"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3321,21 +3058,17 @@
         }
       },
       "System.Memory/4.5.5": {},
-      "System.Memory.Data/1.0.2": {
-        "dependencies": {
-          "System.Text.Encodings.Web": "8.0.0",
-          "System.Text.Json": "8.0.1"
-        },
+      "System.Memory.Data/6.0.1": {
         "runtime": {
-          "lib/netstandard2.0/System.Memory.Data.dll": {
-            "assemblyVersion": "1.0.2.0",
-            "fileVersion": "1.0.221.20802"
+          "lib/net6.0/System.Memory.Data.dll": {
+            "assemblyVersion": "6.0.0.1",
+            "fileVersion": "6.0.3624.51421"
           }
         }
       },
       "System.Net.Http/4.3.4": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
@@ -3350,11 +3083,11 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.OpenSsl": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
-          "System.Security.Cryptography.X509Certificates": "4.3.2",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0",
@@ -3365,7 +3098,7 @@
       },
       "System.Net.NameResolution/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Tracing": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3383,30 +3116,30 @@
       },
       "System.Net.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0",
           "runtime.win.System.Net.Primitives": "4.3.0"
         }
       },
+      "System.Net.ServerSentEvents/10.0.0-preview.1.25080.5": {
+        "runtime": {
+          "lib/net8.0/System.Net.ServerSentEvents.dll": {
+            "assemblyVersion": "10.0.0.0",
+            "fileVersion": "10.0.25.8005"
+          }
+        }
+      },
       "System.Net.Sockets/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Net.Primitives": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Threading.Tasks": "4.3.0",
           "runtime.win.System.Net.Sockets": "4.3.0"
-        }
-      },
-      "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-        "runtime": {
-          "lib/netcoreapp2.1/System.Net.WebSockets.WebSocketProtocol.dll": {
-            "assemblyVersion": "4.0.0.2",
-            "fileVersion": "4.6.27129.4"
-          }
         }
       },
       "System.Numerics.Vectors/4.5.0": {},
@@ -3419,37 +3152,9 @@
           "System.Threading": "4.3.0"
         }
       },
-      "System.Private.DataContractSerialization/4.1.1": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Collections.Concurrent": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Serialization.Primitives": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Text.Encoding.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1",
-          "System.Xml.XmlSerializer": "4.0.11"
-        }
-      },
       "System.Private.Uri/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
       },
@@ -3525,7 +3230,7 @@
       },
       "System.Reflection/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.IO": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
@@ -3559,7 +3264,7 @@
       },
       "System.Reflection.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Runtime": "4.3.1",
@@ -3569,7 +3274,7 @@
       "System.Reflection.Metadata/1.6.0": {},
       "System.Reflection.Primitives/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Reflection.Primitives": "4.3.0"
@@ -3578,7 +3283,7 @@
       "System.Reflection.TypeExtensions/4.7.0": {},
       "System.Resources.ResourceManager/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Globalization": "4.3.0",
           "System.Reflection": "4.3.0",
@@ -3588,26 +3293,26 @@
       },
       "System.Runtime/4.3.1": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "runtime.any.System.Runtime": "4.3.0"
         }
       },
-      "System.Runtime.Caching/8.0.0": {
+      "System.Runtime.Caching/8.0.1": {
         "dependencies": {
-          "System.Configuration.ConfigurationManager": "8.0.0"
+          "System.Configuration.ConfigurationManager": "8.0.1"
         },
         "runtime": {
-          "runtimes/win/lib/net6.0/System.Runtime.Caching.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
+          "runtimes/win/lib/net8.0/System.Runtime.Caching.dll": {
+            "assemblyVersion": "8.0.0.1",
+            "fileVersion": "8.0.1024.46610"
           }
         }
       },
       "System.Runtime.CompilerServices.Unsafe/6.0.0": {},
       "System.Runtime.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.win.System.Runtime.Extensions": "4.3.0"
@@ -3615,7 +3320,7 @@
       },
       "System.Runtime.Handles/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Runtime.Handles": "4.3.0"
@@ -3623,7 +3328,7 @@
       },
       "System.Runtime.InteropServices/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Reflection": "4.3.0",
           "System.Reflection.Primitives": "4.3.0",
@@ -3632,10 +3337,10 @@
           "runtime.any.System.Runtime.InteropServices": "4.3.0"
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
           "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.InteropServices": "4.3.0",
@@ -3658,23 +3363,10 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
-      "System.Runtime.Serialization.Json/4.0.2": {
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Private.DataContractSerialization": "4.1.1",
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Runtime.Serialization.Primitives/4.3.0": {
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1"
-        }
-      },
       "System.Security.AccessControl/6.0.0": {},
-      "System.Security.Cryptography.Algorithms/4.3.1": {
+      "System.Security.Cryptography.Algorithms/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3686,7 +3378,7 @@
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
-          "runtime.native.System.Security.Cryptography.Apple": "4.3.1",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
@@ -3697,7 +3389,7 @@
       },
       "System.Security.Cryptography.Csp/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
@@ -3705,7 +3397,7 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3714,7 +3406,7 @@
       },
       "System.Security.Cryptography.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Collections.Concurrent": "4.3.0",
           "System.Linq": "4.3.0",
@@ -3738,7 +3430,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
           "System.Security.Cryptography.Primitives": "4.3.0",
           "System.Text.Encoding": "4.3.0",
@@ -3758,15 +3450,15 @@
       },
       "System.Security.Cryptography.ProtectedData/8.0.0": {
         "runtime": {
-          "lib/net6.0/System.Security.Cryptography.ProtectedData.dll": {
+          "lib/net8.0/System.Security.Cryptography.ProtectedData.dll": {
             "assemblyVersion": "8.0.0.0",
             "fileVersion": "8.0.23.53103"
           }
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.3.2": {
+      "System.Security.Cryptography.X509Certificates/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
           "System.Globalization": "4.3.0",
@@ -3780,7 +3472,7 @@
           "System.Runtime.Handles": "4.3.0",
           "System.Runtime.InteropServices": "4.3.0",
           "System.Runtime.Numerics": "4.3.0",
-          "System.Security.Cryptography.Algorithms": "4.3.1",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
           "System.Security.Cryptography.Cng": "5.0.0",
           "System.Security.Cryptography.Csp": "4.3.0",
           "System.Security.Cryptography.Encoding": "4.3.0",
@@ -3793,51 +3485,45 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
       },
+      "System.Security.Permissions/4.7.0": {
+        "dependencies": {
+          "System.Security.AccessControl": "6.0.0",
+          "System.Windows.Extensions": "4.7.0"
+        },
+        "runtime": {
+          "lib/netcoreapp3.0/System.Security.Permissions.dll": {
+            "assemblyVersion": "4.0.3.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
       "System.Security.Principal.Windows/5.0.0": {},
       "System.Text.Encoding/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Text.Encoding": "4.3.0"
         }
       },
-      "System.Text.Encoding.CodePages/4.5.1": {
+      "System.Text.Encoding.CodePages/4.4.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+          "Microsoft.NETCore.Platforms": "3.1.9"
         }
       },
       "System.Text.Encoding.Extensions/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "System.Text.Encoding": "4.3.0",
           "runtime.any.System.Text.Encoding.Extensions": "4.3.0"
         }
       },
-      "System.Text.Encodings.Web/8.0.0": {
+      "System.Text.Encodings.Web/8.0.0": {},
+      "System.Text.Json/8.0.4": {
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Encodings.Web.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.23.53103"
-          }
-        }
-      },
-      "System.Text.Json/8.0.1": {
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "8.0.0"
-        },
-        "runtime": {
-          "lib/net6.0/System.Text.Json.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.123.58001"
-          }
         }
       },
       "System.Text.RegularExpressions/4.3.1": {
@@ -3851,10 +3537,10 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Threading.Channels/4.7.1": {},
+      "System.Threading.Channels/6.0.0": {},
       "System.Threading.Overlapped/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Handles": "4.3.0"
@@ -3862,7 +3548,7 @@
       },
       "System.Threading.Tasks/4.3.0": {
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "2.1.2",
+          "Microsoft.NETCore.Platforms": "3.1.9",
           "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
           "runtime.any.System.Threading.Tasks": "4.3.0"
@@ -3870,19 +3556,27 @@
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
       "System.Threading.Tasks.Extensions/4.5.4": {},
-      "System.Threading.Thread/4.3.0": {
+      "System.Threading.Timer/4.3.0": {
         "dependencies": {
-          "System.Runtime": "4.3.1"
-        }
-      },
-      "System.Threading.ThreadPool/4.3.0": {
-        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.9",
+          "Microsoft.NETCore.Targets": "1.1.3",
           "System.Runtime": "4.3.1",
-          "System.Runtime.Handles": "4.3.0"
+          "runtime.any.System.Threading.Timer": "4.3.0"
         }
       },
       "System.ValueTuple/4.5.0": {},
-      "System.Xml.ReaderWriter/4.0.11": {
+      "System.Windows.Extensions/4.7.0": {
+        "dependencies": {
+          "System.Drawing.Common": "4.7.3"
+        },
+        "runtime": {
+          "runtimes/win/lib/netcoreapp3.0/System.Windows.Extensions.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.700.19.56404"
+          }
+        }
+      },
+      "System.Xml.ReaderWriter/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
@@ -3901,46 +3595,27 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "System.Xml.XmlDocument/4.0.1": {
+      "System.Xml.XDocument/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
           "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.1",
           "System.Runtime.Extensions": "4.3.0",
           "System.Text.Encoding": "4.3.0",
           "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11"
-        }
-      },
-      "System.Xml.XmlSerializer/4.0.11": {
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.7.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Text.RegularExpressions": "4.3.1",
-          "System.Threading": "4.3.0",
-          "System.Xml.ReaderWriter": "4.0.11",
-          "System.Xml.XmlDocument": "4.0.1"
+          "System.Xml.ReaderWriter": "4.3.0"
         }
       },
       "Twilio/5.6.3": {
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "7.6.3",
           "Microsoft.IdentityModel.Tokens": "7.6.3",
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Specialized": "4.3.0",
           "System.IdentityModel.Tokens.Jwt": "7.5.1"
@@ -3954,7 +3629,7 @@
       },
       "WindowsAzure.Storage/9.3.1": {
         "dependencies": {
-          "NETStandard.Library": "2.0.1",
+          "NETStandard.Library": "1.6.1",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
@@ -3966,7 +3641,7 @@
       },
       "ZstdSharp.Port/0.7.3": {
         "runtime": {
-          "lib/net6.0/ZstdSharp.dll": {
+          "lib/net7.0/ZstdSharp.dll": {
             "assemblyVersion": "0.7.3.0",
             "fileVersion": "0.7.3.0"
           }
@@ -4016,12 +3691,12 @@
       "path": "azure.ai.openai/1.0.0-beta.15",
       "hashPath": "azure.ai.openai.1.0.0-beta.15.nupkg.sha512"
     },
-    "Azure.Core/1.41.0": {
+    "Azure.Core/1.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7OO8rPCVSvXj2IQET3NkRf8hU2ZDCCvCIUhlrE089qkLNpNfWufJnBwHRKLAOWF3bhKBGJS/9hPBgjJ8kupUIg==",
-      "path": "azure.core/1.41.0",
-      "hashPath": "azure.core.1.41.0.nupkg.sha512"
+      "sha512": "sha512-YyznXLQZCregzHvioip07/BkzjuWNXogJEVz9T5W6TwjNr17ax41YGzYMptlo2G10oLCuVPoyva62y0SIRDixg==",
+      "path": "azure.core/1.44.1",
+      "hashPath": "azure.core.1.44.1.nupkg.sha512"
     },
     "Azure.Core.Amqp/1.3.1": {
       "type": "package",
@@ -4030,19 +3705,19 @@
       "path": "azure.core.amqp/1.3.1",
       "hashPath": "azure.core.amqp.1.3.1.nupkg.sha512"
     },
-    "Azure.Data.Tables/12.8.3": {
+    "Azure.Data.Tables/12.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2wAUXLS1ebTnV+qm9qc1z1MZIPC3as2WJt9bEgL08oC1wlT5UhaW78PlYgTld89p/YWCawJycHtBwVx+SWIuLw==",
-      "path": "azure.data.tables/12.8.3",
-      "hashPath": "azure.data.tables.12.8.3.nupkg.sha512"
+      "sha512": "sha512-d5529gg24alnMKbE8Aw7NY3q9dxFvzfhCMW+TtQA7GGIqASFSIh+536p2qdyJNPEQDFYtqfoLqIBlP9IGqgLfA==",
+      "path": "azure.data.tables/12.9.1",
+      "hashPath": "azure.data.tables.12.9.1.nupkg.sha512"
     },
-    "Azure.Identity/1.12.0": {
+    "Azure.Identity/1.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OBIM3aPz8n9oEO5fdnee+Vsc5Nl4W3FeslPpESyDiyByntQI5BAa76KD60eFXm9ulevnwxGZP9YXL8Y+paI5Uw==",
-      "path": "azure.identity/1.12.0",
-      "hashPath": "azure.identity.1.12.0.nupkg.sha512"
+      "sha512": "sha512-4eeK9XztjTmvA4WN+qAvlUCSxSv45+LqTMeC8XT2giGGZHKthTMU2IuXcHjAOf5VLH3wE3Bo6EwhIcJxVB8RmQ==",
+      "path": "azure.identity/1.13.1",
+      "hashPath": "azure.identity.1.13.1.nupkg.sha512"
     },
     "Azure.Messaging.EventGrid/4.21.0": {
       "type": "package",
@@ -4051,40 +3726,54 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.9.2": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KAC79xzlOUrtQ0mlrPqijznfmlKeraiqavtZ3RfbV+8ukJf9C5fFSZCMSqq9N/2+eUkW3G4wJSchMXAyf+jxow==",
-      "path": "azure.messaging.eventhubs/5.9.2",
-      "hashPath": "azure.messaging.eventhubs.5.9.2.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
-    "Azure.Messaging.ServiceBus/7.18.1": {
+    "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-40KKWWA1PYlZQiMkEZdG7zof0kHfmak1PeCihp/W4vTbb+EYsHNypHEV63R41UBwVcU/lLGQQab6Gl6J8c9Byg==",
-      "path": "azure.messaging.servicebus/7.18.1",
-      "hashPath": "azure.messaging.servicebus.7.18.1.nupkg.sha512"
+      "sha512": "sha512-c0ROPOBgzQ8PLvhG9YNBaq+zMMXRWCLr1C/oPgJqxQMsGxHRfuxvYWNvxTVYe96caiBaGkDDLAUb3wsIWJaw2w==",
+      "path": "azure.messaging.eventhubs.processor/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.processor.5.11.5.nupkg.sha512"
     },
-    "Azure.Search.Documents/11.5.1": {
+    "Azure.Messaging.ServiceBus/7.18.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Vg+1mtM3LXVYwKQ+DDi7Wd/Rf2Ajo6rl5/7bFPfouUMBe/cNg71TIU62PY/eEtKfUI3Y7wdFXNcgGkpUG+OVnw==",
-      "path": "azure.search.documents/11.5.1",
-      "hashPath": "azure.search.documents.11.5.1.nupkg.sha512"
+      "sha512": "sha512-/vmMVM5REjasEnhlQVX0O9PTZXAGS4vflNtox4gx5ofpgQgX6rzG0PnlO0Zy8Jp7454C06QeyGbV3EjVliCzOQ==",
+      "path": "azure.messaging.servicebus/7.18.2",
+      "hashPath": "azure.messaging.servicebus.7.18.2.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.21.0": {
+    "Azure.Messaging.WebPubSub/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W1aSEH11crU3CscfuICUPXScTO9nKwSof3YFsdxmbdi+P+JARYzntkGJuZ685gvmyUse7isBNncNlVEjB5LT0g==",
-      "path": "azure.storage.blobs/12.21.0",
-      "hashPath": "azure.storage.blobs.12.21.0.nupkg.sha512"
+      "sha512": "sha512-27PpgpaTtwOXXP08ZKAt612S/D0ZXINPpR2JTPurbuVPy+eHj1RDvoyJPGsZkHXnk9nVNR6zAu45YBf/8llgOw==",
+      "path": "azure.messaging.webpubsub/1.4.0",
+      "hashPath": "azure.messaging.webpubsub.1.4.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.20.0": {
+    "Azure.Search.Documents/11.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-C0uTY4E1NSGiNf/dlLMQ/d85a2CDazEg4YYtNJOYnLSb8ZXJ5RBPHYGW7a46kN5Xn5Bc9BKMvs8fME285TfEpw==",
-      "path": "azure.storage.common/12.20.0",
-      "hashPath": "azure.storage.common.12.20.0.nupkg.sha512"
+      "sha512": "sha512-M7WLx3ANLPHymfqb4Nwk4EwcWWRiHqdvnxJ7RH857baAbkEZ3FYVCRJmHgxH+ROpYOTVSx30uJzsa573/cdD8A==",
+      "path": "azure.search.documents/11.6.0",
+      "hashPath": "azure.search.documents.11.6.0.nupkg.sha512"
+    },
+    "Azure.Storage.Blobs/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-wokJ5KX/iViQQ32xyCu69+Ter0aR4B9QQ+oR9NCpc/WPIanxnDErrmFfdmE7K8ZdccjHkvE/wEnqJxaF1+5wFg==",
+      "path": "azure.storage.blobs/12.23.0",
+      "hashPath": "azure.storage.blobs.12.23.0.nupkg.sha512"
+    },
+    "Azure.Storage.Common/12.23.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-X/pe1LS3lC6s6MSL7A6FzRfnB6P72rNBt5oSuyan6Q4Jxr+KiN9Ufwqo32YLHOVfPcB8ESZZ4rBDketn+J37Rw==",
+      "path": "azure.storage.common/12.23.0",
+      "hashPath": "azure.storage.common.12.23.0.nupkg.sha512"
     },
     "Azure.Storage.Files.DataLake/12.18.0": {
       "type": "package",
@@ -4093,12 +3782,12 @@
       "path": "azure.storage.files.datalake/12.18.0",
       "hashPath": "azure.storage.files.datalake.12.18.0.nupkg.sha512"
     },
-    "Azure.Storage.Queues/12.19.0": {
+    "Azure.Storage.Queues/12.22.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+EXqf4aTyshZDpi/DBgffEX0CJMbvs9fHTZX4EMPBPc4WHyXCNs2oKelJes1pdHLRwTUVJ3jGdK1kU/IB5lJJw==",
-      "path": "azure.storage.queues/12.19.0",
-      "hashPath": "azure.storage.queues.12.19.0.nupkg.sha512"
+      "sha512": "sha512-HPQgOlfH+rJ4CL4V8ePFnsT/KKnvLU35ytxC3fsTTqOazhQ0593C0aPVu258DRN8bQCbx4OpNpjtiO9czDy3VQ==",
+      "path": "azure.storage.queues/12.22.0",
+      "hashPath": "azure.storage.queues.12.22.0.nupkg.sha512"
     },
     "Castle.Core/5.0.0": {
       "type": "package",
@@ -4121,33 +3810,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/1.9.0": {
+    "Confluent.Kafka/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nw69qqZx5lJp6aY3sdxgY19AMYFMvRDewcA7V4Nl2NGZq30gy53KK5n47AbAjRyhew2EFeR2tDYTBT0a/qZMaQ==",
-      "path": "confluent.kafka/1.9.0",
-      "hashPath": "confluent.kafka.1.9.0.nupkg.sha512"
+      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
+      "path": "confluent.kafka/2.4.0",
+      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/1.9.0": {
+    "Confluent.SchemaRegistry/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-48aKeZZWLp5Ldbsc+YYgZr4MlZIA6Bqaxd1x6cduJti5cykFUm2glv7LQ9ctatd0nFx1uiafVdkkC0yEcsTnBA==",
-      "path": "confluent.schemaregistry/1.9.0",
-      "hashPath": "confluent.schemaregistry.1.9.0.nupkg.sha512"
+      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
+      "path": "confluent.schemaregistry/2.4.0",
+      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NLGYT79XJ0h3iZAFpu7YnBHPZ2ZEW6/098zigwQP9sHAjYVXL2kDrvOwmbkb3unH1XR+M4SIbPc8UlV12kG0zQ==",
-      "path": "confluent.schemaregistry.serdes.avro/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.1.9.0.nupkg.sha512"
+      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
+      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/1.9.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CgEV79MoW+ncCBbXn/zi3TyEFV8GE0SWz0gglZ+ze0JaLsIP78mDCKMn6HLkNV97u6NxfokhwP33Ofg/Mhuq3w==",
-      "path": "confluent.schemaregistry.serdes.protobuf/1.9.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4156,12 +3845,12 @@
       "path": "dnsclient/1.6.1",
       "hashPath": "dnsclient.1.6.1.nupkg.sha512"
     },
-    "Google.Protobuf/3.24.3": {
+    "Google.Protobuf/3.28.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HX8KHRTJPUcC4KOvEobKBNlMpHGYmK+3X73xPq+OUE2M5dLYvpGhp9qQQWt2jASgTUbxI1yHaGeBqFYiECBupw==",
-      "path": "google.protobuf/3.24.3",
-      "hashPath": "google.protobuf.3.24.3.nupkg.sha512"
+      "sha512": "sha512-Z86ZKAB+v1B/m0LTM+EVamvZlYw/g3VND3/Gs4M/+aDIxa2JE9YPKjDxTpf0gv2sh26hrve3eI03brxBmzn92g==",
+      "path": "google.protobuf/3.28.2",
+      "hashPath": "google.protobuf.3.28.2.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -4191,19 +3880,19 @@
       "path": "grpc.core/2.46.6",
       "hashPath": "grpc.core.2.46.6.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.52.0": {
+    "Grpc.Core.Api/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SQiPyBczG4vKPmI6Fd+O58GcxxDSFr6nfRAJuBDUNj+PgdokhjWJvZE/La1c09AkL2FVm/jrDloG89nkzmVF7A==",
-      "path": "grpc.core.api/2.52.0",
-      "hashPath": "grpc.core.api.2.52.0.nupkg.sha512"
+      "sha512": "sha512-cL1/2f8kc8lsAGNdfCU25deedXVehhLA6GXKLLN4hAWx16XN7BmjYn3gFU+FBpir5yJynvDTHEypr3Tl0j7x/Q==",
+      "path": "grpc.core.api/2.67.0",
+      "hashPath": "grpc.core.api.2.67.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.52.0": {
+    "Grpc.Net.Client/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWVH9g/Nnjz40ni//2S8UIOyEmhueQREoZIkD0zKHEPqLxXcNlbp4eebXIOicZtkwDSx0TFz9NpkbecEDn6rBw==",
-      "path": "grpc.net.client/2.52.0",
-      "hashPath": "grpc.net.client.2.52.0.nupkg.sha512"
+      "sha512": "sha512-ofTjJQfegWkVlk5R4k/LlwpcucpsBzntygd4iAeuKd/eLMkmBWoXN+xcjYJ5IibAahRpIJU461jABZvT6E9dwA==",
+      "path": "grpc.net.client/2.67.0",
+      "hashPath": "grpc.net.client.2.67.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4212,33 +3901,61 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.52.0": {
+    "Grpc.Net.Common/2.67.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-di9qzpdx525IxumZdYmu6sG2y/gXJyYeZ1ruFUzB9BJ1nj4kU1/dTAioNCMt1VLRvNVDqh8S8B1oBdKhHJ4xRg==",
-      "path": "grpc.net.common/2.52.0",
-      "hashPath": "grpc.net.common.2.52.0.nupkg.sha512"
+      "sha512": "sha512-gazn1cD2Eol0/W5ZJRV4PYbNrxJ9oMs8pGYux5S9E4MymClvl7aqYSmpqgmWAUWvziRqK9K+yt3cjCMfQ3x/5A==",
+      "path": "grpc.net.common/2.67.0",
+      "hashPath": "grpc.net.common.2.67.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.49.0": {
+    "Grpc.Tools/2.68.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fvA8M6m+cKR5cCwVfKNyUtC8/immoNiNGXW8rwLmwb4y4XRFtQJyN9dmGCJNh1mt0cb9LjSSiAZwmSfMgmE2Ng==",
-      "path": "grpc.tools/2.49.0",
-      "hashPath": "grpc.tools.2.49.0.nupkg.sha512"
+      "sha512": "sha512-BZ96s7ijKAhJoRpIK+pqCeLaGaSwyc5/CAZFwgCcBuAnkU2naYvH0P6qnYCkl0pWDY/JBOnE2RvX9IvRX1Yc5Q==",
+      "path": "grpc.tools/2.68.1",
+      "hashPath": "grpc.tools.2.68.1.nupkg.sha512"
     },
-    "librdkafka.redist/1.9.0": {
+    "K4os.Compression.LZ4/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LzDiHvNd4ZH4tK0fj0fpptbybS31aYZxOwWtUEeekPN7Tg/S3Dmd4epXGkkX3kbOhVLbGOixoTIfMG5o87N/LQ==",
-      "path": "librdkafka.redist/1.9.0",
-      "hashPath": "librdkafka.redist.1.9.0.nupkg.sha512"
+      "sha512": "sha512-TS4mqlT0X1OlnvOGNfl02QdVUhuqgWuCnn7UxupIa7C9Pb6qlQ5yZA2sPhRh0OSmVULaQU64KV4wJuu//UyVQQ==",
+      "path": "k4os.compression.lz4/1.3.5",
+      "hashPath": "k4os.compression.lz4.1.3.5.nupkg.sha512"
     },
-    "MessagePack/1.9.11": {
+    "K4os.Compression.LZ4.Streams/1.3.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vS21kQ7dm7STWkA9QITlnyjKIAssbhgrhMIptfk+TwsLlR1eov6ABTHcLtcMJjQrbJSk7WRS3CRuhi/jQCWOKw==",
-      "path": "messagepack/1.9.11",
-      "hashPath": "messagepack.1.9.11.nupkg.sha512"
+      "sha512": "sha512-M0NufZI8ym3mm6F6HMSPz1jw7TJGdY74fjAtbIXATmnAva/8xLz50eQZJI9tf9mMeHUaFDg76N1BmEh8GR5zeA==",
+      "path": "k4os.compression.lz4.streams/1.3.5",
+      "hashPath": "k4os.compression.lz4.streams.1.3.5.nupkg.sha512"
+    },
+    "K4os.Hash.xxHash/1.0.8": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Wp2F7BamQ2Q/7Hk834nV9vRQapgcr8kgv9Jvfm8J3D0IhDqZMMl+a2yxUq5ltJitvXvQfB8W6K4F4fCbw/P6YQ==",
+      "path": "k4os.hash.xxhash/1.0.8",
+      "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
+    },
+    "librdkafka.redist/2.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
+      "path": "librdkafka.redist/2.4.0",
+      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+    },
+    "MessagePack/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
+      "path": "messagepack/2.5.192",
+      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+    },
+    "MessagePack.Annotations/2.5.192": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
+      "path": "messagepack.annotations/2.5.192",
+      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.22.0": {
       "type": "package",
@@ -4246,6 +3963,48 @@
       "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
       "path": "microsoft.applicationinsights/2.22.0",
       "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.AspNetCore/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-d+7MB4YdUMc9Mtq2u6C7TritzC0eKfHkhGmlnNckDDQiOQuk9IHMPxUmPBRMm/tn+db8fI/BYno9jGxLhI+SZw==",
+      "path": "microsoft.applicationinsights.aspnetcore/2.21.0",
+      "hashPath": "microsoft.applicationinsights.aspnetcore.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.DependencyCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-XArm5tBEUdWs05eDKxnsUUQBduJ45DEQOMnpL7wNWxBpgxn+dbl8nObA2jzExbQhbw6P74lc/1f+RdV4iPaOgg==",
+      "path": "microsoft.applicationinsights.dependencycollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.dependencycollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.EventCounterCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MfF9IKxx9UhaYHVFQ1VKw0LYvBhkjZtPNUmCTYlGws0N7D2EaupmeIj/EWalqP47sQRedR9+VzARsONcwH8OCA==",
+      "path": "microsoft.applicationinsights.eventcountercollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.eventcountercollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-RcckSVkfu+NkDie6/HyM6AVLHmTMVZrUrYnDeJdvRByOc2a+DqTM6KXMtsTHW/5+K7DT9QK5ZrZdi0YbBW8PVA==",
+      "path": "microsoft.applicationinsights.perfcountercollector/2.21.0",
+      "hashPath": "microsoft.applicationinsights.perfcountercollector.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Xbhss7dqbKyE5PENm1lRA9oxzhKEouKGMzgNqJ9xTHPZiogDwKVMK02qdbVhvaXKf9zG8RvvIpM5tnGR5o+Onw==",
+      "path": "microsoft.applicationinsights.windowsserver/2.21.0",
+      "hashPath": "microsoft.applicationinsights.windowsserver.2.21.0.nupkg.sha512"
+    },
+    "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7D4oq+9YyagEPx+0kNNOXdG6c7IDM/2d+637nAYKFqdWhNN0IqHZEed0DuG28waj7hBSLM9lBO+B8qQqgfE4rw==",
+      "path": "microsoft.applicationinsights.windowsserver.telemetrychannel/2.21.0",
+      "hashPath": "microsoft.applicationinsights.windowsserver.telemetrychannel.2.21.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -4323,20 +4082,6 @@
       "sha512": "sha512-Nxs7Z1q3f1STfLYKJSVXCs1iBl+Ya6E8o4Oy1bCxJ/rNI44E/0f6tbsrVqAWfB7jlnJfyaAtIalBVxPKUPQb4Q==",
       "path": "microsoft.aspnetcore.http.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.2.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections/1.0.15": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-jq2OPhIdCCjkcdZGVd4NMRwDG+A/3yUx2mgR3Bd4z+HXNZMbQzOQnL4hw6YFLsyBjHNnJc17fyeKSyV3DlKLEg==",
-      "path": "microsoft.aspnetcore.http.connections/1.0.15",
-      "hashPath": "microsoft.aspnetcore.http.connections.1.0.15.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.Http.Connections.Common/1.0.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-vllvIeTpVzCDs5kPEdICbvcmxLmRAlJUxG6bG55tf29Wfp/ehHQza5P14S1hFl4Ff7kuxJw5VoqSUHD0gaJMKg==",
-      "path": "microsoft.aspnetcore.http.connections.common/1.0.4",
-      "hashPath": "microsoft.aspnetcore.http.connections.common.1.0.4.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
       "type": "package",
@@ -4436,33 +4181,12 @@
       "path": "microsoft.aspnetcore.server.kestrel.transport.abstractions/2.2.0",
       "hashPath": "microsoft.aspnetcore.server.kestrel.transport.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.1": {
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tzRdyQ0qrMJ5YS0qsXfmhVd/kr25IzLpayoIAvU1yi27wqsqxXVPADDEv0S9PaS7xn6bpMFit8kZw92IICDSWg==",
-      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.1",
-      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.1.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Common/1.1.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TyLgQ4y4RVUIxiYFnHT181/rJ33/tL/NcBWC9BwLpulDt5/yGCG4EvsToZ49EBQ7256zj+R6OGw6JF+jj6MdPQ==",
-      "path": "microsoft.aspnetcore.signalr.common/1.1.0",
-      "hashPath": "microsoft.aspnetcore.signalr.common.1.1.0.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/1.1.5": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GEfEzUT0b4doXLekKDmE+kUoDMhHfq5UbeANOPLiLGsiNfwb3QqQHENYLxyKsviNtJVFMJcCWdzf3EKvCVSP9Q==",
-      "path": "microsoft.aspnetcore.signalr.protocols.messagepack/1.1.5",
-      "hashPath": "microsoft.aspnetcore.signalr.protocols.messagepack.1.1.5.nupkg.sha512"
-    },
-    "Microsoft.AspNetCore.WebSockets/2.1.7": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-OgfFIdZpINWU7X+DLbzEYamnSaQmo6oax6nr9qDWLqFJuoVDTRjndV9QwvOMF4r6oOyi2VkZJuJs6WgcmVreWQ==",
-      "path": "microsoft.aspnetcore.websockets/2.1.7",
-      "hashPath": "microsoft.aspnetcore.websockets.2.1.7.nupkg.sha512"
+      "sha512": "sha512-qTACI0wePgAKCH+YKrMgChyfqJpjwgGZEtSuwBw6TjWLQ66THGasleia/7EZz2t2eAjwWxw8RA/D8ODrBqpj9A==",
+      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/2.2.0",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.2.2.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.WebUtilities/2.2.0": {
       "type": "package",
@@ -4478,68 +4202,54 @@
       "path": "microsoft.azure.amqp/2.6.7",
       "hashPath": "microsoft.azure.amqp.2.6.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Core.NewtonsoftJson/1.0.0": {
+    "Microsoft.Azure.Core.NewtonsoftJson/2.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HdNo6Z5mTe1voaPhFhjegHUtVpNDtXPL7sdJI+xSnFQiCu85bdYzFs6oiL0UhFSO6g17WYVdoC/UW6B2TSjBFQ==",
-      "path": "microsoft.azure.core.newtonsoftjson/1.0.0",
-      "hashPath": "microsoft.azure.core.newtonsoftjson.1.0.0.nupkg.sha512"
+      "sha512": "sha512-ZKV0eHmR1JM4BXPv0TC5fp3PjbWeO+iwHmnV2acYTElYlU9ilmk97ocfmTmKcRFGOmn4zztWqbCBSmdvKqOQng==",
+      "path": "microsoft.azure.core.newtonsoftjson/2.0.0",
+      "hashPath": "microsoft.azure.core.newtonsoftjson.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Cosmos/3.41.0": {
+    "Microsoft.Azure.Cosmos/3.44.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-SlY2fuF+U+06Ba440Usii/s92sPCDxxuQDLUUbxgFtczKyxyY3+LhR3n1vLZS3yjDLtmFZHzcgtHu3JQluv1Eg==",
-      "path": "microsoft.azure.cosmos/3.41.0",
-      "hashPath": "microsoft.azure.cosmos.3.41.0.nupkg.sha512"
+      "sha512": "sha512-RKqF3S+BD6Wy4uhlb6a8NXZhkN/cf4A3GrsUOH8GMV/izLDXBfGr3gN6Yk4dBtR9lAPfLJG27G3od9caZv1U4Q==",
+      "path": "microsoft.azure.cosmos/3.44.1",
+      "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.1.6": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/mBhUF82NJq1mNr2u/7LkP3oDPqtw9jpH8Xo2yYxjwpIX3REK9bvgH1hqcBOLQTZIMGRDqjq6W/pEEzLqH1iZg==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.1.6",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.1.6.nupkg.sha512"
+      "sha512": "sha512-+zLlvMq5Bh1ifxCj27AapYc97muyS3+6y6clIFEBgm0uHAlPDWcvjz06gTp+sLiIMCUWSPRcC3RhzG+V84ZLqQ==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.2.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/1.17.4": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GxG4vMxZkZGj912TCtDO4RetqSrKprCO+pQAea/f5ouQzN+rB3aqYRV/TC+E8t9+F6dXFlZWFRZZvapj1RIJlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/1.17.4",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.1.17.4.nupkg.sha512"
+      "sha512": "sha512-U8PW868Ao+T4QMnXFBHqJgUefPBePK7SHOH3UpN1apqdsDksGrQuE/n+8jCEcv7EbpjCJSMqdoQKnZTMVbBZKg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.0.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/2.17.1": {
+    "Microsoft.Azure.DurableTask.Core/3.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zKtXC0wxGxOoAGPi5B0TT0f6mqjave2USL/Q7rJOwf+xVg+axiYpU4kad5muvzib4IeikOBfqWqs/xOFOKqR6w==",
-      "path": "microsoft.azure.durabletask.core/2.17.1",
-      "hashPath": "microsoft.azure.durabletask.core.2.17.1.nupkg.sha512"
+      "sha512": "sha512-KqAF02yugJC2hsDBfE4mhjiXAOj4JvKDYs/9GSrxuO/TLXbDY1Nx7meSpFw0E4Jp3kZiIH6UgHOAtHi0mnGCnw==",
+      "path": "microsoft.azure.durabletask.core/3.0.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o+65IPewJLhkuPIvziQxgsan6g3nJ981CWX3xtkHNiSnQqqA9WeUIxjA8ZYYyU1wJLj32CvPmVIyaALK9ejr2Q==",
-      "path": "microsoft.azure.durabletask.netherite/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.1.5.4.nupkg.sha512"
+      "sha512": "sha512-SnPG3BUH5MMX/rVfWEfWwguSXIAaGUWATS0yhlBQxJg8of99gRFTRm3x3/NVQqGDxlKSDpf82P4ACgzimEnGRA==",
+      "path": "microsoft.azure.durabletask.netherite/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/1.5.4": {
+    "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tPosZ6BcmQ8Rg6RDAjGpV71+HzEHPWuPDk+n7GVBtdUTBUasv4ndWcRuW5QYKzLchqUVobLSxrtJLDZRaono/A==",
-      "path": "microsoft.azure.durabletask.netherite.azurefunctions/1.5.4",
-      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.1.5.4.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-U5PEuRFxw6Jgsu1oc2BwNEFkIVH8PCAWuG8D0zeaF3V/nwKmvsAw3r0N1HR29UHO1WQtCOIl2Vh6yuA0BqxEBw==",
-      "path": "microsoft.azure.eventhubs/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.4.3.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.EventHubs.Processor/4.3.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-8zRsNRdPQAWAkASAI3r5SPEHJK/qXdje4KkjZUCNbPXdb+IXcfNno8esV5w34mxiUN59S9mTstZLzWC2VOUqlw==",
-      "path": "microsoft.azure.eventhubs.processor/4.3.2",
-      "hashPath": "microsoft.azure.eventhubs.processor.4.3.2.nupkg.sha512"
+      "sha512": "sha512-E1gPfwA4iY5LXY0T4A31L9Z88yYAOaPVIpImBJMOXrhRkS6jE9dcf/aZSbWu0cX+o4lfKzvL4fQB0f6J1G0hWA==",
+      "path": "microsoft.azure.durabletask.netherite.azurefunctions/3.1.0",
+      "hashPath": "microsoft.azure.durabletask.netherite.azurefunctions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.Analyzers/1.0.0": {
       "type": "package",
@@ -4562,68 +4272,61 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.KeyVault.Core/3.0.3": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.0.0-beta423": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-amP4gG7tMficBHRuTaCJpdiPGZyfrLHqYth0D4Yp3lu7Z7XQfEau0/BWNSuvpdZJKWW8M/wmFyI07vTA6EF88A==",
-      "path": "microsoft.azure.keyvault.core/3.0.3",
-      "hashPath": "microsoft.azure.keyvault.core.3.0.3.nupkg.sha512"
+      "sha512": "sha512-KdwGg1+gw3QVXfqa24BS6HT9IftRgnI6afaJBED4ib62XGyQ1hYbv7JBeicXmN8IhwzqLPZgUz/JLQsRCHHShg==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.0.0-beta423",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.0.0-beta423.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RyJsnaSMlwTPLFw8LfEZfff72JwxG+oBNQoI4NM0paAbx5N1Klx0SAAQQvG5oNlIstBgTeImH5sytndbVZIeLg==",
-      "path": "microsoft.azure.kusto.cloud.platform/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.3.nupkg.sha512"
+      "sha512": "sha512-g3gf2XSGf5i3o59ros3dkAuyHh57DvKPIrLe7OBj/3UhD0wbf7pro/RCdBu8urQpeOSdUxXcPbaAueGYXRdW1g==",
+      "path": "microsoft.azure.kusto.cloud.platform/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.3": {
+    "Microsoft.Azure.Kusto.Cloud.Platform.Msal/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5owQ2zf16iGrm7hsjNozG0y8dYLQ33VgPeIr3or9xV4pUdWDNMk1QHQkwtl2kKvR7BnSvJvWjiWPJqddbcsv9g==",
-      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.3",
-      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.3.nupkg.sha512"
+      "sha512": "sha512-y43GEkrl3eLDSKTl7fJs1JO0V5yc+uNej9J9lJjSPs7Y7Js3/nCsF9vkMSnytNSg1UH7sfENXSSwBQLSe+iAeA==",
+      "path": "microsoft.azure.kusto.cloud.platform.msal/12.2.7",
+      "hashPath": "microsoft.azure.kusto.cloud.platform.msal.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Data/12.2.3": {
+    "Microsoft.Azure.Kusto.Data/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-a55PhqueiSMpCAIa96XMUdN1TL73M5rtSsQLzvd8RtAAK7oUhtriy3tLCt0sN643s3w2EdTJEa0GcYHrYQem1w==",
-      "path": "microsoft.azure.kusto.data/12.2.3",
-      "hashPath": "microsoft.azure.kusto.data.12.2.3.nupkg.sha512"
+      "sha512": "sha512-b0yRwFDTRORnyAq7mRUbIFt6K9RsgAHoZrSlGe4CxMDQX0t7+70j//3NHN3vzLQdmQn3SDkTs569wErZbcfrGQ==",
+      "path": "microsoft.azure.kusto.data/12.2.7",
+      "hashPath": "microsoft.azure.kusto.data.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Kusto.Ingest/12.2.3": {
+    "Microsoft.Azure.Kusto.Ingest/12.2.7": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2/5l1EC5Imn7dOHkYY/n0t/06lvqIsYdm6+EuFWcIVSULGN7YNt9qnHzzlLLJHfkwnDEhy0ZP9LMmtT1+97fdQ==",
-      "path": "microsoft.azure.kusto.ingest/12.2.3",
-      "hashPath": "microsoft.azure.kusto.ingest.12.2.3.nupkg.sha512"
+      "sha512": "sha512-x5oTbesbMDVvmN6POpFF0frvh/bnHUtaKynlUxLTivmWUcZq8dw1rgQjnhX+YwfQWEg6fNSlJgpb58BZFV7qug==",
+      "path": "microsoft.azure.kusto.ingest/12.2.7",
+      "hashPath": "microsoft.azure.kusto.ingest.12.2.7.nupkg.sha512"
     },
-    "Microsoft.Azure.Services.AppAuthentication/1.0.3": {
+    "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ywpQaK1klu1IoX4VUf+TBmU4kR71aWNI6O5rEIJU8z28L2xhJhnIm7k2Nf1Zu/PygeuOtt5g0QPCk5+lLltbeQ==",
-      "path": "microsoft.azure.services.appauthentication/1.0.3",
-      "hashPath": "microsoft.azure.services.appauthentication.1.0.3.nupkg.sha512"
+      "sha512": "sha512-Nv2Z6e5pU4vRGjoZc/HAFvR+b5QxfToVIrpfH7ccUX237a1dGJ3Z9z1xrjkvD4KDeaF4A6us+cgAhb9e8KVa1Q==",
+      "path": "microsoft.azure.signalr/1.29.0",
+      "hashPath": "microsoft.azure.signalr.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR/1.25.2": {
+    "Microsoft.Azure.SignalR.Management/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AaYpk+7iEXO54Hbe9f1zX55FzF5NGOhoDo7MiNKWBrqpqKUoldwU+GVoWh4QiRRTq1Sou7uSLs8nQnUVaW5pyg==",
-      "path": "microsoft.azure.signalr/1.25.2",
-      "hashPath": "microsoft.azure.signalr.1.25.2.nupkg.sha512"
+      "sha512": "sha512-4UCRtJMUqth0K8TBG/honPUhmzG/Coqy2rJKeytrQJh4w22a4tWyCjBrHL1ey9gy3DxBF48NqBBHNGC1hSb7Wg==",
+      "path": "microsoft.azure.signalr.management/1.29.0",
+      "hashPath": "microsoft.azure.signalr.management.1.29.0.nupkg.sha512"
     },
-    "Microsoft.Azure.SignalR.Management/1.25.2": {
+    "Microsoft.Azure.SignalR.Protocols/1.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2BM0GRIqqG9yCmIu3V+9rojioun/jbeZuRiVp62otcO0dDWYGEOtdwm3IOmX8gwQ6jV9QXYyfJM16eijxdBJwQ==",
-      "path": "microsoft.azure.signalr.management/1.25.2",
-      "hashPath": "microsoft.azure.signalr.management.1.25.2.nupkg.sha512"
-    },
-    "Microsoft.Azure.SignalR.Protocols/1.25.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-ZXQtxErsw7JdNO/KPzrq4AuhF4Rc4gBDObJZcXRNVJVVP/HIQ0gqZ6/mHiEs3yqZTOew7RFhAc0wkJZ+0hzF+w==",
-      "path": "microsoft.azure.signalr.protocols/1.25.2",
-      "hashPath": "microsoft.azure.signalr.protocols.1.25.2.nupkg.sha512"
+      "sha512": "sha512-54j531KO1GffnsbHSZCebtd96QoXnc67r0oUXoO7lsxfhvRAVsiMw77wSehQFOo1JF1yF98dvRoVc+kMDilbPw==",
+      "path": "microsoft.azure.signalr.protocols/1.29.0",
+      "hashPath": "microsoft.azure.signalr.protocols.1.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR.Serverless.Protocols/1.10.0": {
       "type": "package",
@@ -4639,33 +4342,19 @@
       "path": "microsoft.azure.stackexchangeredis/2.0.0",
       "hashPath": "microsoft.azure.stackexchangeredis.2.0.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Blob/11.2.3": {
+    "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gM48FyiinUQq+fiUFHf0hGwQaTug4b+zYcYjbZ1KpxC3RkSgOd3twL9Yv9MqpvTkMcexGLwtELYIBhaTQ3zd9A==",
-      "path": "microsoft.azure.storage.blob/11.2.3",
-      "hashPath": "microsoft.azure.storage.blob.11.2.3.nupkg.sha512"
+      "sha512": "sha512-EOigHt+kjrpbg53s8SYn4dlTpZG9IgWPNrdmcdSG8c7U8qKZvcF4BwZtF7ETy3KGir2NtIpJaIc7dUm2+k9/GA==",
+      "path": "microsoft.azure.webjobs/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
-    "Microsoft.Azure.Storage.Common/11.2.3": {
+    "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WqX0ckhXQSUIBEq6wd2xgFz3KPjIONfDdgNg1ClQYxYTvuXQv3g3cnL9DGXCvuxEFZNPk0BJdQeW+uZwGqdDjw==",
-      "path": "microsoft.azure.storage.common/11.2.3",
-      "hashPath": "microsoft.azure.storage.common.11.2.3.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-H/Al/2UOXef8Qqwvsm3Dur9JStz1xvV/UXb0GDys5YPx+qpWDS/U203b/+EUPLeZeuvGTnmcOFtnZzvxMuDamQ==",
-      "path": "microsoft.azure.webjobs/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.3.0.39.nupkg.sha512"
-    },
-    "Microsoft.Azure.WebJobs.Core/3.0.39": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O1RDMe2mBGZI4q4IUns+mxsfCjaMej4FzicMLqvnN5Ti5E3mSo+/kqDbEZzXA/RqnuLIOk+DhvFg/rwKhqEaow==",
-      "path": "microsoft.azure.webjobs.core/3.0.39",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.39.nupkg.sha512"
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
+      "path": "microsoft.azure.webjobs.core/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/3.0.6": {
       "type": "package",
@@ -4681,12 +4370,12 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.8.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-WaL+NcxoETT+w7T7hxzSLYhu8wwymlr/9UOXjr0/ZgH2lM+zrOOQIOmB23xh9jUsqIJSm+B9xvgd65Iy1HbVqg==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.8.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.8.0.nupkg.sha512"
+      "sha512": "sha512-F3wTIc8IPaPTPchEyTK9FgujcMrmUaGTWDrxT2mviVMLFT0mtrYj4wIl0D0jnT3EzltohmIlAnhb+IDRWqQKaw==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4695,12 +4384,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/2.13.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7SPfaLdUnRmN4dajBQEZ4Yei0IzTCL/z7zYkEio0hb3vX9M+XXcWw1exBb3S83yvzOYCFlFYSGDREicYvPxmhg==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/2.13.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.2.13.5.nupkg.sha512"
+      "sha512": "sha512-oja7F/OtGpxM7qr84BdlE7FqgUJhHuaCiuujOHNkQUj3bbTReoVB4Ad6psxhiDBGMKjLkyJjyaaQ6lxmWBuI9g==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.0.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.0.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4709,12 +4398,19 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.2": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-P7xUepplf/Tz2YD+Y0qXv0FloYVxPNGs0KuHXphiTB/ZZGUl+QPKiBfV24LhOca6NpcUhyymYtIWUdoWwMGJXA==",
-      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.2.nupkg.sha512"
+      "sha512": "sha512-uiluTugaUmj+GUhDzkEm+0W18LXLWukVGpwqYqzmxwcYirjsOefl9IMHL3aLazNIF63IyDf8/4/60BbqpEtg7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/0.4.2-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.0.4.2-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.4.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-67oZGcbOFfzncu15giVjAJkuOQW8rkDfo2ywe2HAxhG8YCzZhqofqiwkwUVTnBvc351xVltZ0BpLBM6VnSY8kQ==",
+      "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
@@ -4723,12 +4419,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.1.54-rc": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/0.2.9-rc": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Lr9MGqAVZdFTmuG8NHdJUIY/SkIrl1thrOmhhdtbQwuFF040pVF6GYyU0UyNisGLax7CaD5ly0MayTV7Psi8sQ==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/0.1.54-rc",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.1.54-rc.nupkg.sha512"
+      "sha512": "sha512-vrgRqOPjkyOF/MDectRoNpbYvTOlsmggG/Qf8ERULdFCXSb1jJKftdNfEot/mz8fBzm2MyGkOP0ilyJzOLyVmQ==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/0.2.9-rc",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.0.2.9-rc.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -4737,47 +4433,54 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/3.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ppywjwR3nEJAlM570BxaSnQTdEa7pzOxQ7EoRU5qSwvwbxn9NT7mKDDerYgO21EpEYHer+DaAwBjv7AC4DTLHA==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/3.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.3.9.0.nupkg.sha512"
+      "sha512": "sha512-crV3C6NUM6b9qwIvoNKiIfPslOIxtM+IEr2ViAy6EpGG+pXkYfMipi3ePKOBYVTyH87sBAtkHc4CBladu3jUPg==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.10-Preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.11-Preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qYD7VIvXk9DQFGtmKkH4wO0SLkoitacfhIcGLO3WUQT7QdZXE15odDsEkWjMhPovoHnkmGCYFjQnAjuL4uKa4Q==",
-      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.10-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.10-preview.nupkg.sha512"
+      "sha512": "sha512-PNNDW4ktUIsTyZWrFdHMrLTQdtAqHyjOibK8sLL6O9qI/emN/VdFFewnmpZfBisLIPnc/5WUKW66KZuyOYA+SQ==",
+      "path": "microsoft.azure.webjobs.extensions.kusto/1.0.11-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.kusto.1.0.11-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.16.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.31-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZYBel0IbpiCpryN9u30bBWcFboI8yerraXljCFYJGJZAp5UTcGVjuQmsOfSKUs+6We6yJTFEzFG3CfELjbBNvg==",
-      "path": "microsoft.azure.webjobs.extensions.openai/0.16.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.16.0-alpha.nupkg.sha512"
+      "sha512": "sha512-c6zx4iVHSwV7p2fotzWvxw+Ttrn7gXh/EjVkh2tdQ2g0TgD1E8I08s8j2PoCqww6ke9awIdq3+R/RwG7CwRrRg==",
+      "path": "microsoft.azure.webjobs.extensions.mysql/1.0.31-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.mysql.1.0.31-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.3.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI/0.18.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3dRX/RvGTzrbPXMVXK0uHZHolzsPr+vhE+vwV+G6h5CRD2tHyf8iJBAmgpO/vOIertM52SZhSDuyCOGfFxOUiQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.3.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.3.0-alpha.nupkg.sha512"
+      "sha512": "sha512-HupnrqbRfod2J9d93SxfjdlNUGM+LwjL9wgYa29Gzfs40gQ2X+bBPnXyLYmYSnEhhlqPV6yToilb+4D9c0uOOg==",
+      "path": "microsoft.azure.webjobs.extensions.openai/0.18.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.0.18.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.2.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch/0.4.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vOVQ8OJfd5PZ2zPhs7HPo6lO+xYf+347VOgaIZjQop7TnQQTLqr/2TxcAyIVyS02qH29xsrlmpRrEoOnTE85MQ==",
-      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.2.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.2.0-alpha.nupkg.sha512"
+      "sha512": "sha512-h+zjHJbJgpL0J/h9DEZBxpRXV/0ws/bVwD3V77WaG7219CzhJqSouw1xPZkEISESIEwBF9ZSDaXwq4DQZdqjAw==",
+      "path": "microsoft.azure.webjobs.extensions.openai.azureaisearch/0.4.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.azureaisearch.0.4.0-alpha.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.15.0-alpha": {
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch/0.3.0-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JB88Fukr0wMkrGso7eS+7w+jzqJSOi/T7Cbc16BXob5CtDu012fQZ9qm3xVgGBm6yV8MulMc6LAgTSO0kuI2NA==",
-      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.15.0-alpha",
-      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.15.0-alpha.nupkg.sha512"
+      "sha512": "sha512-lyirO2ZWuTTY25dnWuKzcbq0dFn4BlPJ4w21rRvIsKe0RYylV2I45Kfq2yn76Wa6qjLOVc6rg6sTWfbYjKksFA==",
+      "path": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch/0.3.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.cosmosdbsearch.0.3.0-alpha.nupkg.sha512"
+    },
+    "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto/0.16.0-alpha": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PyDCInGcaIjzurx5W0fHbcreTR+54JUBMKjFIoLXp9G23InBPxHPNcjYfA2FSa0P1jMJHddDGOdNRKL2ho7s5A==",
+      "path": "microsoft.azure.webjobs.extensions.openai.kusto/0.16.0-alpha",
+      "hashPath": "microsoft.azure.webjobs.extensions.openai.kusto.0.16.0-alpha.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.RabbitMQ/1.1.0": {
       "type": "package",
@@ -4793,61 +4496,61 @@
       "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
       "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.37": {
+    "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6tybd5xeTeBEOSy+CjfmDOkc8Xwwb73nmG/rQdInNiPuPX6hl9vTkHeEQATOeG4Sv7t+oJQZPPdT6ZprypmMaQ==",
-      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.37.nupkg.sha512"
+      "sha512": "sha512-ZTC2+g7/zBqOLvCr9/g0eE08Z68RE8MT5IuC90q2JcM6it4Kqckc3TvR3SilzloDr1/9EOa1wvlxfC57o8bmWA==",
+      "path": "microsoft.azure.webjobs.extensions.rpc/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.extensions.rpc.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.0.3": {
+    "Microsoft.Azure.WebJobs.Extensions.SendGrid/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FmrlD0QK5XtiGKIf1rObDbtXH/GA/LxwZ23M7hkHP9OzSLfGd9+GV6udVuitAwZE7jPuKgP3O0b80ZGlk4TIZg==",
-      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.0.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.0.3.nupkg.sha512"
+      "sha512": "sha512-tG/Kql9wgfrSOLW6EahS7cJFIPSQJiWDW0U/OE5Vz9ypc+AHL3qceueasfSBvYQmd2DiaNaomrTMER+LmfoQaw==",
+      "path": "microsoft.azure.webjobs.extensions.sendgrid/3.1.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.sendgrid.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.4": {
+    "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.16.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-T1lenl/t7fTajHMXAg4KhOImnUKFn2dHVG6aWOHBFIklPZ0cvMRNqDDEQqf3sSBD4aRDW1Yn9PR8pGj45O3LHw==",
-      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.4",
-      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.4.nupkg.sha512"
+      "sha512": "sha512-IBwhXFHKGpjIvW944DhtEKfOs0eNlLxOA2fsrLYsZPeWBhIWRhcO47vjmsVUC/zkVRg9Sx/AfNEyeNPCzS8qrw==",
+      "path": "microsoft.azure.webjobs.extensions.servicebus/5.16.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.servicebus.5.16.5.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.SignalRService/1.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-pvE/bIqlKtDdphIuV00dmhscT3pviz729edAl1c2F90IQG/HQCBQOFcZdU3tM/9i3lxpiSMoKwiuqndo7Z+tkg==",
-      "path": "microsoft.azure.webjobs.extensions.signalrservice/1.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.1.14.0.nupkg.sha512"
+      "sha512": "sha512-N7XIMQAGqMIt6lpiy3Wsf9k0oTG9+ivKesBht2C0u5Ny7QhvgpDxMi8jG/NrIgpe56JOih8izKG7k+UGDHmUUA==",
+      "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.169-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.376": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YDOLY05g9RaZHVCLRDlRaQ1LH7e3QvCXTV4N050kK7C3med6taVlrorE3Yy6XMi3AG6CqZlC8LbgnNCIQRIHHw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.169-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.169-preview.nupkg.sha512"
+      "sha512": "sha512-FK/XVJ0PXiShpMAR/ijDvzt5uz5HQixe0nZN6JZZyVQ4xtdGVf/10gx7UW21lwOeE/RZX/re8//ENzD9+8YKxg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.376",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.376.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-W5VzuQKK41J0HIQr3Eij6ghxtcZOmARjYARRFIB4tDo3eutw8Lr7mKfr5iyEyHAC4MOTSKeIgknY99MaZC7GqA==",
-      "path": "microsoft.azure.webjobs.extensions.storage/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Aeq/MXbKxgAZInNjnvpcDkwKgu9lhZW4/zhW4fpj0Kyxwg3MvOL2xFhQkKbLUc2EU/vjTOuVD7xZS7wO3hmFWQ==",
+      "path": "microsoft.azure.webjobs.extensions.storage/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h6NX6pd8eX1pkClh4Dxys357aLJCffVAUJMsK1xvjrOlwaityPZRNqMJJ/BCrAXqqn9hqFF1tmcS8DgD2wI7WA==",
-      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.1.nupkg.sha512"
+      "sha512": "sha512-Bkk30ZaKBrv8+seeluGW2wU4g52AKQKLWcofe9HflcoxU2ucNxv3meEB4lHfxNY6eBbSAvFEVLcbVWHxkY4h+Q==",
+      "path": "microsoft.azure.webjobs.extensions.storage.blobs/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.blobs.5.3.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Storage.Queues/5.3.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UAKPp/fm6m2GvYMDjoF8MLudIprgPxuaaaCsBJID49G1ectgFJdp9CuexFWcUx4eHOdTVjqTdomByz9PglsKQw==",
-      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.1.nupkg.sha512"
+      "sha512": "sha512-+o07+2up9D3HlxJCSbKBVrj/sl6Mr4DDVChrtxEBvdto59elY6uwYVZ240zqbqikWdRb3aJ621kljp1hdPAGUg==",
+      "path": "microsoft.azure.webjobs.extensions.storage.queues/5.3.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.storage.queues.5.3.4.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Twilio/3.0.2": {
       "type": "package",
@@ -4856,6 +4559,13 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/1.0.0-beta.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-J5dRt7gSNkWfdN7kxnt+vP4ActPRYo2+/eLnXK1c/kgiKqqcwS+552EOm2B7dEpEP1d6/eMLeu5Kz3grXSkwjw==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsubforsocketio/1.0.0-beta.4",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsubforsocketio.1.0.0-beta.4.nupkg.sha512"
+    },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
       "serviceable": true,
@@ -4863,19 +4573,19 @@
       "path": "microsoft.azure.webjobs.host.storage/3.0.14",
       "hashPath": "microsoft.azure.webjobs.host.storage.3.0.14.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
+    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.39": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-KG+ZD6u3KKBBv5bet6r1EeLrP6mNFRoPVWuGUToQTZwpTLlPffouag94JR5IxAJA3DxMQl0A0mV+Qkhg9VorCA==",
-      "path": "microsoft.azure.webjobs.rpc.core/3.0.37",
-      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.37.nupkg.sha512"
+      "sha512": "sha512-sMPOTH6hlAuaiK3EYbf1SfYON8j+Hxl3IL7ZAJX51m9SI5RI0sUR7QPfiwIG0h4Z0BHpfybQXl0so07JbxBqyA==",
+      "path": "microsoft.azure.webjobs.rpc.core/3.0.39",
+      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.39.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.0-preview": {
+    "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-b2wKKtCrpdLbiQBudEPQ04cFCbwFHw8Bi2c/4CRYS2Qcm1Zs21NO37tvZZM/SGbtS2fxgvQhP/wiySYCKydZaQ==",
-      "path": "microsoft.azure.webjobs.script.abstractions/1.0.0-preview",
-      "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.0-preview.nupkg.sha512"
+      "sha512": "sha512-U/aVn/i0P9MdPsca9TrLmTlKuGOJ8okTdifrBeNviwd80Xbv/+dIM/GGReQXaVVtUM5/SlbUHRAhvA9w0yuEyA==",
+      "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
+      "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator/4.0.1": {
       "type": "package",
@@ -4884,12 +4594,19 @@
       "path": "microsoft.azure.webjobs.script.extensionsmetadatagenerator/4.0.1",
       "hashPath": "microsoft.azure.webjobs.script.extensionsmetadatagenerator.4.0.1.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/8.0.0": {
+    "Microsoft.Azure.WebPubSub.Common/1.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
-      "path": "microsoft.bcl.asyncinterfaces/8.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.8.0.0.nupkg.sha512"
+      "sha512": "sha512-51j7iQ6l5NG8SyieJk2zVKMBff8TzDFnGmIWOIPD2U3V5BMzvyYL0gvzgDe+KRkYPNMxzwPwp+IiYE4kNqBQBA==",
+      "path": "microsoft.azure.webpubsub.common/1.4.0",
+      "hashPath": "microsoft.azure.webpubsub.common.1.4.0.nupkg.sha512"
+    },
+    "Microsoft.Bcl.AsyncInterfaces/10.0.0-preview.2.25163.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hoItOloGu4xv8DfHwnNvsfOU1I0ER6HoTDUq2tqir9noTJoRKMeXb+0qH+rScwQlDZ7vwuyLbQappOUCfBWpJA==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.0-preview.2.25163.2",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.0-preview.2.25163.2.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4898,62 +4615,6 @@
       "path": "microsoft.bcl.hashcode/1.1.0",
       "hashPath": "microsoft.bcl.hashcode.1.1.0.nupkg.sha512"
     },
-    "Microsoft.CodeAnalysis/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-BoPeZD+BFE5x/qu28RnelX7hoCnPDbOZkwymrUnslrZjzj8B155gP/GjrI6m66oUOk2Yh1lxlUs+BRFZOPMBnQ==",
-      "path": "microsoft.codeanalysis/3.3.1",
-      "hashPath": "microsoft.codeanalysis.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Analyzers/2.9.4": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-alIJhS0VUg/7x5AsHEoovh/wRZ0RfCSS7k5pDSqpRLTyuMTtRgj6OJJPRApRhJHOGYYsLakf1hKeXFoDwKwNkg==",
-      "path": "microsoft.codeanalysis.analyzers/2.9.4",
-      "hashPath": "microsoft.codeanalysis.analyzers.2.9.4.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Common/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-N5yQdGy+M4kimVG7hwCeGTCfgYjK2o5b/Shumkb/rCC+/SAkvP1HUAYK+vxPFS7dLJNtXLRsmPHKj3fnyNWnrw==",
-      "path": "microsoft.codeanalysis.common/3.3.1",
-      "hashPath": "microsoft.codeanalysis.common.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.CSharp/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-WDUIhTHem38H6VJ98x2Ssq0fweakJHnHYl7vbG8ARnsAwLoJKCQCy78EeY1oRrCKG42j0v6JVljKkeqSDA28UA==",
-      "path": "microsoft.codeanalysis.csharp/3.3.1",
-      "hashPath": "microsoft.codeanalysis.csharp.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.CSharp.Workspaces/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-dHs/UyfLgzsVC4FjTi/x+H+yQifgOnpe3rSN8GwkHWjnidePZ3kSqr1JHmFDf5HTQEydYwrwCAfQ0JSzhsEqDA==",
-      "path": "microsoft.codeanalysis.csharp.workspaces/3.3.1",
-      "hashPath": "microsoft.codeanalysis.csharp.workspaces.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.VisualBasic/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-F7fc/G+0ocOYkKSCJ7Y8Q7eAEkAdG5RYODI9FtSl2Hm8zIDBVA3NccCm98gaOvCamLfMHYqeOjpb3yJnnw3m/w==",
-      "path": "microsoft.codeanalysis.visualbasic/3.3.1",
-      "hashPath": "microsoft.codeanalysis.visualbasic.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.VisualBasic.Workspaces/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Oi4AUxMKAYpx7nHNh7jUO8X18JFCzwtIfu/yDzGzOBpo50591AF7EEdv99geAEidGtmJqbzQ6uRk5dEOL+7F/Q==",
-      "path": "microsoft.codeanalysis.visualbasic.workspaces/3.3.1",
-      "hashPath": "microsoft.codeanalysis.visualbasic.workspaces.3.3.1.nupkg.sha512"
-    },
-    "Microsoft.CodeAnalysis.Workspaces.Common/3.3.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-NfBz3b5hFSbO+7xsCNryD+p8axsIJFTG7qM3jvMTC/MqYrU6b8E1b6JoRj5rJSOBB+pSunk+CMqyGQTOWHeDUg==",
-      "path": "microsoft.codeanalysis.workspaces.common/3.3.1",
-      "hashPath": "microsoft.codeanalysis.workspaces.common.3.3.1.nupkg.sha512"
-    },
     "Microsoft.CSharp/4.7.0": {
       "type": "package",
       "serviceable": true,
@@ -4961,12 +4622,12 @@
       "path": "microsoft.csharp/4.7.0",
       "hashPath": "microsoft.csharp.4.7.0.nupkg.sha512"
     },
-    "Microsoft.Data.SqlClient/5.2.1": {
+    "Microsoft.Data.SqlClient/5.2.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ojg2XWmih4ubPPtrhRqqXk0SM6wC2ZSTkNNEAlYBhMo4IsRHjLazFc0abzcZCNfw1JyWcqY7vGutWTv8ZaFD9g==",
-      "path": "microsoft.data.sqlclient/5.2.1",
-      "hashPath": "microsoft.data.sqlclient.5.2.1.nupkg.sha512"
+      "sha512": "sha512-mtoeRMh7F/OA536c/Cnh8L4H0uLSKB5kSmoi54oN7Fp0hNJDy22IqyMhaMH4PkDCqI7xL//Fvg9ldtuPHG0h5g==",
+      "path": "microsoft.data.sqlclient/5.2.2",
+      "hashPath": "microsoft.data.sqlclient.5.2.2.nupkg.sha512"
     },
     "Microsoft.Data.SqlClient.SNI.runtime/5.2.0": {
       "type": "package",
@@ -4982,47 +4643,61 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.1.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/0.4.2-alpha": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-O0hn+DEl5Ui4DZOs/yDBTtJHvTd9niT6AW0CGn40VoScStWXYuhBmYiMYQj+fCIn/tWLzw2NqYan8DsVNZX4KA==",
-      "path": "microsoft.durabletask.grpc/1.1.0",
-      "hashPath": "microsoft.durabletask.grpc.1.1.0.nupkg.sha512"
+      "sha512": "sha512-r6m2ZM9F94jS38gbdlkt78YCL3KURRYuerBPZWk0pl2eRTZoPQCLDC9XHxuwnXNv3994z5VofcWtAiVgMl1mPg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/0.4.2-alpha",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.0.4.2-alpha.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.3.0": {
+    "Microsoft.DurableTask.SqlServer/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-B28jkMmT1d0z5J4IBzBcNyFfTRSQzhaHHvr1JvYN2aaapVvN/zrRD98b5utVCjBX77tdZxKINoKu18GwLdwIKQ==",
-      "path": "microsoft.durabletask.sqlserver/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.3.0.nupkg.sha512"
+      "sha512": "sha512-1LA/9efdMX7dzoPoP1sNd3NLIqNHv8lQZR1TOq+dW5L/EWhACc/c53gQdfqz3n8cfF5u0WgD9Ns9X0IKcF4cBQ==",
+      "path": "microsoft.durabletask.sqlserver/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.5.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.3.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YLDAWgwwRmz5tN2IJQqVRHIFObPOmkQQ6NR+lMO+CvQiOWiPxdb2wrT1wh9rQ2xp0gYDy+neUuXdIZLDrqdfLQ==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.3.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.3.0.nupkg.sha512"
+      "sha512": "sha512-JjrQbaFMlDvLE5hZ6RMkMZS7uYN5hxrHH1FQShjp+ayH/bK0xQdJsWGzDNFiuYRIGv8MqikDVnpq2aV6vyGM4A==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.5.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.5.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.7.4": {
+    "Microsoft.Extensions.Azure/1.11.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-AVYk0jKLZa1d0r89cNs5pCgPAQMe1uco6g0FIuzyc7eEOccd+TjXGXiRkTNQibf8wYrCd15Qt+xvcKTmGR0sZg==",
-      "path": "microsoft.extensions.azure/1.7.4",
-      "hashPath": "microsoft.extensions.azure.1.7.4.nupkg.sha512"
+      "sha512": "sha512-j6Vb858BgfAbzuv0UQxOvn8jPo8i+96Kkacu1q0RwQi+fAwVljL8WmI0oZX4CCLUsJCs1yzbpJCaS7MYPPCUjw==",
+      "path": "microsoft.extensions.azure/1.11.0",
+      "hashPath": "microsoft.extensions.azure.1.11.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration/2.2.0": {
+    "Microsoft.Extensions.Caching.Abstractions/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nOP8R1mVb/6mZtm2qgAJXn/LFm/2kMjHDAg/QJLFG6CuWYJtaD3p1BwQhufBVvRzL9ceJ/xF0SQ0qsI2GkDQAA==",
-      "path": "microsoft.extensions.configuration/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.2.2.0.nupkg.sha512"
+      "sha512": "sha512-IxlFDVOchL6tdR05bk7EiJvMtvZrVkZXBhkbXqc3GxOHOrHFGcN+92WoWFPeBpdpy8ot/Px5ZdXzt7k+2n1Bdg==",
+      "path": "microsoft.extensions.caching.abstractions/1.0.0",
+      "hashPath": "microsoft.extensions.caching.abstractions.1.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.Abstractions/2.2.0": {
+    "Microsoft.Extensions.Caching.Memory/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-65MrmXCziWaQFrI0UHkQbesrX5wTwf9XPjY5yFm/VkgJKFJ5gqvXRoXjIZcf2wLi5ZlwGz/oMYfyURVCWbM5iw==",
-      "path": "microsoft.extensions.configuration.abstractions/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-6+7zTufCnZ+tfrUo7RbIRR3LB0BxwOwxfXuo0IbLyIvgoToGpWuz5wYEDfCYNOvpig9tY8FA0I1uRHYmITMXMQ==",
+      "path": "microsoft.extensions.caching.memory/1.0.0",
+      "hashPath": "microsoft.extensions.caching.memory.1.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+      "path": "microsoft.extensions.configuration/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.3.1.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.Abstractions/3.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ESz6bVoDQX7sgWdKHF6G9Pq672T8k+19AFb/txDXwdz7MoqaNQj2/in3agm/3qae9V+WvQZH86LLTNVo0it8vQ==",
+      "path": "microsoft.extensions.configuration.abstractions/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.abstractions.3.1.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration.Binder/2.2.0": {
       "type": "package",
@@ -5038,33 +4713,33 @@
       "path": "microsoft.extensions.configuration.environmentvariables/2.2.0",
       "hashPath": "microsoft.extensions.configuration.environmentvariables.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.FileExtensions/2.2.0": {
+    "Microsoft.Extensions.Configuration.FileExtensions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-H1qCpWBC8Ed4tguTR/qYkbb3F6DI5Su3t8xyFo3/5MzAd8PwPpHzgX8X04KbBxKmk173Pb64x7xMHarczVFQUA==",
-      "path": "microsoft.extensions.configuration.fileextensions/2.2.0",
-      "hashPath": "microsoft.extensions.configuration.fileextensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OjRJIkVxUFiVkr9a39AqVThft9QHoef4But5pDCydJOXJ4D/SkmzuW1tm6J2IXynxj6qfeAz9QTnzQAvOcGvzg==",
+      "path": "microsoft.extensions.configuration.fileextensions/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.fileextensions.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Configuration.Json/2.1.0": {
+    "Microsoft.Extensions.Configuration.Json/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9OCdAv7qiRtRlXQnECxW9zINUK8bYPKbNp5x8FQaLZbm/flv7mPvo1muZ1nsKGMZF4uL4Bl6nHw2v1fi3MqQ1Q==",
-      "path": "microsoft.extensions.configuration.json/2.1.0",
-      "hashPath": "microsoft.extensions.configuration.json.2.1.0.nupkg.sha512"
+      "sha512": "sha512-gBpBE1GoaCf1PKYC7u0Bd4mVZ/eR2bnOvn7u8GBXEy3JGar6sC3UVpVfTB9w+biLPtzcukZynBG9uchSBbLTNQ==",
+      "path": "microsoft.extensions.configuration.json/3.1.0",
+      "hashPath": "microsoft.extensions.configuration.json.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
-      "path": "microsoft.extensions.dependencyinjection/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.6.0.0.nupkg.sha512"
+      "sha512": "sha512-elNeOmkeX3eDVG6pYVeV82p29hr+UKDaBhrZyWvWLw/EVZSYEkZlQdkp0V39k/Xehs2Qa0mvoCvkVj3eQxNQ1Q==",
+      "path": "microsoft.extensions.dependencyinjection/7.0.0",
+      "hashPath": "microsoft.extensions.dependencyinjection.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/6.0.0": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5073,26 +4748,26 @@
       "path": "microsoft.extensions.dependencymodel/2.1.0",
       "hashPath": "microsoft.extensions.dependencymodel.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileProviders.Abstractions/2.2.0": {
+    "Microsoft.Extensions.FileProviders.Abstractions/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EcnaSsPTqx2MGnHrmWOD0ugbuuqVT8iICqSqPzi45V5/MA1LjUNb0kwgcxBGqizV1R+WeBK7/Gw25Jzkyk9bIw==",
-      "path": "microsoft.extensions.fileproviders.abstractions/2.2.0",
-      "hashPath": "microsoft.extensions.fileproviders.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-G3iBMOnn3tETEUvkE9J3a23wQpRkiXZp73zR0XNlicjLFhkeWW1FCaC2bTjrgHhPi2KO6x0BXnHvVuJPIlygBQ==",
+      "path": "microsoft.extensions.fileproviders.abstractions/3.1.0",
+      "hashPath": "microsoft.extensions.fileproviders.abstractions.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileProviders.Physical/2.2.0": {
+    "Microsoft.Extensions.FileProviders.Physical/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-tbDHZnBJkjYd9NjlRZ9ondDiv1Te3KYCTW2RWpR1B0e1Z8+EnFRo7qNnHkkSCixLdlPZzhjlX24d/PixQ7w2dA==",
-      "path": "microsoft.extensions.fileproviders.physical/2.2.0",
-      "hashPath": "microsoft.extensions.fileproviders.physical.2.2.0.nupkg.sha512"
+      "sha512": "sha512-KsvgrYp2fhNXoD9gqSu8jPK9Sbvaa7SqNtsLqHugJkCwFmgRvdz76z6Jz2tlFlC7wyMTZxwwtRF8WAorRQWTEA==",
+      "path": "microsoft.extensions.fileproviders.physical/3.1.0",
+      "hashPath": "microsoft.extensions.fileproviders.physical.3.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.FileSystemGlobbing/2.2.0": {
+    "Microsoft.Extensions.FileSystemGlobbing/3.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZSsHZp3PyW6vk37tDEdypjgGlNtpJ0EixBMOfUod2Thx7GtwfFSAQXUQx8a8BN8vfWKGGMbp7jPWdoHx/At4wQ==",
-      "path": "microsoft.extensions.filesystemglobbing/2.2.0",
-      "hashPath": "microsoft.extensions.filesystemglobbing.2.2.0.nupkg.sha512"
+      "sha512": "sha512-tK5HZOmVv0kUYkonMjuSsxR0CBk+Rd/69QU3eOMv9FvODGZ2d0SR+7R+n8XIgBcCCoCHJBSsI4GPRaoN3Le4rA==",
+      "path": "microsoft.extensions.filesystemglobbing/3.1.0",
+      "hashPath": "microsoft.extensions.filesystemglobbing.3.1.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Hosting/2.1.0": {
       "type": "package",
@@ -5108,26 +4783,33 @@
       "path": "microsoft.extensions.hosting.abstractions/2.2.0",
       "hashPath": "microsoft.extensions.hosting.abstractions.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Http/3.1.32": {
+    "Microsoft.Extensions.Http/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0ZNzmbaeKQMQQH8CZ1QVKC26nJ+jOn1AjSrVWKEb9sqX8cgElMbWUtvOXN21BI6IHedS+uhVuzJLQN3Ny46AKw==",
-      "path": "microsoft.extensions.http/3.1.32",
-      "hashPath": "microsoft.extensions.http.3.1.32.nupkg.sha512"
+      "sha512": "sha512-15+pa2G0bAMHbHewaQIdr/y6ag2H3yh4rd9hTXavtWDzQBkvpe2RMqFg8BxDpcQWssmjmBApGPcw93QRz6YcMg==",
+      "path": "microsoft.extensions.http/6.0.0",
+      "hashPath": "microsoft.extensions.http.6.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging/6.0.0": {
+    "Microsoft.Extensions.Logging/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
-      "path": "microsoft.extensions.logging/6.0.0",
-      "hashPath": "microsoft.extensions.logging.6.0.0.nupkg.sha512"
+      "sha512": "sha512-Nw2muoNrOG5U5qa2ZekXwudUn2BJcD41e65zwmDHb1fQegTX66UokLWZkJRpqSSHXDOWZ5V0iqhbxOEky91atA==",
+      "path": "microsoft.extensions.logging/7.0.0",
+      "hashPath": "microsoft.extensions.logging.7.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Logging.Abstractions/6.0.0": {
+    "Microsoft.Extensions.Logging.Abstractions/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA==",
-      "path": "microsoft.extensions.logging.abstractions/6.0.0",
-      "hashPath": "microsoft.extensions.logging.abstractions.6.0.0.nupkg.sha512"
+      "sha512": "sha512-kmn78+LPVMOWeITUjIlfxUPDsI0R6G0RkeAMBmQxAJ7vBJn4q2dTva7pWi65ceN5vPGjJ9q/Uae2WKgvfktJAw==",
+      "path": "microsoft.extensions.logging.abstractions/7.0.0",
+      "hashPath": "microsoft.extensions.logging.abstractions.7.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.ApplicationInsights/2.21.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tjzErt5oaLs1caaThu6AbtJuHH0oIGDG/rYCXDruHVGig3m8MyCDuwDsGQwzimY7g4aFyLOKfHc3unBN2G96gw==",
+      "path": "microsoft.extensions.logging.applicationinsights/2.21.0",
+      "hashPath": "microsoft.extensions.logging.applicationinsights.2.21.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Logging.Configuration/2.1.0": {
       "type": "package",
@@ -5143,12 +4825,12 @@
       "path": "microsoft.extensions.objectpool/2.2.0",
       "hashPath": "microsoft.extensions.objectpool.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Options/6.0.0": {
+    "Microsoft.Extensions.Options/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
-      "path": "microsoft.extensions.options/6.0.0",
-      "hashPath": "microsoft.extensions.options.6.0.0.nupkg.sha512"
+      "sha512": "sha512-lP1yBnTTU42cKpMozuafbvNtQ7QcBjr/CcK3bYOGEMH55Fjt+iecXjT6chR7vbgCMqy3PG3aNQSZgo/EuY/9qQ==",
+      "path": "microsoft.extensions.options/7.0.0",
+      "hashPath": "microsoft.extensions.options.7.0.0.nupkg.sha512"
     },
     "Microsoft.Extensions.Options.ConfigurationExtensions/2.1.0": {
       "type": "package",
@@ -5157,12 +4839,12 @@
       "path": "microsoft.extensions.options.configurationextensions/2.1.0",
       "hashPath": "microsoft.extensions.options.configurationextensions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Primitives/6.0.0": {
+    "Microsoft.Extensions.Primitives/7.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
-      "path": "microsoft.extensions.primitives/6.0.0",
-      "hashPath": "microsoft.extensions.primitives.6.0.0.nupkg.sha512"
+      "sha512": "sha512-um1KU5kxcRp3CNuI8o/GrZtD4AIOXDk+RLsytjZ9QPok3ttLUelLKpilVPuaFT3TFjOhSibUAso0odbOaCDj3Q==",
+      "path": "microsoft.extensions.primitives/7.0.0",
+      "hashPath": "microsoft.extensions.primitives.7.0.0.nupkg.sha512"
     },
     "Microsoft.FASTER.Core/2.6.5": {
       "type": "package",
@@ -5171,19 +4853,19 @@
       "path": "microsoft.faster.core/2.6.5",
       "hashPath": "microsoft.faster.core.2.6.5.nupkg.sha512"
     },
-    "Microsoft.Identity.Client/4.61.3": {
+    "Microsoft.Identity.Client/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-naJo/Qm35Caaoxp5utcw+R8eU8ZtLz2ALh8S+gkekOYQ1oazfCQMWVT4NJ/FnHzdIJlm8dMz0oMpMGCabx5odA==",
-      "path": "microsoft.identity.client/4.61.3",
-      "hashPath": "microsoft.identity.client.4.61.3.nupkg.sha512"
+      "sha512": "sha512-mE+m3pZ7zSKocSubKXxwZcUrCzLflC86IdLxrVjS8tialy0b1L+aECBqRBC/ykcPlB4y7skg49TaTiA+O2UfDw==",
+      "path": "microsoft.identity.client/4.66.1",
+      "hashPath": "microsoft.identity.client.4.66.1.nupkg.sha512"
     },
-    "Microsoft.Identity.Client.Extensions.Msal/4.61.3": {
+    "Microsoft.Identity.Client.Extensions.Msal/4.66.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-PWnJcznrSGr25MN8ajlc2XIDW4zCFu0U6FkpaNLEWLgd1NgFCp5uDY3mqLDgM8zCN8hqj8yo5wHYfLB2HjcdGw==",
-      "path": "microsoft.identity.client.extensions.msal/4.61.3",
-      "hashPath": "microsoft.identity.client.extensions.msal.4.61.3.nupkg.sha512"
+      "sha512": "sha512-osgt1J9Rve3LO7wXqpWoFx9UFjl0oeqoUMK/xEru7dvafQ28RgV1A17CoCGCCRSUbgDQ4Arg5FgGK2lQ3lXR4A==",
+      "path": "microsoft.identity.client.extensions.msal/4.66.1",
+      "hashPath": "microsoft.identity.client.extensions.msal.4.66.1.nupkg.sha512"
     },
     "Microsoft.IdentityModel.Abstractions/7.6.3": {
       "type": "package",
@@ -5191,13 +4873,6 @@
       "sha512": "sha512-EycYJUD/3cZw/b6TioXOpmETjv9OX5/VRk0Tc26x6I+SxxLNxx6ymivwo2dfYeiimqg5d3k88VXnrxc7HJch6Q==",
       "path": "microsoft.identitymodel.abstractions/7.6.3",
       "hashPath": "microsoft.identitymodel.abstractions.7.6.3.nupkg.sha512"
-    },
-    "Microsoft.IdentityModel.Clients.ActiveDirectory/3.14.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-TNsJJMiRnkeby1ovThVoV9yFsPWjAdluwOA+Nf0LtSsBVVrKQv8Qp4kYOgyNwMVj+pDwbhXISySk+4HyHVWNZQ==",
-      "path": "microsoft.identitymodel.clients.activedirectory/3.14.2",
-      "hashPath": "microsoft.identitymodel.clients.activedirectory.3.14.2.nupkg.sha512"
     },
     "Microsoft.IdentityModel.JsonWebTokens/7.6.3": {
       "type": "package",
@@ -5248,19 +4923,26 @@
       "path": "microsoft.net.http.headers/2.2.0",
       "hashPath": "microsoft.net.http.headers.2.2.0.nupkg.sha512"
     },
-    "Microsoft.NET.Sdk.Functions/4.4.0": {
+    "Microsoft.NET.Sdk.Functions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-c7hsHAfKhFaPZP6UIeZbWpNqPd+QGObV0VViniGvZYpXkpzmW9XsY8/6nVbtZFchUe/2ziN06sG0f++A6TxjNg==",
-      "path": "microsoft.net.sdk.functions/4.4.0",
-      "hashPath": "microsoft.net.sdk.functions.4.4.0.nupkg.sha512"
+      "sha512": "sha512-jDnf2TZ5JcBQY9BhI5hzRsbsu+EzJuz22GzmHmV9iGFFBraD3MaOTsoHxtS5kpd9qX3qCv7I7HuNjUSiH3nTZg==",
+      "path": "microsoft.net.sdk.functions/4.6.0",
+      "hashPath": "microsoft.net.sdk.functions.4.6.0.nupkg.sha512"
     },
-    "Microsoft.NETCore.Platforms/2.1.2": {
+    "Microsoft.NET.StringTools/17.6.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mOJy3M0UN+LUG21dLGMxaWZEP6xYpQEpLuvuEQBaownaX4YuhH6NmNUlN9si+vNkAS6dwJ//N1O4DmLf2CikVg==",
-      "path": "microsoft.netcore.platforms/2.1.2",
-      "hashPath": "microsoft.netcore.platforms.2.1.2.nupkg.sha512"
+      "sha512": "sha512-N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA==",
+      "path": "microsoft.net.stringtools/17.6.3",
+      "hashPath": "microsoft.net.stringtools.17.6.3.nupkg.sha512"
+    },
+    "Microsoft.NETCore.Platforms/3.1.9": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-e+/BrhryHoMojWlbcPJAFcShpk3JYvsMfrmoM26dnvHARWR6vtmGbfHppZcANVqf7DUBDIRxlZXcWg7v/9e1TQ==",
+      "path": "microsoft.netcore.platforms/3.1.9",
+      "hashPath": "microsoft.netcore.platforms.3.1.9.nupkg.sha512"
     },
     "Microsoft.NETCore.Targets/1.1.3": {
       "type": "package",
@@ -5276,12 +4958,12 @@
       "path": "microsoft.sqlserver.server/1.0.0",
       "hashPath": "microsoft.sqlserver.server.1.0.0.nupkg.sha512"
     },
-    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9123.0": {
+    "Microsoft.SqlServer.TransactSql.ScriptDom/161.9135.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v1I3SV+EqPHBM+RGrB5LyEc2z74t8WRYFmB0BmSc7EMBDUxFgmJ5oentkf9hPkUFfesha9spB0jci4hDtrCE3Q==",
-      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9123.0",
-      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9123.0.nupkg.sha512"
+      "sha512": "sha512-Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g==",
+      "path": "microsoft.sqlserver.transactsql.scriptdom/161.9135.0",
+      "hashPath": "microsoft.sqlserver.transactsql.scriptdom.161.9135.0.nupkg.sha512"
     },
     "Microsoft.Win32.Primitives/4.3.0": {
       "type": "package",
@@ -5297,40 +4979,54 @@
       "path": "microsoft.win32.registry/5.0.0",
       "hashPath": "microsoft.win32.registry.5.0.0.nupkg.sha512"
     },
-    "MongoDB.Bson/2.25.0": {
+    "Microsoft.Win32.SystemEvents/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xQx/qtC2nu9oGiyNqAwfiDpUMweLi0nID677cyKykpwmj5AVMrnd//UwmcmuX95178DeY6rf7cjmA613TQXPiA==",
-      "path": "mongodb.bson/2.25.0",
-      "hashPath": "mongodb.bson.2.25.0.nupkg.sha512"
+      "sha512": "sha512-mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+      "path": "microsoft.win32.systemevents/4.7.0",
+      "hashPath": "microsoft.win32.systemevents.4.7.0.nupkg.sha512"
     },
-    "MongoDB.Driver/2.25.0": {
+    "MongoDB.Bson/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dMqnZTV6MuvoEI4yFtSvKJdAoN6NeyAEvG8aoxnrLIVd7bR84QxLgpsM1nhK17qkOcIx/IrpMIfrvp5iMnYGBg==",
-      "path": "mongodb.driver/2.25.0",
-      "hashPath": "mongodb.driver.2.25.0.nupkg.sha512"
+      "sha512": "sha512-wz8UtxdjnknHRJuMatTRr2QMlh7k9457BRfaDQxl+OiKV01vMzm1K0/jTvQJqORV5eba6HrCAzMJzj7nnt5cag==",
+      "path": "mongodb.bson/2.29.0",
+      "hashPath": "mongodb.bson.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Driver.Core/2.25.0": {
+    "MongoDB.Driver/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oN4nLgO5HQEThTg/zqeoHqaO2+q64DBVb4r7BvhaFb0p0TM9jZKnCKvh1EA8d9E9swIz0CgvMrvL1mPyRCZzag==",
-      "path": "mongodb.driver.core/2.25.0",
-      "hashPath": "mongodb.driver.core.2.25.0.nupkg.sha512"
+      "sha512": "sha512-1IfTnHX8G2SsXIHDz80OVSmcdL95vzzWXGGucR45k7+TUOcWVhiqYcc13ckRXl4NVxn4UTRrrKl+92xvjwWrRA==",
+      "path": "mongodb.driver/2.29.0",
+      "hashPath": "mongodb.driver.2.29.0.nupkg.sha512"
     },
-    "MongoDB.Libmongocrypt/1.8.2": {
+    "MongoDB.Driver.Core/2.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-z/8JCULSHM1+mzkau0ivIkU9kIn8JEFFSkmYTSaMaWMMHt96JjUtMKuXxeGNGSnHZ5290ZPKIlQfjoWFk2sKog==",
-      "path": "mongodb.libmongocrypt/1.8.2",
-      "hashPath": "mongodb.libmongocrypt.1.8.2.nupkg.sha512"
+      "sha512": "sha512-3M7gdmuLEay4Wc/q4zm/oA5KT4E62SsRBiq3prpT3tGEPkfstr3N3fYRbzYNu8TJgeyS0q5OPe4zI4yi6/GemQ==",
+      "path": "mongodb.driver.core/2.29.0",
+      "hashPath": "mongodb.driver.core.2.29.0.nupkg.sha512"
     },
-    "morelinq/3.4.2": {
+    "MongoDB.Libmongocrypt/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q==",
-      "path": "morelinq/3.4.2",
-      "hashPath": "morelinq.3.4.2.nupkg.sha512"
+      "sha512": "sha512-B1X51jrtNacKvxKoaqWeknYeJfQS5aWf6BmVLT5JZerz3AUXFzv8edPskJYqBc3kLy1J2PWzMqqsnyb9g8FtcA==",
+      "path": "mongodb.libmongocrypt/1.12.0",
+      "hashPath": "mongodb.libmongocrypt.1.12.0.nupkg.sha512"
+    },
+    "morelinq/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-tkUeXp5dWNVP47MIhVEsIQk4DaN2oM/owIAnHblNOiwDQ5RB7oKreqZ7a+z+AEdyNgzLSkj6Pv0D0rY6Gh1/Ng==",
+      "path": "morelinq/4.1.0",
+      "hashPath": "morelinq.4.1.0.nupkg.sha512"
+    },
+    "MySql.Data/8.0.33": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mW+A9tc0s+3E3+XYe80aJmr/AvZoKBZG44w13AdVf4+1iRDwgdL6eLMPZgHyQFGwdLwNvQNPKegcOE4rRDuv8Q==",
+      "path": "mysql.data/8.0.33",
+      "hashPath": "mysql.data.8.0.33.nupkg.sha512"
     },
     "ncrontab.signed/3.3.0": {
       "type": "package",
@@ -5339,12 +5035,12 @@
       "path": "ncrontab.signed/3.3.0",
       "hashPath": "ncrontab.signed.3.3.0.nupkg.sha512"
     },
-    "NETStandard.Library/2.0.1": {
+    "NETStandard.Library/1.6.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oA6nwv9MhEKYvLpjZ0ggSpb1g4CQViDVQjLUcDWg598jtvJbpfeP2reqwI1GLW2TbxC/Ml7xL6BBR1HmKPXlTg==",
-      "path": "netstandard.library/2.0.1",
-      "hashPath": "netstandard.library.2.0.1.nupkg.sha512"
+      "sha512": "sha512-WcSp3+vP+yHNgS8EV5J7pZ9IRpeDuARBPN28by8zqff1wJQXm26PVU8L3/fYLBJVU7BtDyqNVWq2KlCVvSSR4A==",
+      "path": "netstandard.library/1.6.1",
+      "hashPath": "netstandard.library.1.6.1.nupkg.sha512"
     },
     "Newtonsoft.Json/13.0.3": {
       "type": "package",
@@ -5366,6 +5062,13 @@
       "sha512": "sha512-zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ==",
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
+    },
+    "Portable.BouncyCastle/1.9.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw==",
+      "path": "portable.bouncycastle/1.9.0",
+      "hashPath": "portable.bouncycastle.1.9.0.nupkg.sha512"
     },
     "RabbitMQ.Client/5.1.2": {
       "type": "package",
@@ -5486,6 +5189,13 @@
       "path": "runtime.any.system.threading.tasks/4.3.0",
       "hashPath": "runtime.any.system.threading.tasks.4.3.0.nupkg.sha512"
     },
+    "runtime.any.System.Threading.Timer/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-w4ehZJ+AwXYmGwYu+rMvym6RvMaRiUEQR1u6dwcyuKHxz8Heu/mO9AG1MquEgTyucnhv3M43X0iKpDOoN17C0w==",
+      "path": "runtime.any.system.threading.timer/4.3.0",
+      "hashPath": "runtime.any.system.threading.timer.4.3.0.nupkg.sha512"
+    },
     "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
       "serviceable": true,
@@ -5514,6 +5224,13 @@
       "path": "runtime.native.system/4.3.0",
       "hashPath": "runtime.native.system.4.3.0.nupkg.sha512"
     },
+    "runtime.native.System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+      "path": "runtime.native.system.io.compression/4.3.0",
+      "hashPath": "runtime.native.system.io.compression.4.3.0.nupkg.sha512"
+    },
     "runtime.native.System.Net.Http/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5521,12 +5238,12 @@
       "path": "runtime.native.system.net.http/4.3.0",
       "hashPath": "runtime.native.system.net.http.4.3.0.nupkg.sha512"
     },
-    "runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UPrVPlqPRSVZaB4ADmbsQ77KXn9ORiWXyA1RP2W2+byCh3bhgT1bQz0jbeOoog9/2oTQ5wWZSDSMeb74MjezcA==",
-      "path": "runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+      "path": "runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5549,12 +5266,12 @@
       "path": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.2",
       "hashPath": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.2.nupkg.sha512"
     },
-    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.1": {
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-t15yGf5r6vMV1rB5O6TgfXKChtCaN3niwFw44M2ImX3eZ8yzueplqMqXPCbWzoBDHJVz9fE+9LFUGCsUmS2Jgg==",
-      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.1",
-      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.1.nupkg.sha512"
+      "sha512": "sha512-kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ==",
+      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
     },
     "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.2": {
       "type": "package",
@@ -5598,6 +5315,13 @@
       "path": "runtime.win.microsoft.win32.primitives/4.3.0",
       "hashPath": "runtime.win.microsoft.win32.primitives.4.3.0.nupkg.sha512"
     },
+    "runtime.win.System.Console/4.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vHPXC3B18dxhyipVce8xQT1MQv1o5srYZqBlCNu9p9MNjhgGOntdQh/Xh2X4o7M2F839YUcQiGwu8Q498FyDjg==",
+      "path": "runtime.win.system.console/4.3.1",
+      "hashPath": "runtime.win.system.console.4.3.1.nupkg.sha512"
+    },
     "runtime.win.System.Diagnostics.Debug/4.3.0": {
       "type": "package",
       "serviceable": true,
@@ -5640,12 +5364,12 @@
       "path": "semanticversion/2.1.0",
       "hashPath": "semanticversion.2.1.0.nupkg.sha512"
     },
-    "Sendgrid/9.10.0": {
+    "SendGrid/9.29.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-G8CYo0oPP/on1D3QNfU27GMLCEUIii8/nGTLGnbmrddrRaRShdxpCHWZhxr02cwZDwAsx0WBCi+IjbJ+DpQo0A==",
-      "path": "sendgrid/9.10.0",
-      "hashPath": "sendgrid.9.10.0.nupkg.sha512"
+      "sha512": "sha512-nb/zHePecN9U4/Bmct+O+lpgK994JklbCCNMIgGPOone/DngjQoMCHeTvkl+m0Nglvm0dqMEshmvB4fO8eF3dA==",
+      "path": "sendgrid/9.29.3",
+      "hashPath": "sendgrid.9.29.3.nupkg.sha512"
     },
     "SharpCompress/0.30.1": {
       "type": "package",
@@ -5668,12 +5392,19 @@
       "path": "stackexchange.redis/2.7.4",
       "hashPath": "stackexchange.redis.2.7.4.nupkg.sha512"
     },
-    "System.AppContext/4.1.0": {
+    "starkbank-ecdsa/1.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
-      "path": "system.appcontext/4.1.0",
-      "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
+      "sha512": "sha512-OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog==",
+      "path": "starkbank-ecdsa/1.3.3",
+      "hashPath": "starkbank-ecdsa.1.3.3.nupkg.sha512"
+    },
+    "System.AppContext/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-fKC+rmaLfeIzUhagxY17Q9siv/sPrjjKcfNg1Ic8IlQkZLipo8ljcaZQu4VtI4Jqbzjc2VTjzGLF6WmsRXAEgA==",
+      "path": "system.appcontext/4.3.0",
+      "hashPath": "system.appcontext.4.3.0.nupkg.sha512"
     },
     "System.Buffers/4.5.1": {
       "type": "package",
@@ -5682,12 +5413,12 @@
       "path": "system.buffers/4.5.1",
       "hashPath": "system.buffers.4.5.1.nupkg.sha512"
     },
-    "System.ClientModel/1.0.0": {
+    "System.ClientModel/1.1.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I3CVkvxeqFYjIVEP59DnjbeoGNfo/+SZrCLpRz2v/g0gpCHaEMPtWSY0s9k/7jR1rAsLNg2z2u1JRB76tPjnIw==",
-      "path": "system.clientmodel/1.0.0",
-      "hashPath": "system.clientmodel.1.0.0.nupkg.sha512"
+      "sha512": "sha512-UocOlCkxLZrG2CKMAAImPcldJTxeesHnHGHwhJ0pNlZEvEXcWKuQvVOER2/NiOkJGRJk978SNdw3j6/7O9H1lg==",
+      "path": "system.clientmodel/1.1.0",
+      "hashPath": "system.clientmodel.1.1.0.nupkg.sha512"
     },
     "System.CodeDom/4.4.0": {
       "type": "package",
@@ -5738,54 +5469,19 @@
       "path": "system.componentmodel.annotations/4.4.0",
       "hashPath": "system.componentmodel.annotations.4.4.0.nupkg.sha512"
     },
-    "System.Composition/1.0.31": {
+    "System.Configuration.ConfigurationManager/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-I+D26qpYdoklyAVUdqwUBrEIckMNjAYnuPJy/h9dsQItpQwVREkDFs4b4tkBza0kT2Yk48Lcfsv2QQ9hWsh9Iw==",
-      "path": "system.composition/1.0.31",
-      "hashPath": "system.composition.1.0.31.nupkg.sha512"
+      "sha512": "sha512-gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+      "path": "system.configuration.configurationmanager/8.0.1",
+      "hashPath": "system.configuration.configurationmanager.8.0.1.nupkg.sha512"
     },
-    "System.Composition.AttributedModel/1.0.31": {
+    "System.Console/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NHWhkM3ZkspmA0XJEsKdtTt1ViDYuojgSND3yHhTzwxepiwqZf+BCWuvCbjUt4fe0NxxQhUDGJ5km6sLjo9qnQ==",
-      "path": "system.composition.attributedmodel/1.0.31",
-      "hashPath": "system.composition.attributedmodel.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Convention/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-GLjh2Ju71k6C0qxMMtl4efHa68NmWeIUYh4fkUI8xbjQrEBvFmRwMDFcylT8/PR9SQbeeL48IkFxU/+gd0nYEQ==",
-      "path": "system.composition.convention/1.0.31",
-      "hashPath": "system.composition.convention.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Hosting/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-fN1bT4RX4vUqjbgoyuJFVUizAl2mYF5VAb+bVIxIYZSSc0BdnX+yGAxcavxJuDDCQ1K+/mdpgyEFc8e9ikjvrg==",
-      "path": "system.composition.hosting/1.0.31",
-      "hashPath": "system.composition.hosting.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.Runtime/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-0LEJN+2NVM89CE4SekDrrk5tHV5LeATltkp+9WNYrR+Huiyt0vaCqHbbHtVAjPyeLWIc8dOz/3kthRBj32wGQg==",
-      "path": "system.composition.runtime/1.0.31",
-      "hashPath": "system.composition.runtime.1.0.31.nupkg.sha512"
-    },
-    "System.Composition.TypedParts/1.0.31": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-0Zae/FtzeFgDBBuILeIbC/T9HMYbW4olAmi8XqqAGosSOWvXfiQLfARZEhiGd0LVXaYgXr0NhxiU1LldRP1fpQ==",
-      "path": "system.composition.typedparts/1.0.31",
-      "hashPath": "system.composition.typedparts.1.0.31.nupkg.sha512"
-    },
-    "System.Configuration.ConfigurationManager/8.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-JlYi9XVvIREURRUlGMr1F6vOFLk7YSY4p1vHo4kX3tQ0AGrjqlRWHDi66ImHhy6qwXBG3BJ6Y1QlYQ+Qz6Xgww==",
-      "path": "system.configuration.configurationmanager/8.0.0",
-      "hashPath": "system.configuration.configurationmanager.8.0.0.nupkg.sha512"
+      "sha512": "sha512-DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg==",
+      "path": "system.console/4.3.0",
+      "hashPath": "system.console.4.3.0.nupkg.sha512"
     },
     "System.Diagnostics.Debug/4.3.0": {
       "type": "package",
@@ -5801,19 +5497,19 @@
       "path": "system.diagnostics.diagnosticsource/8.0.0",
       "hashPath": "system.diagnostics.diagnosticsource.8.0.0.nupkg.sha512"
     },
-    "System.Diagnostics.EventLog/6.0.0": {
+    "System.Diagnostics.EventLog/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw==",
-      "path": "system.diagnostics.eventlog/6.0.0",
-      "hashPath": "system.diagnostics.eventlog.6.0.0.nupkg.sha512"
+      "sha512": "sha512-n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg==",
+      "path": "system.diagnostics.eventlog/8.0.1",
+      "hashPath": "system.diagnostics.eventlog.8.0.1.nupkg.sha512"
     },
-    "System.Diagnostics.Process/4.3.0": {
+    "System.Diagnostics.PerformanceCounter/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-J0wOX07+QASQblsfxmIMFc9Iq7KTXYL3zs2G/Xc704Ylv3NpuVdo6gij6V3PGiptTxqsK0K7CdXenRvKUnkA2g==",
-      "path": "system.diagnostics.process/4.3.0",
-      "hashPath": "system.diagnostics.process.4.3.0.nupkg.sha512"
+      "sha512": "sha512-kE9szT4i3TYT9bDE/BPfzg9/BL6enMiZlcUmnUEBrhRtxWvurKoa8qhXkLTRhrxMzBqaDleWlRfIPE02tulU+w==",
+      "path": "system.diagnostics.performancecounter/4.7.0",
+      "hashPath": "system.diagnostics.performancecounter.4.7.0.nupkg.sha512"
     },
     "System.Diagnostics.Tools/4.3.0": {
       "type": "package",
@@ -5835,6 +5531,13 @@
       "sha512": "sha512-rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
       "path": "system.diagnostics.tracing/4.3.0",
       "hashPath": "system.diagnostics.tracing.4.3.0.nupkg.sha512"
+    },
+    "System.Drawing.Common/4.7.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-B3+wwhAeoUQ6KeshWSq3IRLQiMoqPEzSHzyVyxTI/EbYuqIp90lXrRISlip2AF+5tj74ycIVPpnRY4M424HahA==",
+      "path": "system.drawing.common/4.7.3",
+      "hashPath": "system.drawing.common.4.7.3.nupkg.sha512"
     },
     "System.Dynamic.Runtime/4.0.11": {
       "type": "package",
@@ -5892,12 +5595,33 @@
       "path": "system.io/4.3.0",
       "hashPath": "system.io.4.3.0.nupkg.sha512"
     },
+    "System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+      "path": "system.io.compression/4.3.0",
+      "hashPath": "system.io.compression.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Compression.ZipFile/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-G4HwjEsgIwy3JFBduZ9quBkAu+eUwjIdJleuNSgmUojbH6O3mlvEIme+GHx/cLlTAPcrnnL7GqvB9pTlWRfhOg==",
+      "path": "system.io.compression.zipfile/4.3.0",
+      "hashPath": "system.io.compression.zipfile.4.3.0.nupkg.sha512"
+    },
     "System.IO.FileSystem/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
       "path": "system.io.filesystem/4.3.0",
       "hashPath": "system.io.filesystem.4.3.0.nupkg.sha512"
+    },
+    "System.IO.FileSystem.AccessControl/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vMToiarpU81LR1/KZtnT7VDPvqAZfw9oOS5nY6pPP78nGYz3COLsQH3OfzbR+SjTgltd31R6KmKklz/zDpTmzw==",
+      "path": "system.io.filesystem.accesscontrol/4.7.0",
+      "hashPath": "system.io.filesystem.accesscontrol.4.7.0.nupkg.sha512"
     },
     "System.IO.FileSystem.Primitives/4.3.0": {
       "type": "package",
@@ -5913,12 +5637,12 @@
       "path": "system.io.hashing/6.0.0",
       "hashPath": "system.io.hashing.6.0.0.nupkg.sha512"
     },
-    "System.IO.Pipelines/5.0.1": {
+    "System.IO.Pipelines/6.0.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg==",
-      "path": "system.io.pipelines/5.0.1",
-      "hashPath": "system.io.pipelines.5.0.1.nupkg.sha512"
+      "sha512": "sha512-ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw==",
+      "path": "system.io.pipelines/6.0.3",
+      "hashPath": "system.io.pipelines.6.0.3.nupkg.sha512"
     },
     "System.Json/4.5.0": {
       "type": "package",
@@ -5955,12 +5679,12 @@
       "path": "system.memory/4.5.5",
       "hashPath": "system.memory.4.5.5.nupkg.sha512"
     },
-    "System.Memory.Data/1.0.2": {
+    "System.Memory.Data/6.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JGkzeqgBsiZwKJZ1IxPNsDFZDhUvuEdX8L8BDC8N3KOj+6zMcNU28CNN59TpZE/VJYy9cP+5M+sbxtWJx3/xtw==",
-      "path": "system.memory.data/1.0.2",
-      "hashPath": "system.memory.data.1.0.2.nupkg.sha512"
+      "sha512": "sha512-yliDgLh9S9Mcy5hBIdZmX6yphYIW3NH+3HN1kV1m7V1e0s7LNTw/tHNjJP4U9nSMEgl3w1TzYv/KA1Tg9NYy6w==",
+      "path": "system.memory.data/6.0.1",
+      "hashPath": "system.memory.data.6.0.1.nupkg.sha512"
     },
     "System.Net.Http/4.3.4": {
       "type": "package",
@@ -5983,19 +5707,19 @@
       "path": "system.net.primitives/4.3.0",
       "hashPath": "system.net.primitives.4.3.0.nupkg.sha512"
     },
+    "System.Net.ServerSentEvents/10.0.0-preview.1.25080.5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WXlkTQNLx+O4Ys5lMZNjGOUsuMXjL8nbmBGCWR0np0EKasGZmmfMXmzm9xT22arIS74uhRb/z8Y5l5C4Ceur9Q==",
+      "path": "system.net.serversentevents/10.0.0-preview.1.25080.5",
+      "hashPath": "system.net.serversentevents.10.0.0-preview.1.25080.5.nupkg.sha512"
+    },
     "System.Net.Sockets/4.3.0": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
       "path": "system.net.sockets/4.3.0",
       "hashPath": "system.net.sockets.4.3.0.nupkg.sha512"
-    },
-    "System.Net.WebSockets.WebSocketProtocol/4.5.3": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-O8RIMEVeOFzT8fscu6MDc4y+0LfnlXdqGovb0rJHBNVKhwn6BsNJmTY1oYUZPPsMfcc5OP20WpX4vj/aK8n98g==",
-      "path": "system.net.websockets.websocketprotocol/4.5.3",
-      "hashPath": "system.net.websockets.websocketprotocol.4.5.3.nupkg.sha512"
     },
     "System.Numerics.Vectors/4.5.0": {
       "type": "package",
@@ -6010,13 +5734,6 @@
       "sha512": "sha512-bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
       "path": "system.objectmodel/4.3.0",
       "hashPath": "system.objectmodel.4.3.0.nupkg.sha512"
-    },
-    "System.Private.DataContractSerialization/4.1.1": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-lcqFBUaCZxPiUkA4dlSOoPZGtZsAuuElH2XHgLwGLxd7ZozWetV5yiz0qGAV2AUYOqw97MtZBjbLMN16Xz4vXA==",
-      "path": "system.private.datacontractserialization/4.1.1",
-      "hashPath": "system.private.datacontractserialization.4.1.1.nupkg.sha512"
     },
     "System.Private.Uri/4.3.0": {
       "type": "package",
@@ -6144,12 +5861,12 @@
       "path": "system.runtime/4.3.1",
       "hashPath": "system.runtime.4.3.1.nupkg.sha512"
     },
-    "System.Runtime.Caching/8.0.0": {
+    "System.Runtime.Caching/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4TmlmvGp4kzZomm7J2HJn6IIx0UUrQyhBDyb5O1XiunZlQImXW+B8b7W/sTPcXhSf9rp5NR5aDtQllwbB5elOQ==",
-      "path": "system.runtime.caching/8.0.0",
-      "hashPath": "system.runtime.caching.8.0.0.nupkg.sha512"
+      "sha512": "sha512-tdl7Q47P09UpRu0C/OQsGJU6GacBzzk4vfp5My9rodD+BchrxmajORnTthH8RxPUTPrIoVDJmLyvJcGxB267nQ==",
+      "path": "system.runtime.caching/8.0.1",
+      "hashPath": "system.runtime.caching.8.0.1.nupkg.sha512"
     },
     "System.Runtime.CompilerServices.Unsafe/6.0.0": {
       "type": "package",
@@ -6179,12 +5896,12 @@
       "path": "system.runtime.interopservices/4.3.0",
       "hashPath": "system.runtime.interopservices.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.InteropServices.RuntimeInformation/4.0.0": {
+    "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hWPhJxc453RCa8Z29O91EmfGeZIHX1ZH2A8L6lYQVSaKzku2DfArSfMEb1/MYYzPQRJZeu0c9dmYeJKxW5Fgng==",
-      "path": "system.runtime.interopservices.runtimeinformation/4.0.0",
-      "hashPath": "system.runtime.interopservices.runtimeinformation.4.0.0.nupkg.sha512"
+      "sha512": "sha512-cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+      "path": "system.runtime.interopservices.runtimeinformation/4.3.0",
+      "hashPath": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg.sha512"
     },
     "System.Runtime.Loader/4.3.0": {
       "type": "package",
@@ -6200,20 +5917,6 @@
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
     },
-    "System.Runtime.Serialization.Json/4.0.2": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-+7DIJhnKYgCzUgcLbVTtRQb2l1M0FP549XFlFkQM5lmNiUBl44AfNbx4bz61xA8PzLtlYwfmif4JJJW7MPPnjg==",
-      "path": "system.runtime.serialization.json/4.0.2",
-      "hashPath": "system.runtime.serialization.json.4.0.2.nupkg.sha512"
-    },
-    "System.Runtime.Serialization.Primitives/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
-      "path": "system.runtime.serialization.primitives/4.3.0",
-      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
-    },
     "System.Security.AccessControl/6.0.0": {
       "type": "package",
       "serviceable": true,
@@ -6221,12 +5924,12 @@
       "path": "system.security.accesscontrol/6.0.0",
       "hashPath": "system.security.accesscontrol.6.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.Algorithms/4.3.1": {
+    "System.Security.Cryptography.Algorithms/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-DVUblnRfnarrI5olEC2B/OCsJQd0anjVaObQMndHSc43efbc88/RMOlDyg/EyY0ix5ecyZMXS8zMksb5ukebZA==",
-      "path": "system.security.cryptography.algorithms/4.3.1",
-      "hashPath": "system.security.cryptography.algorithms.4.3.1.nupkg.sha512"
+      "sha512": "sha512-W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+      "path": "system.security.cryptography.algorithms/4.3.0",
+      "hashPath": "system.security.cryptography.algorithms.4.3.0.nupkg.sha512"
     },
     "System.Security.Cryptography.Cng/5.0.0": {
       "type": "package",
@@ -6270,12 +5973,19 @@
       "path": "system.security.cryptography.protecteddata/8.0.0",
       "hashPath": "system.security.cryptography.protecteddata.8.0.0.nupkg.sha512"
     },
-    "System.Security.Cryptography.X509Certificates/4.3.2": {
+    "System.Security.Cryptography.X509Certificates/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uwlfOnvJd7rXRvP3aV126Q9XebIIEGEaZ245Rd5/ZwOg7U7AU+AmpE0vRh2F0DFjfOTuk7MAexv4nYiNP/RYnQ==",
-      "path": "system.security.cryptography.x509certificates/4.3.2",
-      "hashPath": "system.security.cryptography.x509certificates.4.3.2.nupkg.sha512"
+      "sha512": "sha512-t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+      "path": "system.security.cryptography.x509certificates/4.3.0",
+      "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Permissions/4.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dkOV6YYVBnYRa15/yv004eCGRBVADXw8qRbbNiCn/XpdJSUXkkUeIvdvFHkvnko4CdKMqG8yRHC4ox83LSlMsQ==",
+      "path": "system.security.permissions/4.7.0",
+      "hashPath": "system.security.permissions.4.7.0.nupkg.sha512"
     },
     "System.Security.Principal.Windows/5.0.0": {
       "type": "package",
@@ -6291,12 +6001,12 @@
       "path": "system.text.encoding/4.3.0",
       "hashPath": "system.text.encoding.4.3.0.nupkg.sha512"
     },
-    "System.Text.Encoding.CodePages/4.5.1": {
+    "System.Text.Encoding.CodePages/4.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w==",
-      "path": "system.text.encoding.codepages/4.5.1",
-      "hashPath": "system.text.encoding.codepages.4.5.1.nupkg.sha512"
+      "sha512": "sha512-6JX7ZdaceBiLKLkYt8zJcp4xTJd1uYyXXEkPw6mnlUIjh1gZPIVKPtRXPmY5kLf6DwZmf5YLwR3QUrRonl7l0A==",
+      "path": "system.text.encoding.codepages/4.4.0",
+      "hashPath": "system.text.encoding.codepages.4.4.0.nupkg.sha512"
     },
     "System.Text.Encoding.Extensions/4.3.0": {
       "type": "package",
@@ -6312,12 +6022,12 @@
       "path": "system.text.encodings.web/8.0.0",
       "hashPath": "system.text.encodings.web.8.0.0.nupkg.sha512"
     },
-    "System.Text.Json/8.0.1": {
+    "System.Text.Json/8.0.4": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
-      "path": "system.text.json/8.0.1",
-      "hashPath": "system.text.json.8.0.1.nupkg.sha512"
+      "sha512": "sha512-bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
+      "path": "system.text.json/8.0.4",
+      "hashPath": "system.text.json.8.0.4.nupkg.sha512"
     },
     "System.Text.RegularExpressions/4.3.1": {
       "type": "package",
@@ -6333,12 +6043,12 @@
       "path": "system.threading/4.3.0",
       "hashPath": "system.threading.4.3.0.nupkg.sha512"
     },
-    "System.Threading.Channels/4.7.1": {
+    "System.Threading.Channels/6.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-6akRtHK/wab3246t4p5v3HQrtQk8LboOt5T4dtpNgsp3zvDeM4/Gx8V12t0h+c/W9/enUrilk8n6EQqdQorZAA==",
-      "path": "system.threading.channels/4.7.1",
-      "hashPath": "system.threading.channels.4.7.1.nupkg.sha512"
+      "sha512": "sha512-TY8/9+tI0mNaUMgntOxxaq2ndTkdXqLSxvPmas7XEqOlv9lQtB7wLjYGd756lOaO7Dvb5r/WXhluM+0Xe87v5Q==",
+      "path": "system.threading.channels/6.0.0",
+      "hashPath": "system.threading.channels.6.0.0.nupkg.sha512"
     },
     "System.Threading.Overlapped/4.3.0": {
       "type": "package",
@@ -6368,19 +6078,12 @@
       "path": "system.threading.tasks.extensions/4.5.4",
       "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
     },
-    "System.Threading.Thread/4.3.0": {
+    "System.Threading.Timer/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
-      "path": "system.threading.thread/4.3.0",
-      "hashPath": "system.threading.thread.4.3.0.nupkg.sha512"
-    },
-    "System.Threading.ThreadPool/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-k/+g4b7vjdd4aix83sTgC9VG6oXYKAktSfNIJUNGxPEj7ryEOfzHHhfnmsZvjxawwcD9HyWXKCXmPjX8U4zeSw==",
-      "path": "system.threading.threadpool/4.3.0",
-      "hashPath": "system.threading.threadpool.4.3.0.nupkg.sha512"
+      "sha512": "sha512-Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+      "path": "system.threading.timer/4.3.0",
+      "hashPath": "system.threading.timer.4.3.0.nupkg.sha512"
     },
     "System.ValueTuple/4.5.0": {
       "type": "package",
@@ -6389,26 +6092,26 @@
       "path": "system.valuetuple/4.5.0",
       "hashPath": "system.valuetuple.4.5.0.nupkg.sha512"
     },
-    "System.Xml.ReaderWriter/4.0.11": {
+    "System.Windows.Extensions/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ZIiLPsf67YZ9zgr31vzrFaYQqxRPX9cVHjtPSnmx4eN6lbS/yEyYNr2vs1doGDEscF0tjCZFsk9yUg1sC9e8tg==",
-      "path": "system.xml.readerwriter/4.0.11",
-      "hashPath": "system.xml.readerwriter.4.0.11.nupkg.sha512"
+      "sha512": "sha512-CeWTdRNfRaSh0pm2gDTJFwVaXfTq6Xwv/sA887iwPTneW7oMtMlpvDIO+U60+3GWTB7Aom6oQwv5VZVUhQRdPQ==",
+      "path": "system.windows.extensions/4.7.0",
+      "hashPath": "system.windows.extensions.4.7.0.nupkg.sha512"
     },
-    "System.Xml.XmlDocument/4.0.1": {
+    "System.Xml.ReaderWriter/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2eZu6IP+etFVBBFUFzw2w6J21DqIN5eL9Y8r8JfJWUmV28Z5P0SNU01oCisVHQgHsDhHPnmq2s1hJrJCFZWloQ==",
-      "path": "system.xml.xmldocument/4.0.1",
-      "hashPath": "system.xml.xmldocument.4.0.1.nupkg.sha512"
+      "sha512": "sha512-GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+      "path": "system.xml.readerwriter/4.3.0",
+      "hashPath": "system.xml.readerwriter.4.3.0.nupkg.sha512"
     },
-    "System.Xml.XmlSerializer/4.0.11": {
+    "System.Xml.XDocument/4.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FrazwwqfIXTfq23mfv4zH+BjqkSFNaNFBtjzu3I9NRmG8EELYyrv/fJnttCIwRMFRR/YKXF1hmsMmMEnl55HGw==",
-      "path": "system.xml.xmlserializer/4.0.11",
-      "hashPath": "system.xml.xmlserializer.4.0.11.nupkg.sha512"
+      "sha512": "sha512-5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+      "path": "system.xml.xdocument/4.3.0",
+      "hashPath": "system.xml.xdocument.4.3.0.nupkg.sha512"
     },
     "Twilio/5.6.3": {
       "type": "package",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Extension bundles provide a way for non-.NET function apps to reference and use 
 {
     "version": "2.0",
     "extensionBundle": {
-        "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+        "id": "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
         "version": "[4.*, 5.0.0)"
     }
 }
@@ -16,7 +16,7 @@ Extension bundles provide a way for non-.NET function apps to reference and use 
 
 |Branch|Status|
 |------|------|
-|main-preview|[![Build Status](https://azfunc.visualstudio.com/public/_apis/build/status/extension-bundles.public?branchName=main-preview)](https://azfunc.visualstudio.com/public/_build?definitionId=939&_a=summary&branchFilter=12530)|
+|main-experimental|[![Build Status](https://dev.azure.com/azfunc/public/_apis/build/status/extension-bundles.public?branchName=main-experimental)](https://dev.azure.com/azfunc/public/_build?definitionId=939&branchFilter=13485)|
 
 ## Build Requirements
 
@@ -51,6 +51,7 @@ dotnet run skip:dotnet run skip:PackageNetCoreV3BundlesWindows,CreateRUPackage,C
     | v2.x | https://github.com/Azure/azure-functions-extension-bundles/tree/main-v2 |
     | v3.x | https://github.com/Azure/azure-functions-extension-bundles/tree/main-v3 |
     | v4.x-preview | https://github.com/Azure/azure-functions-extension-bundles/tree/main-preview |
+    | v4.x-experimental | https://github.com/Azure/azure-functions-extension-bundles/tree/main-experimental |
 
 2. Add the following details to [extensions.json](src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) file
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
-# Overview
+# Azure Functions Extension Bundles
+
+## Overview
+
+### IMPORTANT: Experimental Bundle Notice
+
+This extension bundle is experimental and may contain breaking changes without prior notice. It includes features that are still under development and not yet ready for production use. Users should be aware that:
+
+- Bindings or triggers may change between versions
+- Extensions may be added, removed, or replaced without warning
+- Performance characteristics and stability may vary across releases
+- Security updates may require version upgrades
+- Testing in non-production environments is strongly recommended
+
+Use this bundle at your own risk in development and testing environments only.
+
+## What are Extension Bundles?
 
 Extension bundles provide a way for non-.NET function apps to reference and use Azure Function extension packages written in C#. It bundles several of the Azure Function extensions into a single package which can then be referenced extension via the `host.json` file. Below is a sample configuration:
 
@@ -20,8 +36,7 @@ Extension bundles provide a way for non-.NET function apps to reference and use 
 
 ## Build Requirements
 
-- [Dotnet Core SDK 2.2](https://dotnet.microsoft.com/en-us/download/dotnet/2.2)
-- [Dotnet Core SDK 3.1](https://dotnet.microsoft.com/en-us/download/dotnet/3.1)
+- [Dotnet SDK 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
 ## Build Steps
 
@@ -30,7 +45,7 @@ Extension bundles provide a way for non-.NET function apps to reference and use 
 ```bash
 cd build
 
-dotnet run skip:PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux
+dotnet run skip:PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux,PackageBundlesLinux
 ```
 
 ### Linux
@@ -47,10 +62,6 @@ dotnet run skip:dotnet run skip:PackageNetCoreV3BundlesWindows,CreateRUPackage,C
 
     |Bundle version | Branch |
     |------|------|
-    | v1.x | https://github.com/Azure/azure-functions-extension-bundles/tree/v1.x |
-    | v2.x | https://github.com/Azure/azure-functions-extension-bundles/tree/main-v2 |
-    | v3.x | https://github.com/Azure/azure-functions-extension-bundles/tree/main-v3 |
-    | v4.x-preview | https://github.com/Azure/azure-functions-extension-bundles/tree/main-preview |
     | v4.x-experimental | https://github.com/Azure/azure-functions-extension-bundles/tree/main-experimental |
 
 2. Add the following details to [extensions.json](src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) file

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -209,9 +209,12 @@ namespace Build
                 AddBindingInfoToExtensionsJson(extensionJsonFilePath);
             }
 
-            // Copy templates
-            var staticContentDirectory = Path.Combine(bundlePath, Settings.StaticContentDirectoryName);
-            FileUtility.CopyDirectory(Settings.StaticContentDirectoryPath, staticContentDirectory);
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_BUILDID")))   // skipped for local build
+            {
+                // Copy templates
+                var staticContentDirectory = Path.Combine(bundlePath, Settings.StaticContentDirectoryName);
+                FileUtility.CopyDirectory(Settings.StaticContentDirectoryPath, staticContentDirectory);
+            }
 
             // Add bundle.json
             CreateBundleJsonFile(bundlePath);

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -44,8 +44,8 @@ namespace Build
             }
 
             var files = Directory.GetFiles(Settings.TemplatesArtifactsDirectory);
-            string previewStr = BundleConfiguration.Instance.IsPreviewBundle ? ".Preview" : String.Empty;
-            string zipFileName = $"ExtensionBundle{previewStr}.v{BundleConfiguration.Instance.ExtensionBundleVersion[0]}.Templates";
+            string experimentalStr = BundleConfiguration.Instance.IsExperimentalBundle ? ".Experimental" : String.Empty;
+            string zipFileName = $"ExtensionBundle{experimentalStr}.v{BundleConfiguration.Instance.ExtensionBundleVersion[0]}.Templates";
 
             foreach (string file in files)
             {
@@ -121,7 +121,7 @@ namespace Build
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
             FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
-            await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle);
+            await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsExperimentalBundle);
             return targetProjectFilePath;
         }
 

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -44,7 +44,7 @@ namespace Build
             }
 
             var files = Directory.GetFiles(Settings.TemplatesArtifactsDirectory);
-            string experimentalStr = BundleConfiguration.Instance.IsExperimentalBundle ? ".Experimental" : String.Empty;
+            string experimentalStr = BundleConfiguration.Instance.IsExperimentalBundle ? ".Preview" : String.Empty;  // use preview templates as experimental bundle does not have separate templates
             string zipFileName = $"ExtensionBundle{experimentalStr}.v{BundleConfiguration.Instance.ExtensionBundleVersion[0]}.Templates";
 
             foreach (string file in files)

--- a/build/BundleConfiguration.cs
+++ b/build/BundleConfiguration.cs
@@ -31,7 +31,7 @@ namespace Build
         [JsonProperty("templateVersion")]
         public string TemplateVersion { get; private set; }
 
-        [JsonProperty("isPreviewBundle")]
-        public bool IsPreviewBundle { get; private set; }
+        [JsonProperty("isExperimentalBundle")]
+        public bool IsExperimentalBundle { get; private set; }
     }
 }

--- a/build/BundleConfiguration.cs
+++ b/build/BundleConfiguration.cs
@@ -28,9 +28,6 @@ namespace Build
         [JsonProperty("bundleVersion")]
         public string ExtensionBundleVersion { get; private set; }
 
-        [JsonProperty("templateVersion")]
-        public string TemplateVersion { get; private set; }
-
         [JsonProperty("isExperimentalBundle")]
         public bool IsExperimentalBundle { get; private set; }
     }

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -14,17 +14,6 @@ namespace Build
         public static string ExtensionsJsonFilePath => Path.Combine(SourcePath, ExtensionsJsonFileName);
 
         public static string BundleConfigJsonFilePath => Path.Combine(SourcePath, BundleConfigJsonFileName);
-        public static string[] nugetFeed = new[]
-        {
-            "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json",
-            "https://www.nuget.org/api/v2/"
-        };
-
-        public static Dictionary<string, string> nugetSources = new Dictionary<string, string>()
-        {
-            { "azureSdk", "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"},
-            { "nuget", "https://www.nuget.org/api/v2/"}
-        };
 
         public static readonly string StaticContentDirectoryName = "StaticContent";
 

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -49,7 +49,6 @@ namespace Build
 
         public static readonly string BundleConfigJsonFileName = "bundleConfig.json";
 
-        public static string ExtensionBundleVersionRange = "[3.*, 4.0.0)";
         public static readonly string NugetConfigFileName = "NuGet.Config";
 
         public static readonly string RUPackagePath = Path.Combine(RootBinDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package", BundleConfiguration.Instance.ExtensionBundleVersion);

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   - task: UseDotNet@2
     inputs:
       packageType: 'sdk'
-      version: '3.1.x'
+      version: '8.x'
       performMultiLevelLookup: true
   - task: DotNetCoreCLI@2
     displayName: 'Run tests'

--- a/eng/code-mirror.yml
+++ b/eng/code-mirror.yml
@@ -3,6 +3,7 @@ trigger:
     include:
     - main
     - main-preview
+    - main-experimental
     - main-v2
     - main-v3
     - v1.x

--- a/eng/official-build.yml
+++ b/eng/official-build.yml
@@ -3,6 +3,7 @@ trigger:
     include:
     - main
     - main-preview
+    - main-experimental
     - main-v2
     - main-v3
     - release/v4.x
@@ -22,6 +23,7 @@ schedules:
     include:
     - main
     - main-preview
+    - main-experimental
   always: true
 
 # CI only, does not trigger on PRs.

--- a/eng/public-build.yml
+++ b/eng/public-build.yml
@@ -3,6 +3,7 @@ trigger:
     include:
       - main
       - main-preview
+      - main-experimental
       - main-v2
       - main-v3
       - release/v2.x
@@ -15,6 +16,7 @@ pr:
     include:
       - main
       - main-preview
+      - main-experimental
       - main-v2
       - main-v3
       - release/v2.x
@@ -30,6 +32,7 @@ schedules:
       include:
         - main
         - main-preview
+        - main-experimental
     always: true
 
 resources:

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -4,6 +4,5 @@
     <clear />
     <add key="azureSdk" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctions" value="https://pkgs.dev.azure.com/azfunc/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>  
 </configuration>

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -4,5 +4,6 @@
     <clear />
     <add key="azureSdk" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>  
 </configuration>

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -4,6 +4,6 @@
     <clear />
     <add key="azureSdk" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" protocolVersion="3" />
+    <add key="AzureFunctions" value="https://pkgs.dev.azure.com/azfunc/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>  
 </configuration>

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,6 +1,5 @@
 ﻿{
     "bundleId":  "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
     "bundleVersion":  "4.0.0",
-    "templateVersion":  "4.0.3043",
     "isExperimentalBundle":  true
 }

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,6 +1,6 @@
 ﻿{
-    "bundleId":  "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-    "bundleVersion":  "4.29.0",
+    "bundleId":  "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
+    "bundleVersion":  "4.0.0",
     "templateVersion":  "4.0.3043",
-    "isPreviewBundle":  true
+    "isExperimentalBundle":  true
 }

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -260,16 +260,6 @@
     ]
   },
   {
-    "id": "Microsoft.Azure.WebJobs.Extensions.Fabric",
-    "majorVersion": "0",
-    "name": "Startup",
-    "bindings": [
-      "FabricItem",
-      "UdfProperty",
-      "UserDataFunctionContext"
-    ]
-  },
-  {
     "id": " System.Formats.Asn1",
     "Version": "6.0.1",
     "name": "SystemFormatsAsn1",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -284,5 +284,14 @@
       "socketionegotiation",
       "socketio"
     ]
+  },
+  {
+    "id": "Microsoft.Azure.Functions.Extensions.Mcp",
+    "majorVersion": "1",
+    "name": "Mcp",
+    "bindings": [
+      "mcpToolTrigger",
+      "mcpToolProperty"
+    ]
   }
 ]

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -287,7 +287,7 @@
   },
   {
     "id": "Microsoft.Azure.Functions.Extensions.Mcp",
-    "majorVersion": "1",
+    "version": "1.0.0-beta423",
     "name": "Mcp",
     "bindings": [
       "mcpToolTrigger",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -287,8 +287,8 @@
   },
   {
     "id": "Microsoft.Azure.Functions.Extensions.Mcp",
-    "version": "1.0.0-beta423",
-    "name": "Mcp",
+    "majorVersion": "1",
+    "name": "Startup",
     "bindings": [
       "mcpToolTrigger",
       "mcpToolProperty"

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -39,7 +39,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
-    "majorVersion": "5",
+    "majorVersion": "6",
     "name": "EventHubs",
     "bindings": [
       "eventhubtrigger",


### PR DESCRIPTION
- Changes to support experimental bundle
- Mcp extension added 
- unused nuget feed variables removed
- unused templateVersion variable removed
- unused ExtensionBundleVersionRange variable removed
- templates being pulled from preview templates - in future we might need separate experimental templates too
- skip copy templates for local build as download templates is already skipped
- event hub major version bump to 6
- remove fabric extension temporarily due to startup file name conflict, Fabio will update Startup file name in subsequent releases.