### PR TITLE
main-experimental: unpin mysql extension

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -225,7 +225,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.MySql",
-    "version": "1.0.31-preview",
+    "majorVersion": "1",
     "name": "MySqlBinding",
     "bindings": [
       "MySql",


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `extensions.json` file to improve versioning clarity for the MySQL binding.

Versioning update:

* [`src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json`](diffhunk://#diff-ef04bd46da33b5dc5074a2236e1584380e5c32959ad0c3b0b30b2e6213341c45L228-R228): Replaced the specific preview version (`1.0.31-preview`) of the `Microsoft.Azure.WebJobs.Extensions.MySql` extension with a `majorVersion` field set to `1`. This change simplifies version management by allowing any compatible version within the major version range.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main - Already updated
- [ ] main-preview - Already updated
- [x] main-experimental
- [ ] main-v2 - N/A
- [ ] main-v3 - N/A

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->