### PR TITLE
main: downgrade event hub to major version 5

### DIFF
--- a/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -12,17 +12,17 @@
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
-          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.1",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.1",
+          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.2",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.6",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.490",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.512",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
@@ -129,23 +129,28 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.12.1": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.9",
-          "System.Reflection.TypeExtensions": "4.7.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
-          "lib/net8.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.12.1.0",
-            "fileVersion": "5.1200.125.20902"
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.9",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -611,14 +616,14 @@
           }
         }
       },
-      "Microsoft.ApplicationInsights/2.22.0": {
+      "Microsoft.ApplicationInsights/2.23.0": {
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
-            "assemblyVersion": "2.22.0.997",
-            "fileVersion": "2.22.0.997"
+            "assemblyVersion": "2.23.0.29",
+            "fileVersion": "2.23.0.29"
           }
         }
       },
@@ -945,37 +950,37 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.3.0.0",
-            "fileVersion": "0.3.0.14742"
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Storage.Blobs": "12.23.0",
           "Azure.Storage.Queues": "12.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.1.0.0",
-            "fileVersion": "2.1.0.14742"
+            "assemblyVersion": "2.2.0.0",
+            "fileVersion": "2.2.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.1.0": {
+      "Microsoft.Azure.DurableTask.Core/3.2.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
@@ -986,8 +991,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.1.0.0",
-            "fileVersion": "3.1.0.14742"
+            "assemblyVersion": "3.2.0.0",
+            "fileVersion": "3.2.0.25381"
           }
         }
       },
@@ -995,10 +1000,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
         },
@@ -1011,9 +1016,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
@@ -1188,14 +1193,14 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.3.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.1.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.4.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.2.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1205,7 +1210,7 @@
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.1.0.0"
+            "fileVersion": "3.2.0.0"
           }
         }
       },
@@ -1223,17 +1228,17 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+      "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
-            "assemblyVersion": "6.5.1.0",
-            "fileVersion": "6.500.125.20902"
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
+            "assemblyVersion": "5.5.0.0",
+            "fileVersion": "5.500.23.41402"
           }
         }
       },
@@ -1253,7 +1258,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
@@ -1265,15 +1270,15 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.1.1.0",
-            "fileVersion": "4.1.1.0"
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.1.2.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -1379,22 +1384,23 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.1"
+          "System.Runtime.Caching": "8.0.1",
+          "System.Security.AccessControl": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.490.0",
-            "fileVersion": "3.1.490.0"
+            "assemblyVersion": "3.1.512.0",
+            "fileVersion": "3.1.512.0"
           }
         }
       },
@@ -1638,7 +1644,7 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
@@ -1654,7 +1660,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
@@ -2886,6 +2892,7 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Security.AccessControl/6.0.1": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -3244,12 +3251,12 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.12.1": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EGwiegZ3lB6csXQ1MLqOTVAJhEEhXejaPcCla/oB1L8a1s4BaCxPjUAdFeAr0O6cI7bjzVbh9JHRik8R264Jkw==",
-      "path": "azure.messaging.eventhubs/5.12.1",
-      "hashPath": "azure.messaging.eventhubs.5.12.1.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
     "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
@@ -3461,12 +3468,12 @@
       "path": "messagepack.annotations/2.5.192",
       "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
-    "Microsoft.ApplicationInsights/2.22.0": {
+    "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-      "path": "microsoft.applicationinsights/2.22.0",
-      "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+      "sha512": "sha512-nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
+      "path": "microsoft.applicationinsights/2.23.0",
+      "hashPath": "microsoft.applicationinsights.2.23.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -3678,26 +3685,26 @@
       "path": "microsoft.azure.cosmos/3.44.1",
       "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-foj3cSDQKDjlhQ5XRQ59r1ItUl95qG1nIz+cGF43ioiaMfo0NaRdOPxaAhR3Lv2y0FAfyV8p0lI7WL65l+k8NQ==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.3.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.3.0.nupkg.sha512"
+      "sha512": "sha512-2U6I8i/tL7Asi6CqvANmbNuG2dDSciyr0NThY+vMMdBLELlOk0UDZaxWTDjCX79QzTfIzPCj6jZ29lwWiyrKqA==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.4.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.4.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMlqii/PjdHsL+h4RcFMEJUEMfDeH4UAFl2J35N1IzldcRa39MZm/6mVe4OcpY0nMC0Mx1/4w44AdCzi0ZGeaA==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.1.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.1.0.nupkg.sha512"
+      "sha512": "sha512-ta8sCuIbUY6klEqmGOd59fnEauvbMGxSUeR6LOP42axqD+48UYTZmFPN7H+vkLlJyeplk1IQPcep3olXOyoIwg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.2.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.1.0": {
+    "Microsoft.Azure.DurableTask.Core/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-y5a/Jhr2wVAubd8yt0JAKevUliDXDXUdPKa50DYDuqd4WVm/SLU0fsVMMYAywKXkPasjZX3s5okje7tw94p4YQ==",
-      "path": "microsoft.azure.durabletask.core/3.1.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.1.0.nupkg.sha512"
+      "sha512": "sha512-lssn7ssuD/rbYWkDnt91XPWFddGTYnXZe+SSsbugqBF7VAhpJUuwDYGknRT96+oq0THOkHHdgN+eAp5pPLAbRw==",
+      "path": "microsoft.azure.durabletask.core/3.2.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
@@ -3797,12 +3804,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sEiF5+RcYf6DkL8eL50IpKNUejySuwqnH29hXb8k02HZ5UVNWoS5AWPo0usDwD0f6nuJtOOum3RB5DLZGkRPlA==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.1.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.1.0.nupkg.sha512"
+      "sha512": "sha512-a+fTO5NDTGCuvCQ8oVe/9lRsnt2fa9KhIOtV9ylRHhkXTEIulJxUb6uHs1E/0gwLxyXNNhZOkJMdEjVJ/FrnIw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.2.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3818,12 +3825,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
       "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+    "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWA5ur5F/VyjyXpw19uJSKaU/W9w3PitAjK3svAPf16XxxxaDc+Qr2iF1U/ydEQ/6SOA86dh4gEC7FGtk3DGFQ==",
-      "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.1.nupkg.sha512"
+      "sha512": "sha512-Ur6FCILAUd9HJliA4JdOkom5D0bOtKi1pOTwDDI0UZY9s0w1Bf8bG4Q09f/gDSJzsCVyfk5ij49CH2Wp6is8Uw==",
+      "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -3832,12 +3839,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xAKkD8RcIIn9J0UMW+wSORQM0pSSUBiYvzVpKIsR2RtMhRaxp3alXqbNgZiGAnLu82Vn93SOXs8G39aONRsjxQ==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.1.nupkg.sha512"
+      "sha512": "sha512-AKYb3io+Qp/ymLupa/NjdYk0cqYsXVESF428kwUCGAafCxUqCcyqyx5WLUX8S1Y/Q15pjA5nczlH5w/QcCvEYQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.2",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.2.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
       "type": "package",
@@ -3888,12 +3895,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mXLWyllX60xY2yolOql9ur41M/szUBOC16+cAY/33xceqeyJe0HCcb3OWpmViaM/G38Pcoos56K6/vQw3K80vA==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.490",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.490.nupkg.sha512"
+      "sha512": "sha512-eJkxpLb6jNbbw2I/WxY5VLsdA0IeSGxzasYE1WZWm9tJ4kd1rGeKV6WuXxxgji4umz2kkUtcnrPj0wU7F98OVw==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.512",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.512.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
@@ -4986,6 +4993,13 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
+    },
+    "System.Security.AccessControl/6.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IQ4NXP/B3Ayzvw0rDQzVTYsCKyy0Jp9KI6aYcK7UnGVlR9+Awz++TIPCQtPYfLJfOpm8ajowMR09V7quD3sEHw==",
+      "path": "system.security.accesscontrol/6.0.1",
+      "hashPath": "system.security.accesscontrol.6.0.1.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
@@ -12,17 +12,17 @@
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
-          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.1",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.1",
+          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.2",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.6",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.490",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.512",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
@@ -129,23 +129,28 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.12.1": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.9",
-          "System.Reflection.TypeExtensions": "4.7.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
-          "lib/net8.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.12.1.0",
-            "fileVersion": "5.1200.125.20902"
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.9",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -611,14 +616,14 @@
           }
         }
       },
-      "Microsoft.ApplicationInsights/2.22.0": {
+      "Microsoft.ApplicationInsights/2.23.0": {
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
-            "assemblyVersion": "2.22.0.997",
-            "fileVersion": "2.22.0.997"
+            "assemblyVersion": "2.23.0.29",
+            "fileVersion": "2.23.0.29"
           }
         }
       },
@@ -945,37 +950,37 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.3.0.0",
-            "fileVersion": "0.3.0.14742"
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Storage.Blobs": "12.23.0",
           "Azure.Storage.Queues": "12.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.1.0.0",
-            "fileVersion": "2.1.0.14742"
+            "assemblyVersion": "2.2.0.0",
+            "fileVersion": "2.2.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.1.0": {
+      "Microsoft.Azure.DurableTask.Core/3.2.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
@@ -986,8 +991,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.1.0.0",
-            "fileVersion": "3.1.0.14742"
+            "assemblyVersion": "3.2.0.0",
+            "fileVersion": "3.2.0.25381"
           }
         }
       },
@@ -995,10 +1000,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
         },
@@ -1011,9 +1016,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
@@ -1188,14 +1193,14 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.3.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.1.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.4.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.2.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1205,7 +1210,7 @@
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.1.0.0"
+            "fileVersion": "3.2.0.0"
           }
         }
       },
@@ -1223,17 +1228,17 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+      "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
-            "assemblyVersion": "6.5.1.0",
-            "fileVersion": "6.500.125.20902"
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
+            "assemblyVersion": "5.5.0.0",
+            "fileVersion": "5.500.23.41402"
           }
         }
       },
@@ -1253,7 +1258,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
@@ -1265,15 +1270,15 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.1.1.0",
-            "fileVersion": "4.1.1.0"
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.1.2.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -1379,22 +1384,23 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.1"
+          "System.Runtime.Caching": "8.0.1",
+          "System.Security.AccessControl": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.490.0",
-            "fileVersion": "3.1.490.0"
+            "assemblyVersion": "3.1.512.0",
+            "fileVersion": "3.1.512.0"
           }
         }
       },
@@ -1638,7 +1644,7 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
@@ -1654,7 +1660,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
@@ -2886,6 +2892,7 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Security.AccessControl/6.0.1": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -3244,12 +3251,12 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.12.1": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EGwiegZ3lB6csXQ1MLqOTVAJhEEhXejaPcCla/oB1L8a1s4BaCxPjUAdFeAr0O6cI7bjzVbh9JHRik8R264Jkw==",
-      "path": "azure.messaging.eventhubs/5.12.1",
-      "hashPath": "azure.messaging.eventhubs.5.12.1.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
     "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
@@ -3461,12 +3468,12 @@
       "path": "messagepack.annotations/2.5.192",
       "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
-    "Microsoft.ApplicationInsights/2.22.0": {
+    "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-      "path": "microsoft.applicationinsights/2.22.0",
-      "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+      "sha512": "sha512-nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
+      "path": "microsoft.applicationinsights/2.23.0",
+      "hashPath": "microsoft.applicationinsights.2.23.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -3678,26 +3685,26 @@
       "path": "microsoft.azure.cosmos/3.44.1",
       "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-foj3cSDQKDjlhQ5XRQ59r1ItUl95qG1nIz+cGF43ioiaMfo0NaRdOPxaAhR3Lv2y0FAfyV8p0lI7WL65l+k8NQ==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.3.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.3.0.nupkg.sha512"
+      "sha512": "sha512-2U6I8i/tL7Asi6CqvANmbNuG2dDSciyr0NThY+vMMdBLELlOk0UDZaxWTDjCX79QzTfIzPCj6jZ29lwWiyrKqA==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.4.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.4.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMlqii/PjdHsL+h4RcFMEJUEMfDeH4UAFl2J35N1IzldcRa39MZm/6mVe4OcpY0nMC0Mx1/4w44AdCzi0ZGeaA==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.1.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.1.0.nupkg.sha512"
+      "sha512": "sha512-ta8sCuIbUY6klEqmGOd59fnEauvbMGxSUeR6LOP42axqD+48UYTZmFPN7H+vkLlJyeplk1IQPcep3olXOyoIwg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.2.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.1.0": {
+    "Microsoft.Azure.DurableTask.Core/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-y5a/Jhr2wVAubd8yt0JAKevUliDXDXUdPKa50DYDuqd4WVm/SLU0fsVMMYAywKXkPasjZX3s5okje7tw94p4YQ==",
-      "path": "microsoft.azure.durabletask.core/3.1.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.1.0.nupkg.sha512"
+      "sha512": "sha512-lssn7ssuD/rbYWkDnt91XPWFddGTYnXZe+SSsbugqBF7VAhpJUuwDYGknRT96+oq0THOkHHdgN+eAp5pPLAbRw==",
+      "path": "microsoft.azure.durabletask.core/3.2.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
@@ -3797,12 +3804,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sEiF5+RcYf6DkL8eL50IpKNUejySuwqnH29hXb8k02HZ5UVNWoS5AWPo0usDwD0f6nuJtOOum3RB5DLZGkRPlA==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.1.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.1.0.nupkg.sha512"
+      "sha512": "sha512-a+fTO5NDTGCuvCQ8oVe/9lRsnt2fa9KhIOtV9ylRHhkXTEIulJxUb6uHs1E/0gwLxyXNNhZOkJMdEjVJ/FrnIw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.2.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3818,12 +3825,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
       "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+    "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWA5ur5F/VyjyXpw19uJSKaU/W9w3PitAjK3svAPf16XxxxaDc+Qr2iF1U/ydEQ/6SOA86dh4gEC7FGtk3DGFQ==",
-      "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.1.nupkg.sha512"
+      "sha512": "sha512-Ur6FCILAUd9HJliA4JdOkom5D0bOtKi1pOTwDDI0UZY9s0w1Bf8bG4Q09f/gDSJzsCVyfk5ij49CH2Wp6is8Uw==",
+      "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -3832,12 +3839,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xAKkD8RcIIn9J0UMW+wSORQM0pSSUBiYvzVpKIsR2RtMhRaxp3alXqbNgZiGAnLu82Vn93SOXs8G39aONRsjxQ==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.1.nupkg.sha512"
+      "sha512": "sha512-AKYb3io+Qp/ymLupa/NjdYk0cqYsXVESF428kwUCGAafCxUqCcyqyx5WLUX8S1Y/Q15pjA5nczlH5w/QcCvEYQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.2",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.2.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
       "type": "package",
@@ -3888,12 +3895,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mXLWyllX60xY2yolOql9ur41M/szUBOC16+cAY/33xceqeyJe0HCcb3OWpmViaM/G38Pcoos56K6/vQw3K80vA==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.490",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.490.nupkg.sha512"
+      "sha512": "sha512-eJkxpLb6jNbbw2I/WxY5VLsdA0IeSGxzasYE1WZWm9tJ4kd1rGeKV6WuXxxgji4umz2kkUtcnrPj0wU7F98OVw==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.512",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.512.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
@@ -4986,6 +4993,13 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
+    },
+    "System.Security.AccessControl/6.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IQ4NXP/B3Ayzvw0rDQzVTYsCKyy0Jp9KI6aYcK7UnGVlR9+Awz++TIPCQtPYfLJfOpm8ajowMR09V7quD3sEHw==",
+      "path": "system.security.accesscontrol/6.0.1",
+      "hashPath": "system.security.accesscontrol.6.0.1.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -13,17 +13,17 @@
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
-          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.1",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.1",
+          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.2",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.6",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.490",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.512",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
@@ -130,23 +130,28 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.12.1": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.9",
-          "System.Reflection.TypeExtensions": "4.7.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
-          "lib/net8.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.12.1.0",
-            "fileVersion": "5.1200.125.20902"
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.9",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -496,14 +501,14 @@
           }
         }
       },
-      "Microsoft.ApplicationInsights/2.22.0": {
+      "Microsoft.ApplicationInsights/2.23.0": {
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
-            "assemblyVersion": "2.22.0.997",
-            "fileVersion": "2.22.0.997"
+            "assemblyVersion": "2.23.0.29",
+            "fileVersion": "2.23.0.29"
           }
         }
       },
@@ -820,37 +825,37 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.3.0.0",
-            "fileVersion": "0.3.0.14742"
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Storage.Blobs": "12.23.0",
           "Azure.Storage.Queues": "12.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.1.0.0",
-            "fileVersion": "2.1.0.14742"
+            "assemblyVersion": "2.2.0.0",
+            "fileVersion": "2.2.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.1.0": {
+      "Microsoft.Azure.DurableTask.Core/3.2.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
@@ -861,8 +866,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.1.0.0",
-            "fileVersion": "3.1.0.14742"
+            "assemblyVersion": "3.2.0.0",
+            "fileVersion": "3.2.0.25381"
           }
         }
       },
@@ -870,10 +875,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
         },
@@ -886,9 +891,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
@@ -1063,14 +1068,14 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.3.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.1.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.4.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.2.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1080,7 +1085,7 @@
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.1.0.0"
+            "fileVersion": "3.2.0.0"
           }
         }
       },
@@ -1098,17 +1103,17 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+      "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
-            "assemblyVersion": "6.5.1.0",
-            "fileVersion": "6.500.125.20902"
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
+            "assemblyVersion": "5.5.0.0",
+            "fileVersion": "5.500.23.41402"
           }
         }
       },
@@ -1128,7 +1133,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
@@ -1140,15 +1145,15 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.1.1.0",
-            "fileVersion": "4.1.1.0"
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.1.2.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -1254,22 +1259,23 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.1"
+          "System.Runtime.Caching": "8.0.1",
+          "System.Security.AccessControl": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.490.0",
-            "fileVersion": "3.1.490.0"
+            "assemblyVersion": "3.1.512.0",
+            "fileVersion": "3.1.512.0"
           }
         }
       },
@@ -1482,7 +1488,7 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
@@ -1498,7 +1504,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
@@ -2829,6 +2835,7 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Security.AccessControl/6.0.1": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -3191,12 +3198,12 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.12.1": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EGwiegZ3lB6csXQ1MLqOTVAJhEEhXejaPcCla/oB1L8a1s4BaCxPjUAdFeAr0O6cI7bjzVbh9JHRik8R264Jkw==",
-      "path": "azure.messaging.eventhubs/5.12.1",
-      "hashPath": "azure.messaging.eventhubs.5.12.1.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
     "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
@@ -3408,12 +3415,12 @@
       "path": "messagepack.annotations/2.5.192",
       "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
-    "Microsoft.ApplicationInsights/2.22.0": {
+    "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-      "path": "microsoft.applicationinsights/2.22.0",
-      "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+      "sha512": "sha512-nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
+      "path": "microsoft.applicationinsights/2.23.0",
+      "hashPath": "microsoft.applicationinsights.2.23.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -3625,26 +3632,26 @@
       "path": "microsoft.azure.cosmos/3.44.1",
       "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-foj3cSDQKDjlhQ5XRQ59r1ItUl95qG1nIz+cGF43ioiaMfo0NaRdOPxaAhR3Lv2y0FAfyV8p0lI7WL65l+k8NQ==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.3.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.3.0.nupkg.sha512"
+      "sha512": "sha512-2U6I8i/tL7Asi6CqvANmbNuG2dDSciyr0NThY+vMMdBLELlOk0UDZaxWTDjCX79QzTfIzPCj6jZ29lwWiyrKqA==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.4.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.4.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMlqii/PjdHsL+h4RcFMEJUEMfDeH4UAFl2J35N1IzldcRa39MZm/6mVe4OcpY0nMC0Mx1/4w44AdCzi0ZGeaA==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.1.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.1.0.nupkg.sha512"
+      "sha512": "sha512-ta8sCuIbUY6klEqmGOd59fnEauvbMGxSUeR6LOP42axqD+48UYTZmFPN7H+vkLlJyeplk1IQPcep3olXOyoIwg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.2.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.1.0": {
+    "Microsoft.Azure.DurableTask.Core/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-y5a/Jhr2wVAubd8yt0JAKevUliDXDXUdPKa50DYDuqd4WVm/SLU0fsVMMYAywKXkPasjZX3s5okje7tw94p4YQ==",
-      "path": "microsoft.azure.durabletask.core/3.1.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.1.0.nupkg.sha512"
+      "sha512": "sha512-lssn7ssuD/rbYWkDnt91XPWFddGTYnXZe+SSsbugqBF7VAhpJUuwDYGknRT96+oq0THOkHHdgN+eAp5pPLAbRw==",
+      "path": "microsoft.azure.durabletask.core/3.2.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
@@ -3744,12 +3751,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sEiF5+RcYf6DkL8eL50IpKNUejySuwqnH29hXb8k02HZ5UVNWoS5AWPo0usDwD0f6nuJtOOum3RB5DLZGkRPlA==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.1.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.1.0.nupkg.sha512"
+      "sha512": "sha512-a+fTO5NDTGCuvCQ8oVe/9lRsnt2fa9KhIOtV9ylRHhkXTEIulJxUb6uHs1E/0gwLxyXNNhZOkJMdEjVJ/FrnIw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.2.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3765,12 +3772,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
       "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+    "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWA5ur5F/VyjyXpw19uJSKaU/W9w3PitAjK3svAPf16XxxxaDc+Qr2iF1U/ydEQ/6SOA86dh4gEC7FGtk3DGFQ==",
-      "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.1.nupkg.sha512"
+      "sha512": "sha512-Ur6FCILAUd9HJliA4JdOkom5D0bOtKi1pOTwDDI0UZY9s0w1Bf8bG4Q09f/gDSJzsCVyfk5ij49CH2Wp6is8Uw==",
+      "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -3779,12 +3786,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xAKkD8RcIIn9J0UMW+wSORQM0pSSUBiYvzVpKIsR2RtMhRaxp3alXqbNgZiGAnLu82Vn93SOXs8G39aONRsjxQ==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.1.nupkg.sha512"
+      "sha512": "sha512-AKYb3io+Qp/ymLupa/NjdYk0cqYsXVESF428kwUCGAafCxUqCcyqyx5WLUX8S1Y/Q15pjA5nczlH5w/QcCvEYQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.2",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.2.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
       "type": "package",
@@ -3835,12 +3842,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mXLWyllX60xY2yolOql9ur41M/szUBOC16+cAY/33xceqeyJe0HCcb3OWpmViaM/G38Pcoos56K6/vQw3K80vA==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.490",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.490.nupkg.sha512"
+      "sha512": "sha512-eJkxpLb6jNbbw2I/WxY5VLsdA0IeSGxzasYE1WZWm9tJ4kd1rGeKV6WuXxxgji4umz2kkUtcnrPj0wU7F98OVw==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.512",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.512.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
@@ -5101,6 +5108,13 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
+    },
+    "System.Security.AccessControl/6.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IQ4NXP/B3Ayzvw0rDQzVTYsCKyy0Jp9KI6aYcK7UnGVlR9+Awz++TIPCQtPYfLJfOpm8ajowMR09V7quD3sEHw==",
+      "path": "system.security.accesscontrol/6.0.1",
+      "hashPath": "system.security.accesscontrol.6.0.1.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",

--- a/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -13,17 +13,17 @@
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.9.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.4.4",
-          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.1",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.1",
+          "Microsoft.Azure.WebJobs.Extensions.EventHubs": "5.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.1.2",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
           "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.0",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.16.6",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.490",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.512",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.4",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.4",
@@ -130,23 +130,28 @@
           }
         }
       },
-      "Azure.Messaging.EventHubs/5.12.1": {
+      "Azure.Messaging.EventHubs/5.11.5": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.6.9",
-          "System.Reflection.TypeExtensions": "4.7.0"
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
+          "System.Memory.Data": "6.0.1",
+          "System.Reflection.TypeExtensions": "4.7.0",
+          "System.Threading.Channels": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         },
         "runtime": {
-          "lib/net8.0/Azure.Messaging.EventHubs.dll": {
-            "assemblyVersion": "5.12.1.0",
-            "fileVersion": "5.1200.125.20902"
+          "lib/netstandard2.0/Azure.Messaging.EventHubs.dll": {
+            "assemblyVersion": "5.11.5.0",
+            "fileVersion": "5.1100.524.38102"
           }
         }
       },
       "Azure.Messaging.EventHubs.Processor/5.11.5": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.Amqp": "2.6.9",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -502,14 +507,14 @@
           }
         }
       },
-      "Microsoft.ApplicationInsights/2.22.0": {
+      "Microsoft.ApplicationInsights/2.23.0": {
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "8.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.ApplicationInsights.dll": {
-            "assemblyVersion": "2.22.0.997",
-            "fileVersion": "2.22.0.997"
+            "assemblyVersion": "2.23.0.29",
+            "fileVersion": "2.23.0.29"
           }
         }
       },
@@ -809,37 +814,37 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
         "dependencies": {
-          "Microsoft.ApplicationInsights": "2.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.3.0.0",
-            "fileVersion": "0.3.0.14742"
+            "assemblyVersion": "0.4.0.0",
+            "fileVersion": "0.4.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
           "Azure.Storage.Blobs": "12.23.0",
           "Azure.Storage.Queues": "12.22.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.1.0.0",
-            "fileVersion": "2.1.0.14742"
+            "assemblyVersion": "2.2.0.0",
+            "fileVersion": "2.2.0.25381"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.1.0": {
+      "Microsoft.Azure.DurableTask.Core/3.2.0": {
         "dependencies": {
           "Castle.Core": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "7.0.0",
@@ -850,8 +855,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.1.0.0",
-            "fileVersion": "3.1.0.14742"
+            "assemblyVersion": "3.2.0.0",
+            "fileVersion": "3.2.0.25381"
           }
         }
       },
@@ -859,10 +864,10 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Data.Tables": "12.9.1",
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3"
         },
@@ -875,9 +880,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.0": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0"
         },
         "runtime": {
           "lib/net6.0/DurableTask.Netherite.AzureFunctions.dll": {
@@ -1052,14 +1057,14 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
           "Grpc.Core": "2.46.6",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.3.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.1.0",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.4.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.2.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1069,7 +1074,7 @@
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.1.0.0"
+            "fileVersion": "3.2.0.0"
           }
         }
       },
@@ -1087,17 +1092,17 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+      "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
         "dependencies": {
-          "Azure.Messaging.EventHubs": "5.12.1",
+          "Azure.Messaging.EventHubs": "5.11.5",
           "Azure.Storage.Blobs": "12.23.0",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Extensions.Azure": "1.10.0"
         },
         "runtime": {
-          "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
-            "assemblyVersion": "6.5.1.0",
-            "fileVersion": "6.500.125.20902"
+          "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.EventHubs.dll": {
+            "assemblyVersion": "5.5.0.0",
+            "fileVersion": "5.500.23.41402"
           }
         }
       },
@@ -1117,7 +1122,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
@@ -1129,15 +1134,15 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.1.1.0",
-            "fileVersion": "4.1.1.0"
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.1.2.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
         "dependencies": {
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
@@ -1243,22 +1248,23 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.ApplicationInsights": "2.22.0",
+          "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.2.2",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Runtime.Caching": "8.0.1"
+          "System.Runtime.Caching": "8.0.1",
+          "System.Security.AccessControl": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.490.0",
-            "fileVersion": "3.1.490.0"
+            "assemblyVersion": "3.1.512.0",
+            "fileVersion": "3.1.512.0"
           }
         }
       },
@@ -1471,7 +1477,7 @@
         "dependencies": {
           "Azure.Core": "1.44.1",
           "Azure.Identity": "1.13.1",
-          "Microsoft.Azure.DurableTask.Core": "3.1.0",
+          "Microsoft.Azure.DurableTask.Core": "3.2.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "6.35.0",
           "SemanticVersion": "2.1.0",
@@ -1487,7 +1493,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.5.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.1.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.2.0",
           "Microsoft.DurableTask.SqlServer": "1.5.1"
         },
         "runtime": {
@@ -2801,6 +2807,7 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Security.AccessControl/6.0.1": {},
       "System.Security.Claims/4.3.0": {
         "dependencies": {
           "System.Collections": "4.3.0",
@@ -3163,12 +3170,12 @@
       "path": "azure.messaging.eventgrid/4.21.0",
       "hashPath": "azure.messaging.eventgrid.4.21.0.nupkg.sha512"
     },
-    "Azure.Messaging.EventHubs/5.12.1": {
+    "Azure.Messaging.EventHubs/5.11.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EGwiegZ3lB6csXQ1MLqOTVAJhEEhXejaPcCla/oB1L8a1s4BaCxPjUAdFeAr0O6cI7bjzVbh9JHRik8R264Jkw==",
-      "path": "azure.messaging.eventhubs/5.12.1",
-      "hashPath": "azure.messaging.eventhubs.5.12.1.nupkg.sha512"
+      "sha512": "sha512-y/jccDQmdBYMSyovJj6rgCVefKEpsnmepISKfD6FoR3oUbGdAwaHyvKcHnMpZQRvYcF7F2EFq6v9MrYQGtfLIw==",
+      "path": "azure.messaging.eventhubs/5.11.5",
+      "hashPath": "azure.messaging.eventhubs.5.11.5.nupkg.sha512"
     },
     "Azure.Messaging.EventHubs.Processor/5.11.5": {
       "type": "package",
@@ -3380,12 +3387,12 @@
       "path": "messagepack.annotations/2.5.192",
       "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
     },
-    "Microsoft.ApplicationInsights/2.22.0": {
+    "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3AOM9bZtku7RQwHyMEY3tQMrHIgjcfRDa6YQpd/QG2LDGvMydSlL9Di+8LLMt7J2RDdfJ7/2jdYv6yHcMJAnNw==",
-      "path": "microsoft.applicationinsights/2.22.0",
-      "hashPath": "microsoft.applicationinsights.2.22.0.nupkg.sha512"
+      "sha512": "sha512-nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
+      "path": "microsoft.applicationinsights/2.23.0",
+      "hashPath": "microsoft.applicationinsights.2.23.0.nupkg.sha512"
     },
     "Microsoft.AspNet.WebApi.Client/5.2.9": {
       "type": "package",
@@ -3597,26 +3604,26 @@
       "path": "microsoft.azure.cosmos/3.44.1",
       "hashPath": "microsoft.azure.cosmos.3.44.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.3.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-foj3cSDQKDjlhQ5XRQ59r1ItUl95qG1nIz+cGF43ioiaMfo0NaRdOPxaAhR3Lv2y0FAfyV8p0lI7WL65l+k8NQ==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.3.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.3.0.nupkg.sha512"
+      "sha512": "sha512-2U6I8i/tL7Asi6CqvANmbNuG2dDSciyr0NThY+vMMdBLELlOk0UDZaxWTDjCX79QzTfIzPCj6jZ29lwWiyrKqA==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.4.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.4.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.1.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMlqii/PjdHsL+h4RcFMEJUEMfDeH4UAFl2J35N1IzldcRa39MZm/6mVe4OcpY0nMC0Mx1/4w44AdCzi0ZGeaA==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.1.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.1.0.nupkg.sha512"
+      "sha512": "sha512-ta8sCuIbUY6klEqmGOd59fnEauvbMGxSUeR6LOP42axqD+48UYTZmFPN7H+vkLlJyeplk1IQPcep3olXOyoIwg==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.2.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.1.0": {
+    "Microsoft.Azure.DurableTask.Core/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-y5a/Jhr2wVAubd8yt0JAKevUliDXDXUdPKa50DYDuqd4WVm/SLU0fsVMMYAywKXkPasjZX3s5okje7tw94p4YQ==",
-      "path": "microsoft.azure.durabletask.core/3.1.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.1.0.nupkg.sha512"
+      "sha512": "sha512-lssn7ssuD/rbYWkDnt91XPWFddGTYnXZe+SSsbugqBF7VAhpJUuwDYGknRT96+oq0THOkHHdgN+eAp5pPLAbRw==",
+      "path": "microsoft.azure.durabletask.core/3.2.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.0": {
       "type": "package",
@@ -3716,12 +3723,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.1.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sEiF5+RcYf6DkL8eL50IpKNUejySuwqnH29hXb8k02HZ5UVNWoS5AWPo0usDwD0f6nuJtOOum3RB5DLZGkRPlA==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.1.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.1.0.nupkg.sha512"
+      "sha512": "sha512-a+fTO5NDTGCuvCQ8oVe/9lRsnt2fa9KhIOtV9ylRHhkXTEIulJxUb6uHs1E/0gwLxyXNNhZOkJMdEjVJ/FrnIw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.2.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.2.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -3737,12 +3744,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventgrid/3.4.4",
       "hashPath": "microsoft.azure.webjobs.extensions.eventgrid.3.4.4.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.EventHubs/6.5.1": {
+    "Microsoft.Azure.WebJobs.Extensions.EventHubs/5.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWA5ur5F/VyjyXpw19uJSKaU/W9w3PitAjK3svAPf16XxxxaDc+Qr2iF1U/ydEQ/6SOA86dh4gEC7FGtk3DGFQ==",
-      "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.1.nupkg.sha512"
+      "sha512": "sha512-Ur6FCILAUd9HJliA4JdOkom5D0bOtKi1pOTwDDI0UZY9s0w1Bf8bG4Q09f/gDSJzsCVyfk5ij49CH2Wp6is8Uw==",
+      "path": "microsoft.azure.webjobs.extensions.eventhubs/5.5.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.5.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -3751,12 +3758,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.1": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.1.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-xAKkD8RcIIn9J0UMW+wSORQM0pSSUBiYvzVpKIsR2RtMhRaxp3alXqbNgZiGAnLu82Vn93SOXs8G39aONRsjxQ==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.1.nupkg.sha512"
+      "sha512": "sha512-AKYb3io+Qp/ymLupa/NjdYk0cqYsXVESF428kwUCGAafCxUqCcyqyx5WLUX8S1Y/Q15pjA5nczlH5w/QcCvEYQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.1.2",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.1.2.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.MySql/1.0.129": {
       "type": "package",
@@ -3807,12 +3814,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.490": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.512": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mXLWyllX60xY2yolOql9ur41M/szUBOC16+cAY/33xceqeyJe0HCcb3OWpmViaM/G38Pcoos56K6/vQw3K80vA==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.490",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.490.nupkg.sha512"
+      "sha512": "sha512-eJkxpLb6jNbbw2I/WxY5VLsdA0IeSGxzasYE1WZWm9tJ4kd1rGeKV6WuXxxgji4umz2kkUtcnrPj0wU7F98OVw==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.512",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.512.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.4": {
       "type": "package",
@@ -5073,6 +5080,13 @@
       "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
       "path": "system.runtime.numerics/4.3.0",
       "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
+    },
+    "System.Security.AccessControl/6.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IQ4NXP/B3Ayzvw0rDQzVTYsCKyy0Jp9KI6aYcK7UnGVlR9+Awz++TIPCQtPYfLJfOpm8ajowMR09V7quD3sEHw==",
+      "path": "system.security.accesscontrol/6.0.1",
+      "hashPath": "system.security.accesscontrol.6.0.1.nupkg.sha512"
     },
     "System.Security.Claims/4.3.0": {
       "type": "package",

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -47,7 +47,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.EventHubs",
-    "majorVersion": "6",
+    "majorVersion": "5",
     "name": "EventHubs",
     "bindings": [
       "eventhubtrigger",


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `extensions.json` file. The change downgrades the `Microsoft.Azure.WebJobs.Extensions.EventHubs` extension from major version 6 to major version 5 to align with compatibility requirements.

Updated test data for 
Changed:
    - Microsoft.Azure.WebJobs.Extensions.EventHubs.dll: 6.5.1.0/6.500.125.20902 -> 5.5.0.0/5.500.23.41402

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves Icm issue - failed to unmarshal the SystemPropertiesArray field in the request metadata: json: cannot unmarshal string into Go struct field EventHubEventSystemProperty.Offset of type int64.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [x] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->