### PR TITLE
main: use dev branch instead of release/main for template artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Extension bundles provide a way for non-.NET function apps to reference and use 
 
 ## Build Requirements
 
-- [Dotnet Core SDK 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
 ## Local Build and Packaging
 
@@ -30,7 +30,7 @@ Before building locally, you need to obtain the latest template artifacts and pl
 
 Required template files (example versions):
 
-```
+```text
 ExtensionBundle.Preview.v3.Templates.3.0.5130.zip
 ExtensionBundle.Preview.v4.Templates.4.0.5130.zip
 ExtensionBundle.v1.Templates.1.0.5130.zip
@@ -68,7 +68,6 @@ dotnet run skip:GenerateVulnerabilityReport,PackageNetCoreV3BundlesWindows,Creat
 ```
 
 **Note:** Replace `<ExtensionBundleRepoPath>` with the actual path to your extension bundle repository.
-
 
 ## Add extension
 

--- a/build/BundleConfiguration.cs
+++ b/build/BundleConfiguration.cs
@@ -28,9 +28,6 @@ namespace Build
         [JsonProperty("bundleVersion")]
         public string ExtensionBundleVersion { get; private set; }
 
-        [JsonProperty("templateVersion")]
-        public string TemplateVersion { get; private set; }
-
         [JsonProperty("isPreviewBundle")]
         public bool IsPreviewBundle { get; private set; }
     }

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -14,17 +14,6 @@ namespace Build
         public static string ExtensionsJsonFilePath => Path.Combine(SourcePath, ExtensionsJsonFileName);
 
         public static string BundleConfigJsonFilePath => Path.Combine(SourcePath, BundleConfigJsonFileName);
-        public static string[] nugetFeed = new[]
-        {
-            "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json",
-            "https://www.nuget.org/api/v2/"
-        };
-
-        public static Dictionary<string, string> nugetSources = new Dictionary<string, string>()
-        {
-            { "azureSdk", "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"},
-            { "nuget", "https://www.nuget.org/api/v2/"}
-        };
 
         public static readonly string StaticContentDirectoryName = "StaticContent";
 
@@ -60,7 +49,6 @@ namespace Build
 
         public static readonly string BundleConfigJsonFileName = "bundleConfig.json";
 
-        public static string ExtensionBundleVersionRange = "[3.*, 4.0.0)";
         public static readonly string NugetConfigFileName = "NuGet.Config";
 
         public static readonly string RUPackagePath = Path.Combine(RootBinDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package", BundleConfiguration.Instance.ExtensionBundleVersion);

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -22,7 +22,7 @@ jobs:
       project: '3f99e810-c336-441f-8892-84983093ad7f'
       pipeline: '963'
       buildVersionToDownload: 'latestFromBranch'
-      branchName: 'refs/heads/release/main'
+      branchName: 'refs/heads/dev'
       downloadType: 'single'
       artifactName: 'drop'
       downloadPath: '$(Build.Repository.LocalPath)\templatesArtifacts'

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,6 +1,5 @@
 ﻿{
     "bundleId":  "Microsoft.Azure.Functions.ExtensionBundle",
     "bundleVersion":  "4.25.0",
-    "templateVersion":  "4.0.3043",
     "isPreviewBundle":  false
 }


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to documentation, configuration files, and code cleanup related to Azure Functions Extension Bundles. The most important changes involve simplifying configuration settings, updating documentation for clarity, and modifying CI pipeline settings.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23): Updated references to the .NET SDK version for clarity and changed code block formatting for template file examples. Removed unnecessary blank lines to tidy up the documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72)

### Code Cleanup:
* [`build/BundleConfiguration.cs`](diffhunk://#diff-21ed74be1563e57526f8f4958d6d27098927047632f1d18ad7aae1e60269d64aL31-L33): Removed the `TemplateVersion` property as it is no longer required.
* [`build/Settings.cs`](diffhunk://#diff-9186c746cf458c0e44bf37d91527d7b4d87ed8034fe9bbe12abb651504334ffcL17-L27): Removed unused `nugetFeed`, `nugetSources`, and `ExtensionBundleVersionRange` properties to simplify the codebase. [[1]](diffhunk://#diff-9186c746cf458c0e44bf37d91527d7b4d87ed8034fe9bbe12abb651504334ffcL17-L27) [[2]](diffhunk://#diff-9186c746cf458c0e44bf37d91527d7b4d87ed8034fe9bbe12abb651504334ffcL63)

### Configuration Updates:
* [`eng/ci/templates/jobs/build.yml`](diffhunk://#diff-011534d541c6c83cdaef02acfd818234399da3b38de11553ed0e3ce663807716L25-R25): Changed the CI pipeline branch name from `refs/heads/release/main` to `refs/heads/dev` to avoid management of multiple branches for template release. Releases to be done from `dev` branch of templates.
* [`src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json`](diffhunk://#diff-240b10f68412409887d4aedab61175e1fface4a1daba7defde1c5376b98d810bL4): Removed the `templateVersion` field from the bundle configuration file as it is no longer needed.
## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview - need PR for this
- [ ] main-experimental - need PR for this
- [ ] main-v2 - need PR for this
- [ ] main-v3 - need PR for this

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->