### PR TITLE
preview: Pin Kusto extension to "1.0.11-Preview"

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -186,7 +186,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Kusto",
-    "majorVersion": "1",
+    "version": "1.0.11-Preview",
     "name": "KustoBinding",
     "bindings": [
       "Kusto"


### PR DESCRIPTION
# Pull Request

## Description
As Kusto extension has published a new version - 1.0.12-Preview, it is breaking dependency validation tests as the extension has introduced some major version dependency changes.
This pull request updates the `extensions.json` file to specify an exact version for the `Microsoft.Azure.WebJobs.Extensions.Kusto` extension instead of a major version.

* [`src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json`](diffhunk://#diff-ef04bd46da33b5dc5074a2236e1584380e5c32959ad0c3b0b30b2e6213341c45L189-R189): Changed the `majorVersion` field to a `version` field with the value `1.0.11-Preview` for the `Microsoft.Azure.WebJobs.Extensions.Kusto` extension.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main - N/A
- [x] main-preview
- [ ] main-experimental
- [ ] main-v2 - N/A
- [ ] main-v3 - N/A

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->