### PR TITLE
Adding emulator tests to request and test basic fabric host extension implmentation

### DIFF
--- a/tests/emulator_tests/fabric_functions/function_app.py
+++ b/tests/emulator_tests/fabric_functions/function_app.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import fabric.functions as fn
+
+udf = fn.UserDataFunctions()
+
+@udf.function()
+def test_hello_fabric() -> str:
+    return f"Welcome to Fabric Functions"
+
+@udf.function()
+def test_add_parameters(stringParam:str, numParam:int) -> str:
+    return f"stringParam: {stringParam}, numParam: {numParam}"
+
+@udf.connection(alias="mockConnection", argName="mockSqlDB")
+@udf.function()
+def test_add_connection(mockSqlDB: fn.FabricSqlConnection) -> dict:
+    # Testing to make sure the endpoints are injected correctly by the host extension
+    
+    return {"mockSqlDB": mockSqlDB.endpoints}
+
+@udf.context(argName="myContext")
+@udf.function()
+def test_add_fabriccontext(myContext: fn.UserDataFunctionContext) -> dict:
+    return  {
+        "invocationId": myContext.invocation_id,
+        "executingUser": myContext.executing_user
+    }

--- a/tests/emulator_tests/test_fabric_functions.py
+++ b/tests/emulator_tests/test_fabric_functions.py
@@ -12,7 +12,7 @@ class TestFabricFunctions(testutils.WebHostTestCase):
 
     @classmethod
     def get_script_dir(cls):
-        return testutils.EMULATOR_TESTS_FOLDER / 'fabric_functions' 
+        return testutils.EMULATOR_TESTS_FOLDER / 'fabric_functions'
 
     def test_fabric_hello_world(self):
         """

--- a/tests/emulator_tests/test_fabric_functions.py
+++ b/tests/emulator_tests/test_fabric_functions.py
@@ -1,0 +1,116 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import json
+import time
+
+from requests import JSONDecodeError
+from tests.utils import testutils
+import logging
+
+
+class TestFabricFunctions(testutils.WebHostTestCase):
+
+    @classmethod
+    def get_script_dir(cls):
+        return testutils.EMULATOR_TESTS_FOLDER / 'fabric_functions' 
+
+    def test_fabric_hello_world(self):
+        """
+        Test the test_hello_fabric function in the Fabric Functions extension.
+        """
+
+        response = self.webhost.request('POST', 'test_hello_fabric', json={}, headers={ 'x-ms-invocation-id': 'test-invocation-id' })
+
+        self.assertEqual(response.status_code, 200)
+        
+        try:
+            data = response.json()
+            self.assertIn("output", data)
+            self.assertEqual(data["output"], "Welcome to Fabric Functions")
+        except JSONDecodeError:
+            self.fail("Response is not valid JSON")
+
+
+    def test_add_parameters(self):
+        """
+        Test the test_add_parameters function in the Fabric Functions extension.
+
+        This function takes two parameters: a string and a number, and returns a formatted string.
+        It is used to verify that the function can correctly handle parameters passed in the request body.
+        """
+
+        response = self.webhost.request('POST', 'test_add_parameters', json={"stringParam": "test", "numParam": 123}, headers={ 'x-ms-invocation-id': 'test-invocation-id' })
+
+        self.assertEqual(response.status_code, 200)
+
+        try:
+            data = response.json()
+            self.assertIn("output", data)
+            self.assertEqual(data["output"], "stringParam: test, numParam: 123")
+        except JSONDecodeError:
+            self.fail("Response is not valid JSON")
+
+    def test_fabric_connection(self):
+        """
+        Test the test_add_connection function in the Fabric Functions extension.
+        This function is used to test the connection to a mock SQL database endpoint.
+        It verifies that the connection string is correctly injected into the function context from the fabric host extension.
+        """
+
+        headers = {
+            'x-ms-invocation-id': 'test-invocation-id',
+            'x-ms-fabric-connected-datasources-connections': "{\"mockConnection_SqlEndpoint\": {\"SqlEndpoint\": \"Server=tcp:mock.database.windows.net,1433;Initial Catalog=mockdb;\"}}"
+        }
+
+        response = self.webhost.request('POST', 'test_add_connection', json={}, headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+
+        try:
+            data = response.json()
+            self.assertIn("output", data)
+            self.assertIn("mockSqlDB", data["output"])
+
+            endpointInfo = data["output"]["mockSqlDB"]
+            self.assertEqual(endpointInfo["sqlendpoint"]['ConnectionString'], "Server=tcp:mock.database.windows.net,1433;Initial Catalog=mockdb;")
+        except JSONDecodeError:
+            self.fail("Response is not valid JSON")
+
+    def test_fabric_context(self):
+        """
+        Test the test_add_fabriccontext function in the Fabric Functions extension.
+        This function is used to test the injection of the function context into the function.
+        It verifies that the context information is correctly passed to the function.
+        """
+
+        context = {
+            'InvocationId': 'test-invocation-id',
+            'ExecutingUser': {
+                'Oid': 'test-user',
+                'TenantId': 'test-tenant-id',
+                'PreferredUsername': 'TestTester'
+            }
+        }
+
+        headers = {
+            'x-ms-invocation-id': 'test-invocation-id',
+            'x-ms-fabric-userdatafunctioncontext': json.dumps(context)
+        }
+
+        response = self.webhost.request('POST', 'test_add_fabriccontext', json={}, headers=headers)
+
+        self.assertEqual(response.status_code, 200)
+
+        try:
+            data = response.json()
+
+            self.assertIn("output", data)
+
+            self.assertIn("executingUser", data["output"])
+            user = data["output"]["executingUser"]
+
+            self.assertEqual(user["Oid"], "test-user")
+            self.assertEqual(user["TenantId"], "test-tenant-id")
+            self.assertEqual(user["PreferredUsername"], "TestTester")
+        except JSONDecodeError:
+            self.fail("Response is not valid JSON")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ invoke
 mysql-connector-python
 requests
 azure-functions
+fabric-user-data-functions

--- a/tests/utils/testutils.py
+++ b/tests/utils/testutils.py
@@ -273,6 +273,7 @@ def popen_webhost(*, stdout, stderr, script_root, port=None):
         'host:logger:consoleLoggingMode': 'always',
         'AZURE_FUNCTIONS_ENVIRONMENT': 'development',
         'AzureWebJobsSecretStorageType': 'files',
+        'PYTHON_ENABLE_WORKER_EXTENSIONS':'1',
         'FUNCTIONS_WORKER_RUNTIME': 'python',
         'FUNCTIONS_WORKER_RUNTIME_VERSION': f'{sys.version_info.major}.{sys.version_info.minor}',  # Use current Python version
         'AzureWebJobsStorage': os.environ.get('AzureWebJobsStorage', 'UseDevelopmentStorage=true'),

--- a/tests/utils/testutils.py
+++ b/tests/utils/testutils.py
@@ -273,7 +273,7 @@ def popen_webhost(*, stdout, stderr, script_root, port=None):
         'host:logger:consoleLoggingMode': 'always',
         'AZURE_FUNCTIONS_ENVIRONMENT': 'development',
         'AzureWebJobsSecretStorageType': 'files',
-        'PYTHON_ENABLE_WORKER_EXTENSIONS':'1',
+        'PYTHON_ENABLE_WORKER_EXTENSIONS': '1',
         'FUNCTIONS_WORKER_RUNTIME': 'python',
         'FUNCTIONS_WORKER_RUNTIME_VERSION': f'{sys.version_info.major}.{sys.version_info.minor}',  # Use current Python version
         'AzureWebJobsStorage': os.environ.get('AzureWebJobsStorage', 'UseDevelopmentStorage=true'),


### PR DESCRIPTION
# Pull Request

## Description

This PR adds several unit tests which test the basic functionality provided by the Fabric Host extension to the emulator tests.

The tests mainly showcase how our host and worker extensions transforms specific headers and requests into the specific format for the Fabric UDF Functions.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [x] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->