### PR TITLE
experimental: update bundleVersion to 4.5.0

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,5 +1,6 @@
 ﻿{
     "bundleId": "Microsoft.Azure.Functions.ExtensionBundle.Experimental",
-    "bundleVersion": "4.4.0",
+    "bundleVersion": "4.5.0",
     "isExperimentalBundle": true
+
 }


### PR DESCRIPTION
This pull request updates the extension bundle configuration to use a newer version. The change is minor and affects only the bundle version.

* Updated the `bundleVersion` in `bundleConfig.json` from `4.4.0` to `4.5.0`, ensuring the bundle references the latest experimental version.