### PR TITLE
Change directory path to 'scripts' in README for bundle version check

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -183,7 +183,7 @@ ls -la get-function-apps-bundle-version.sh
    ```powershell
    # Upload via Cloud Shell interface or clone repository
    git clone https://github.com/Azure/azure-functions-extension-bundles.git
-   cd azure-functions-extension-bundles/tools
+   cd azure-functions-extension-bundles/scripts
    ```
 
 4. **Run the script**:
@@ -201,7 +201,7 @@ ls -la get-function-apps-bundle-version.sh
    ```bash
    # Upload via Cloud Shell interface or clone repository
    git clone https://github.com/Azure/azure-functions-extension-bundles.git
-   cd azure-functions-extension-bundles/tools
+   cd azure-functions-extension-bundles/scripts
    ```
 
 4. **Make executable and run**:


### PR DESCRIPTION
Updated directory path in README for script execution.

# Pull Request

## Description
This pull request makes a minor update to the documentation for running the `get-function-apps-bundle-version.sh` script. The instructions now direct users to the correct `scripts` directory instead of the outdated `tools` directory.

## Issue Link

<!-- Link to the issue this PR addresses -->
In lieu of #630 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [x] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->