### PR TITLE
main-preview: WebJobs.Extensions.CosmosDb 4.12.0-preview.1

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -113,7 +113,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
-    "majorVersion": "4",
+    "version": "4.12.0-preview.1",
     "name": "CosmosDB",
     "bindings": [
       "cosmosdbtrigger",


### PR DESCRIPTION
# Pull Request

## Description

Pin WebJobs.Extensions.CosmosDb to 4.12.0-preview.1 for the preview feed.

CosmosDB package will be following what `Microsoft.Azure.Cosmos` does, where stable & preview are developed in tandem. With preview having extra features that map to preview CosmosDB service features.

As such, when both version `X` and `X-preview` are available, we want the preview feed to still take `X-preview`. With how bundles is set up today, this means we need to explicitly pin as the default logic will always prefer stable packages of the same version over preview.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
Do not port. preview only.

- [ ] main
- [x] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->