### PR TITLE
main-preview: Pin WebPubSubForSocketIO version to 1.0.0-beta.4

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -295,7 +295,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO",
-    "majorVersion": "1",
+    "version": "1.0.0-beta.4",
     "name": "WebPubSubForSocketIO",
     "bindings": [
       "socketiotrigger",


### PR DESCRIPTION
# Pull Request

## Description

https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO is bumping major version of Microsoft.IdentityModel.*, this change doesn't seem to be safe from backward compatibility perspective. It needs coordination  with WebPubSubForSocketIO extension team for why they needed a major version bump and ensuring compatibility and working of all other extensions in the bundle.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [x] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->