### PR TITLE
pin WebPubSub to 1.9.0 until host can update identity model

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -177,7 +177,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.WebPubSub",
-    "majorVersion": "1",
+    "version": "1.9.0",
     "name": "WebPubSub",
     "bindings": [
       "webpubsub",
@@ -277,3 +277,4 @@
     ]
   }
 ]
+


### PR DESCRIPTION
# Pull Request

## Description
This pull request updates the extension bundle configuration for Azure Functions by specifying exact extension versions instead of major versions as they are bumping major version of a shared dependency unified at host level. This fixes the build failures until we are ready to adopt latest version after following issue is shipped in the host - https://github.com/Azure/azure-functions-host/issues/11531.

Dependency version updates:

* Updated the `WebPubSub ` extension to use `version:1.9.0` instead of `majorVersion: 3` in `extensions.json`.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [x] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->