### PR TITLE
Fix emulator tests CI: install SDK from core-tools global.json, auto-detect target framework, and filter host tags to < 4.1049.

### DIFF
--- a/eng/ci/scripts/build-core-tools.ps1
+++ b/eng/ci/scripts/build-core-tools.ps1
@@ -80,6 +80,16 @@ Write-Host "Zip Output Directory: $ZipOutputDir" -ForegroundColor Yellow
 Write-Host "`nPublishing Azure.Functions.Cli with $Configuration configuration..." -ForegroundColor Yellow
 Write-Host "Output Directory: $OutputDir" -ForegroundColor Yellow
 
+# Detect target framework from the project file
+$projXml = [xml](Get-Content $ProjectPath)
+$targetFramework = $projXml.Project.PropertyGroup.TargetFramework | Where-Object { $_ } | Select-Object -First 1
+if (-not $targetFramework) {
+    $targetFramework = "net8.0"
+    Write-Host "Could not detect TargetFramework, defaulting to $targetFramework" -ForegroundColor Yellow
+} else {
+    Write-Host "Detected TargetFramework: $targetFramework" -ForegroundColor Green
+}
+
 Push-Location $CoreToolsDir
 
 try {
@@ -88,7 +98,7 @@ try {
         $ProjectPath,
         "-o", $OutputDir,
         "-c", $Configuration,
-        "-f", "net8.0",
+        "-f", $targetFramework,
         "--self-contained",
         "/p:ZipAfterPublish=true",
         "/p:ZipArtifactsPath=$ZipOutputDir"

--- a/eng/ci/scripts/build-core-tools.ps1
+++ b/eng/ci/scripts/build-core-tools.ps1
@@ -97,7 +97,7 @@ try {
     $restoreArgs = @(
         "restore",
         $ProjectPath,
-        "-f", $targetFramework
+        "/p:TargetFramework=$targetFramework"
     )
     
     if (-not [string]::IsNullOrEmpty($Runtime)) {

--- a/eng/ci/scripts/build-core-tools.ps1
+++ b/eng/ci/scripts/build-core-tools.ps1
@@ -93,6 +93,28 @@ if (-not $targetFramework) {
 Push-Location $CoreToolsDir
 
 try {
+    # Restore packages first, then publish with --no-restore to avoid redundant downloads
+    $restoreArgs = @(
+        "restore",
+        $ProjectPath,
+        "-f", $targetFramework
+    )
+    
+    if (-not [string]::IsNullOrEmpty($Runtime)) {
+        $restoreArgs += "-r", $Runtime
+    }
+    
+    Write-Host "Running: dotnet $($restoreArgs -join ' ')" -ForegroundColor Cyan
+    & dotnet $restoreArgs 2>&1 | Tee-Object -Variable restoreLogs
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "`n##[error]dotnet restore failed with exit code $LASTEXITCODE" -ForegroundColor Red
+        $restoreLogs | ForEach-Object { Write-Host $_ }
+        throw "Restore failed with exit code $LASTEXITCODE"
+    }
+    
+    Write-Host "✓ Restore completed successfully" -ForegroundColor Green
+
     $publishArgs = @(
         "publish",
         $ProjectPath,
@@ -100,6 +122,7 @@ try {
         "-c", $Configuration,
         "-f", $targetFramework,
         "--self-contained",
+        "--no-restore",
         "/p:ZipAfterPublish=true",
         "/p:ZipArtifactsPath=$ZipOutputDir"
     )

--- a/eng/ci/scripts/build-multi-version-core-tools.ps1
+++ b/eng/ci/scripts/build-multi-version-core-tools.ps1
@@ -233,6 +233,11 @@ try {
             }
             Write-Host "  ✓ Cleaned obj/bin directories" -ForegroundColor Green
         }
+
+        # Clean NuGet cache between builds to reclaim disk space
+        Write-Host "  Clearing NuGet cache..." -ForegroundColor Gray
+        & dotnet nuget locals all --clear 2>$null
+        Write-Host "  ✓ Cleared NuGet cache" -ForegroundColor Green
         
         # Store result
         $buildResults += [PSCustomObject]@{

--- a/eng/ci/scripts/build-multi-version-core-tools.ps1
+++ b/eng/ci/scripts/build-multi-version-core-tools.ps1
@@ -113,10 +113,6 @@ $BackupFiles = @{
         Path = $PackagesPropsPath
         Backup = "$PackagesPropsPath.backup"
     }
-    GlobalJson = @{
-        Path = Join-Path $CloneDir "global.json"
-        Backup = Join-Path $CloneDir "global.json.backup"
-    }
     StartupCs = @{
         Path = Join-Path $CloneDir "src\Cli\func\Actions\HostActions\Startup.cs"
         Backup = Join-Path $CloneDir "src\Cli\func\Actions\HostActions\Startup.cs.backup"

--- a/eng/ci/scripts/get-latest-host-tags.ps1
+++ b/eng/ci/scripts/get-latest-host-tags.ps1
@@ -90,6 +90,20 @@ $parsedTags = $tags | ForEach-Object {
     }
 } | Where-Object { $_ -ne $null }
 
+# Exclude host versions >= 4.1049 which require dotnet 10.
+# TODO: Remove this filter once core tools complete migration to dotnet 10.
+$parsedTags = $parsedTags | Where-Object {
+    $versionParts = $_.VersionNoPrefix -split '\.'
+    [int]$versionParts[1] -lt 1049
+}
+
+if (-not $parsedTags) {
+    Write-Error "No tags found after filtering for versions < 4.1049"
+    exit 1
+}
+
+Write-Host "Tags after filtering (< 4.1049): $($parsedTags.Count)" -ForegroundColor Green
+
 # Group by middle version and get the highest patch from each group
 $groupedTags = $parsedTags | 
     Group-Object MiddleVersion | 

--- a/eng/ci/scripts/update-core-tools-versions.ps1
+++ b/eng/ci/scripts/update-core-tools-versions.ps1
@@ -43,39 +43,6 @@ if (-not (Test-Path $PackagesPropsPath)) {
 
 Write-Host "Packages.props: $PackagesPropsPath" -ForegroundColor Yellow
 
-# Get core tools root path for global.json update
-$coreToolsRootForGlobal = Split-Path (Split-Path (Split-Path $PackagesPropsPath -Parent) -Parent) -Parent
-
-# Sync global.json with host repo
-$GlobalJsonPath = Join-Path $coreToolsRootForGlobal "global.json"
-if (Test-Path $GlobalJsonPath) {
-    Write-Host "`nSyncing global.json with host repo..." -ForegroundColor Yellow
-    
-    $hostGlobalJsonUri = "https://raw.githubusercontent.com/Azure/azure-functions-host/refs/tags/v$HostVersion/global.json"
-    
-    try {
-        $hostGlobalJsonContent = (Invoke-WebRequest -Uri $hostGlobalJsonUri -Headers @{"User-Agent" = "azure-functions-extension-bundles-emulator-tests"} -ErrorAction Stop).Content
-        $hostGlobalJson = $hostGlobalJsonContent | ConvertFrom-Json
-        $hostSdkVersion = $hostGlobalJson.sdk.version
-        
-        $localGlobalJson = Get-Content $GlobalJsonPath -Raw | ConvertFrom-Json
-        $localSdkVersion = $localGlobalJson.sdk.version
-        
-        if ($localSdkVersion -ne $hostSdkVersion) {
-            # Update SDK version from host repo
-            $localGlobalJson.sdk.version = $hostSdkVersion
-            $localGlobalJson.sdk.rollForward = "latestMajor"
-            $localGlobalJson | ConvertTo-Json -Depth 10 | Set-Content $GlobalJsonPath
-            Write-Host "  ✓ Updated global.json SDK: $localSdkVersion -> $hostSdkVersion (from host repo)" -ForegroundColor Green
-        } else {
-            Write-Host "  global.json SDK version: $localSdkVersion (no change)" -ForegroundColor Gray
-        }
-    } catch {
-        Write-Warning "  Could not fetch global.json from host repo: $_"
-        Write-Host "  Keeping existing global.json" -ForegroundColor Gray
-    }
-}
-
 # Set up GitHub API headers for compliance with GitHub API requirements
 $script:GitHubHeaders = @{
     "User-Agent" = "azure-functions-extension-bundles-emulator-tests"

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -41,9 +41,6 @@ jobs:
       echo "Disk space before build:"
       df -h
       
-      echo "Pruning unused Docker images to free disk space..."
-      docker image prune -af 2>/dev/null || true
-      
       echo "Removing .git directory from core-tools to free disk space..."
       rm -rf $(Agent.BuildDirectory)/core-tools/.git 2>/dev/null || true
       

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -44,6 +44,13 @@ jobs:
   
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET SDK from core-tools global.json'
+    inputs:
+      packageType: 'sdk'
+      useGlobalJson: true
+      workingDirectory: '$(Agent.BuildDirectory)/core-tools'
     
   - task: PowerShell@2
     displayName: 'Build Azure Functions Core Tools'

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -40,17 +40,19 @@ jobs:
   - script: |
       echo "Disk space before build:"
       df -h
-    displayName: 'Check Initial Disk Space'
+      
+      echo "Pruning unused Docker images to free disk space..."
+      docker image prune -af 2>/dev/null || true
+      
+      echo "Removing .git directory from core-tools to free disk space..."
+      rm -rf $(Agent.BuildDirectory)/core-tools/.git 2>/dev/null || true
+      
+      echo "Disk space after cleanup:"
+      df -h
+    displayName: 'Free Disk Space Before Build'
   
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
-
-  - task: UseDotNet@2
-    displayName: 'Install .NET SDK from core-tools global.json'
-    inputs:
-      packageType: 'sdk'
-      useGlobalJson: true
-      workingDirectory: '$(Agent.BuildDirectory)/core-tools'
     
   - task: PowerShell@2
     displayName: 'Build Azure Functions Core Tools'
@@ -72,10 +74,6 @@ jobs:
       # Clean NuGet cache
       echo "Clearing NuGet cache..."
       rm -rf ~/.nuget/packages/* 2>/dev/null || true
-      
-      # Remove git history from core-tools to save space
-      echo "Removing git history..."
-      rm -rf $(Agent.BuildDirectory)/core-tools/.git 2>/dev/null || true
       
       echo "Disk space after cleanup:"
       df -h


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes and makes the emulator tests CI pipeline more robust and forward-compatible by:

1. **Installing .NET SDK from core-tools `global.json`** — Instead of relying on a pre-installed SDK, the pipeline now uses `UseDotNet@2` to install the exact SDK version specified by the core-tools repo. This ensures build compatibility regardless of the host version.

2. **Auto-detecting TargetFramework from `.csproj`** — `build-core-tools.ps1` no longer hardcodes `net8.0`. It reads the `TargetFramework` from the project file, making it compatible with both `net8.0` and future `net10.0` branches.

3. **Removing `global.json` sync from update script** — The `update-core-tools-versions.ps1` script no longer fetches and overwrites the core-tools `global.json` from the host repo. The SDK is now managed by the pipeline task instead.

4. **Filtering host tags to < 4.1049** — `get-latest-host-tags.ps1` now excludes host versions >= 4.1049 which require dotnet 10. This filter should be removed once [core tools complete the migration to dotnet 10](https://github.com/Azure/azure-functions-core-tools/pull/4850). Created a temporary branch - `manvkaur/dotnethosttests`  with a workaround to do [adhoc verifications](https://dev.azure.com/azfunc/public/_build/results?buildId=272770&view=results) before bundle releases on dotnet 10 based host. 

## Issue Link

Resolves #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Testing

## Branch Propagation

- [x] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated emulator tests that prove my fix or feature works
- [x] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [x] I have added appropriate comments to complex code

## Documentation Updates

NA