### PR TITLE
Add mcpPromptTrigger binding and emulator tests

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -310,7 +310,8 @@
     "bindings": [
       "mcpToolTrigger",
       "mcpToolProperty",
-      "mcpResourceTrigger"
+      "mcpResourceTrigger",
+      "mcpPromptTrigger"
     ]
   }
 ]

--- a/tests/emulator_tests/mcp_functions/function_app.py
+++ b/tests/emulator_tests/mcp_functions/function_app.py
@@ -43,3 +43,34 @@ def mcp_resource_function(context) -> str:
         str: The readme content.
     """
     return "# Sample Readme\nThis is a sample readme file for testing MCP Resource Trigger."
+
+@app.generic_trigger(
+    arg_name="context",
+    type="mcpPromptTrigger",
+    promptName="greeting_prompt",
+    description="Generates a greeting message for a given name.",
+    promptArguments=json.dumps([
+        {"name": "name", "description": "Name of the person to greet.", "required": True}
+    ]),
+)
+def greeting_prompt(context) -> str:
+    """
+    A simple prompt function that returns a greeting message.
+
+    Args:
+        context: The prompt invocation context.
+
+    Returns:
+        str: A JSON-serialized prompt result with the greeting message.
+    """
+    ctx = json.loads(context)
+    args = ctx.get("Arguments") or ctx.get("arguments") or {}
+    name = args.get("name", "world")
+    return json.dumps({
+        "messages": [
+            {
+                "role": "user",
+                "content": {"type": "text", "text": f"Say hello to {name}."}
+            }
+        ]
+    })

--- a/tests/emulator_tests/test_mcp_functions.py
+++ b/tests/emulator_tests/test_mcp_functions.py
@@ -232,3 +232,98 @@ class TestMcpFunctions(testutils.WebHostTestCase):
             )
         except (json.JSONDecodeError, ValueError) as e:
             self.fail(f"Failed to parse response: {e}\nResponse text: {response.text}")
+
+    def test_prompts_list(self):
+        """
+        Test the prompts/list MCP API to verify it returns available prompts.
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "test-prompts-list-1",
+            "method": "prompts/list"
+        }
+
+        response = self.webhost.request(
+            'POST',
+            self.MCP_WEBHOOK_PATH,
+            json=payload,
+            no_prefix=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        try:
+            try:
+                data = response.json()
+            except json.JSONDecodeError:
+                data = self._parse_sse_response(response.text)
+
+            self.assertEqual(data.get("jsonrpc"), "2.0")
+            self.assertEqual(data.get("id"), "test-prompts-list-1")
+            self.assertIn("result", data)
+
+            result = data["result"]
+            self.assertIn("prompts", result)
+            prompts = result["prompts"]
+            self.assertIsInstance(prompts, list)
+
+            prompt_names = [p.get("name") for p in prompts]
+            self.assertIn("greeting_prompt", prompt_names)
+
+            greeting = next(p for p in prompts if p.get("name") == "greeting_prompt")
+            self.assertEqual(
+                greeting.get("description"),
+                "Generates a greeting message for a given name."
+            )
+
+            arguments = greeting.get("arguments") or []
+            arg_names = [a.get("name") for a in arguments]
+            self.assertIn("name", arg_names)
+        except (json.JSONDecodeError, ValueError) as e:
+            self.fail(f"Failed to parse response: {e}\nResponse text: {response.text}")
+
+    def test_prompts_get(self):
+        """
+        Test the prompts/get MCP API to invoke the greeting_prompt.
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "test-prompts-get-1",
+            "method": "prompts/get",
+            "params": {
+                "name": "greeting_prompt",
+                "arguments": {"name": "Functions"}
+            }
+        }
+
+        response = self.webhost.request(
+            'POST',
+            self.MCP_WEBHOOK_PATH,
+            json=payload,
+            no_prefix=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        try:
+            try:
+                data = response.json()
+            except json.JSONDecodeError:
+                data = self._parse_sse_response(response.text)
+
+            self.assertEqual(data.get("jsonrpc"), "2.0")
+            self.assertEqual(data.get("id"), "test-prompts-get-1")
+            self.assertIn("result", data)
+
+            result = data["result"]
+            self.assertIn("messages", result)
+            messages = result["messages"]
+            self.assertIsInstance(messages, list)
+            self.assertTrue(len(messages) > 0)
+
+            first = messages[0]
+            content = first.get("content") or {}
+            self.assertEqual(content.get("type"), "text")
+            self.assertIn("Functions", content.get("text", ""))
+        except (json.JSONDecodeError, ValueError) as e:
+            self.fail(f"Failed to parse response: {e}\nResponse text: {response.text}")


### PR DESCRIPTION
## Summary
- Register `mcpPromptTrigger` in `extensions.json` under the MCP extension.
- Add a `greeting_prompt` sample to the MCP emulator test app.
- Add `prompts/list` and `prompts/get` emulator tests.

## Release notes
- Added `mcpPromptTrigger` binding to the MCP extension entry.