### PR TITLE
main: Exclude Fabric extension from RU package build

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -7,6 +7,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using static Build.Settings;
 
 namespace Build
 {
@@ -112,11 +113,12 @@ namespace Build
             Settings.LinuxBuildConfigurations.ForEach((config) => BuildExtensionsBundle(config).GetAwaiter().GetResult());
         }
 
-        public static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig)
+        public static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig, string configPrefix = null, string[] exclusions = null)
         {
             var sourceNugetConfig = Path.Combine(Settings.SourcePath, Settings.NugetConfigFileName);
             var sourceProjectFilePath = Path.Combine(Settings.SourcePath, buildConfig.SourceProjectFileName);
-            string projectDirectory = Path.Combine(Settings.RootBuildDirectory, buildConfig.ConfigId.ToString());
+            string configDirName = configPrefix != null ? $"{configPrefix}_{buildConfig.ConfigId}" : buildConfig.ConfigId.ToString();
+            string projectDirectory = Path.Combine(Settings.RootBuildDirectory, configDirName);
             string targetProjectFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, "extensions.csproj");
             string targetNugetConfigFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, Settings.NugetConfigFileName);
 
@@ -124,13 +126,20 @@ namespace Build
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
             FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
-            await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle);
+            await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle, exclusions);
             return targetProjectFilePath;
         }
 
-        public static async Task AddExtensionPackages(string projectFilePath, bool addPrereleasePackages)
+        public static async Task AddExtensionPackages(string projectFilePath, bool addPrereleasePackages, string[] exclusions = null)
         {
             var extensions = GetExtensionList();
+
+            if (exclusions != null && exclusions.Length > 0)
+            {
+                extensions = extensions.Where(ext => !exclusions.Contains(ext.Id, StringComparer.OrdinalIgnoreCase)).ToList();
+                Console.WriteLine($"Including {extensions.Count} extensions (excluded {exclusions.Length} by ID)");
+            }
+
             foreach (var extension in extensions)
             {
                 string version = string.IsNullOrEmpty(extension.Version) ? await Helper.GetLatestPackageVersion(extension.Id, extension.MajorVersion, addPrereleasePackages) : extension.Version;
@@ -138,11 +147,19 @@ namespace Build
             }
         }
 
-        public static async Task BuildExtensionsBundle(BuildConfiguration buildConfig)
+        public static async Task BuildExtensionsBundle(BuildConfiguration buildConfig, string configPrefix = null, string[] exclusions = null)
         {
-            var projectFilePath = await GenerateBundleProjectFile(buildConfig);
+            var projectFilePath = await GenerateBundleProjectFile(buildConfig, configPrefix, exclusions);
 
-            var publishCommandArguments = $"publish {projectFilePath} -c Release -o {buildConfig.PublishDirectoryPath}";
+            string publishPath = configPrefix != null
+                ? Path.Combine(Settings.RootBinDirectory, $"{configPrefix}_{buildConfig.ConfigId}")
+                : buildConfig.PublishDirectoryPath;
+
+            string publishBinPath = configPrefix != null
+                ? Path.Combine(publishPath, buildConfig.PublishBinDirectorySubPath)
+                : buildConfig.PublishBinDirectoryPath;
+
+            var publishCommandArguments = $"publish {projectFilePath} -c Release -o {publishPath}";
 
             if (!buildConfig.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase))
             {
@@ -156,10 +173,10 @@ namespace Build
 
             Shell.Run("dotnet", publishCommandArguments);
 
-            if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)
+            if (Path.Combine(publishPath, "bin") != publishBinPath)
             {
-                FileUtility.EnsureDirectoryExists(Directory.GetParent(buildConfig.PublishBinDirectoryPath).FullName);
-                Directory.Move(Path.Combine(buildConfig.PublishDirectoryPath, "bin"), buildConfig.PublishBinDirectoryPath);
+                FileUtility.EnsureDirectoryExists(Directory.GetParent(publishBinPath).FullName);
+                Directory.Move(Path.Combine(publishPath, "bin"), publishBinPath);
             }
         }
 
@@ -224,7 +241,7 @@ namespace Build
             return JsonConvert.DeserializeObject<List<Extension>>(extensionsJsonFileContent);
         }
 
-        public static void CreateExtensionBundle(BundlePackageConfiguration bundlePackageConfig)
+        public static void CreateExtensionBundle(BundlePackageConfiguration bundlePackageConfig, string configPrefix = null)
         {
             // Create a directory to hold the bundle content
             string bundlePath = Path.Combine(Settings.RootBuildDirectory, bundlePackageConfig.BundleName);
@@ -235,10 +252,14 @@ namespace Build
                 var buildConfig = Settings.WindowsBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig) ??
                     Settings.LinuxBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig);
 
+                string sourceBinPath = configPrefix != null
+                    ? Path.Combine(Settings.RootBinDirectory, $"{configPrefix}_{buildConfig.ConfigId}", buildConfig.PublishBinDirectorySubPath)
+                    : buildConfig.PublishBinDirectoryPath;
+
                 string targetBundleBinariesPath = Path.Combine(bundlePath, buildConfig.PublishBinDirectorySubPath);
 
                 // Copy binaries
-                FileUtility.CopyDirectory(buildConfig.PublishBinDirectoryPath, targetBundleBinariesPath);
+                FileUtility.CopyDirectory(sourceBinPath, targetBundleBinariesPath);
 
                 string extensionJsonFilePath = Path.Join(targetBundleBinariesPath, Settings.ExtensionsJsonFileName);
                 AddBindingInfoToExtensionsJson(extensionJsonFilePath);
@@ -292,6 +313,19 @@ namespace Build
 
         public static void CreateRUPackage()
         {
+            if (Settings.RUExclusions.Length > 0)
+            {
+                Console.WriteLine($"Building RU package with exclusions: {string.Join(", ", Settings.RUExclusions)}");
+                BuildAndPackageRUWithExclusions();
+            }
+            else
+            {
+                BuildRUFromWindowsPackage();
+            }
+        }
+
+        private static void BuildRUFromWindowsPackage()
+        {
             FileUtility.EnsureDirectoryExists(Settings.RUPackagePath);
 
             ZipFile.ExtractToDirectory(Settings.BundlePackageNetCoreWindows.GeneratedBundleZipFilePath, Settings.RUPackagePath);
@@ -300,12 +334,38 @@ namespace Build
             ZipFile.CreateFromDirectory(RURootPackagePath.FullName, Path.Combine(Settings.ArtifactsDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package.zip"), CompressionLevel.Optimal, false);
         }
 
+        private static void BuildAndPackageRUWithExclusions()
+        {
+            // Rebuild Windows configs with excluded extensions filtered out
+            Settings.WindowsBuildConfigurations.ForEach(config =>
+                BuildExtensionsBundle(config, configPrefix: "ru", exclusions: Settings.RUExclusions).GetAwaiter().GetResult());
+
+            // Package using the same logic as other bundles, but reading from RU output dirs
+            var ruPackageConfig = new BundlePackageConfiguration()
+            {
+                PackageIdentifier = "RU",
+                ConfigBinariesToInclude = Settings.BundlePackageNetCoreWindows.ConfigBinariesToInclude,
+                CsProjFilePath = Path.Combine(Settings.RootBuildDirectory, $"ru_{ConfigId.any_any}", "extensions.csproj")
+            };
+
+            CreateExtensionBundle(ruPackageConfig, configPrefix: "ru");
+
+            // Create the final RU zip from the bundle output
+            string ruBundlePath = Path.Combine(Settings.RootBuildDirectory, ruPackageConfig.BundleName);
+            FileUtility.EnsureDirectoryExists(Settings.RUPackagePath);
+            FileUtility.CopyDirectory(ruBundlePath, Settings.RUPackagePath);
+
+            var RURootPackagePath = Directory.GetParent(Settings.RUPackagePath);
+            FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
+            ZipFile.CreateFromDirectory(RURootPackagePath.FullName, Path.Combine(Settings.ArtifactsDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package.zip"), CompressionLevel.Optimal, false);
+        }
+
         public static void CreateCDNStoragePackage()
         {
             foreach (var indexFileMetadata in Settings.IndexFiles)
             {
                 string directoryPath = Path.Combine(Settings.RootBinDirectory, indexFileMetadata.IndexFileDirectory, BundleConfiguration.Instance.ExtensionBundleId);
-                FileUtility.EnsureDirectoryExists(directoryPath); 
+                FileUtility.EnsureDirectoryExists(directoryPath);
                 var bundleVersionDirectory = Path.Combine(directoryPath, BundleConfiguration.Instance.ExtensionBundleVersion);
 
                 // Copy templates (only if StaticContent directory exists)

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -343,21 +343,12 @@ namespace Build
             // Package using the same logic as other bundles, but reading from RU output dirs
             var ruPackageConfig = new BundlePackageConfiguration()
             {
-                PackageIdentifier = "RU",
+                PackageIdentifier = "RU_package",
                 ConfigBinariesToInclude = Settings.BundlePackageNetCoreWindows.ConfigBinariesToInclude,
                 CsProjFilePath = Path.Combine(Settings.RootBuildDirectory, $"ru_{ConfigId.any_any}", "extensions.csproj")
             };
 
             CreateExtensionBundle(ruPackageConfig, configPrefix: "ru");
-
-            // Create the final RU zip from the bundle output
-            string ruBundlePath = Path.Combine(Settings.RootBuildDirectory, ruPackageConfig.BundleName);
-            FileUtility.EnsureDirectoryExists(Settings.RUPackagePath);
-            FileUtility.CopyDirectory(ruBundlePath, Settings.RUPackagePath);
-
-            var RURootPackagePath = Directory.GetParent(Settings.RUPackagePath);
-            FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
-            ZipFile.CreateFromDirectory(RURootPackagePath.FullName, Path.Combine(Settings.ArtifactsDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package.zip"), CompressionLevel.Optimal, false);
         }
 
         public static void CreateCDNStoragePackage()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -12,6 +12,9 @@ namespace Build
 {
     public static class BuildSteps
     {
+        private const string RUConfigPrefix = "ru";
+        private const string RUPackageIdentifier = "RU_package";
+
         public static void Clean()
         {
             if (FileUtility.DirectoryExists(Settings.RootBinDirectory))
@@ -318,21 +321,26 @@ namespace Build
 
             // Always build RU self-contained (filtered extension list, own output dirs)
             var allExtensions = GetExtensionList();
+            if (allExtensions == null || allExtensions.Count == 0)
+            {
+                throw new InvalidOperationException("Extension list is empty or could not be loaded.");
+            }
+
             var filteredExtensions = allExtensions
-                .Where(ext => !Settings.RUExclusions.Contains(ext.Id, StringComparer.OrdinalIgnoreCase))
+                .Where(ext => !string.IsNullOrEmpty(ext.Id) && !Settings.RUExclusions.Contains(ext.Id, StringComparer.OrdinalIgnoreCase))
                 .ToList();
             Console.WriteLine($"RU build: including {filteredExtensions.Count} of {allExtensions.Count} extensions");
 
             // Build Windows configs with filtered extension list
             Settings.WindowsBuildConfigurations.ForEach(config =>
-                BuildExtensionsBundle(config, configPrefix: "ru", extensionList: filteredExtensions).GetAwaiter().GetResult());
+                BuildExtensionsBundle(config, configPrefix: RUConfigPrefix, extensionList: filteredExtensions).GetAwaiter().GetResult());
 
             // Package into RU zip with version folder structure for downstream compatibility
             var ruPackageConfig = new BundlePackageConfiguration()
             {
-                PackageIdentifier = "RU_package",
+                PackageIdentifier = RUPackageIdentifier,
                 ConfigBinariesToInclude = Settings.BundlePackageNetCoreWindows.ConfigBinariesToInclude,
-                OutputDirectoryPrefix = "ru",
+                OutputDirectoryPrefix = RUConfigPrefix,
                 CompressionLevel = CompressionLevel.Optimal
             };
 

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -7,7 +7,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using static Build.Settings;
 
 namespace Build
 {
@@ -113,7 +112,7 @@ namespace Build
             Settings.LinuxBuildConfigurations.ForEach((config) => BuildExtensionsBundle(config).GetAwaiter().GetResult());
         }
 
-        public static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig, string configPrefix = null, string[] exclusions = null)
+        private static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig, string configPrefix = null, List<Extension> extensionList = null)
         {
             var sourceNugetConfig = Path.Combine(Settings.SourcePath, Settings.NugetConfigFileName);
             var sourceProjectFilePath = Path.Combine(Settings.SourcePath, buildConfig.SourceProjectFileName);
@@ -126,19 +125,13 @@ namespace Build
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
             FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
-            await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle, exclusions);
+            await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle, extensionList);
             return targetProjectFilePath;
         }
 
-        public static async Task AddExtensionPackages(string projectFilePath, bool addPrereleasePackages, string[] exclusions = null)
+        private static async Task AddExtensionPackages(string projectFilePath, bool addPrereleasePackages, List<Extension> extensionList = null)
         {
-            var extensions = GetExtensionList();
-
-            if (exclusions != null && exclusions.Length > 0)
-            {
-                extensions = extensions.Where(ext => !exclusions.Contains(ext.Id, StringComparer.OrdinalIgnoreCase)).ToList();
-                Console.WriteLine($"Including {extensions.Count} extensions (excluded {exclusions.Length} by ID)");
-            }
+            var extensions = extensionList ?? GetExtensionList();
 
             foreach (var extension in extensions)
             {
@@ -147,9 +140,9 @@ namespace Build
             }
         }
 
-        public static async Task BuildExtensionsBundle(BuildConfiguration buildConfig, string configPrefix = null, string[] exclusions = null)
+        private static async Task BuildExtensionsBundle(BuildConfiguration buildConfig, string configPrefix = null, List<Extension> extensionList = null)
         {
-            var projectFilePath = await GenerateBundleProjectFile(buildConfig, configPrefix, exclusions);
+            var projectFilePath = await GenerateBundleProjectFile(buildConfig, configPrefix, extensionList);
 
             string publishPath = configPrefix != null
                 ? Path.Combine(Settings.RootBinDirectory, $"{configPrefix}_{buildConfig.ConfigId}")
@@ -241,7 +234,7 @@ namespace Build
             return JsonConvert.DeserializeObject<List<Extension>>(extensionsJsonFileContent);
         }
 
-        public static void CreateExtensionBundle(BundlePackageConfiguration bundlePackageConfig, string configPrefix = null, CompressionLevel compressionLevel = CompressionLevel.NoCompression)
+        public static void CreateExtensionBundle(BundlePackageConfiguration bundlePackageConfig)
         {
             // Create a directory to hold the bundle content
             string bundlePath = Path.Combine(Settings.RootBuildDirectory, bundlePackageConfig.BundleName);
@@ -252,8 +245,8 @@ namespace Build
                 var buildConfig = Settings.WindowsBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig) ??
                     Settings.LinuxBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig);
 
-                string sourceBinPath = configPrefix != null
-                    ? Path.Combine(Settings.RootBinDirectory, $"{configPrefix}_{buildConfig.ConfigId}", buildConfig.PublishBinDirectorySubPath)
+                string sourceBinPath = bundlePackageConfig.OutputDirectoryPrefix != null
+                    ? Path.Combine(Settings.RootBinDirectory, $"{bundlePackageConfig.OutputDirectoryPrefix}_{buildConfig.ConfigId}", buildConfig.PublishBinDirectorySubPath)
                     : buildConfig.PublishBinDirectoryPath;
 
                 string targetBundleBinariesPath = Path.Combine(bundlePath, buildConfig.PublishBinDirectorySubPath);
@@ -285,7 +278,7 @@ namespace Build
             File.Copy(bundlePackageConfig.CsProjFilePath, projectPath);
 
             FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
-            ZipFile.CreateFromDirectory(bundlePath, bundlePackageConfig.GeneratedBundleZipFilePath, compressionLevel, false);
+            ZipFile.CreateFromDirectory(bundlePath, bundlePackageConfig.GeneratedBundleZipFilePath, bundlePackageConfig.CompressionLevel, false);
         }
 
         public static void PackageNetCoreV3Bundle()
@@ -336,19 +329,27 @@ namespace Build
 
         private static void BuildAndPackageRUWithExclusions()
         {
-            // Rebuild Windows configs with excluded extensions filtered out
-            Settings.WindowsBuildConfigurations.ForEach(config =>
-                BuildExtensionsBundle(config, configPrefix: "ru", exclusions: Settings.RUExclusions).GetAwaiter().GetResult());
+            // Filter extensions once, pass the explicit list to the build pipeline
+            var allExtensions = GetExtensionList();
+            var filteredExtensions = allExtensions
+                .Where(ext => !Settings.RUExclusions.Contains(ext.Id, StringComparer.OrdinalIgnoreCase))
+                .ToList();
+            Console.WriteLine($"RU build: including {filteredExtensions.Count} extensions (excluded {allExtensions.Count - filteredExtensions.Count})");
 
-            // Package using the same logic as other bundles, but reading from RU output dirs
+            // Rebuild Windows configs with filtered extension list
+            Settings.WindowsBuildConfigurations.ForEach(config =>
+                BuildExtensionsBundle(config, configPrefix: "ru", extensionList: filteredExtensions).GetAwaiter().GetResult());
+
+            // Package using the same logic as other bundles, reading from RU output dirs
             var ruPackageConfig = new BundlePackageConfiguration()
             {
                 PackageIdentifier = "RU_package",
                 ConfigBinariesToInclude = Settings.BundlePackageNetCoreWindows.ConfigBinariesToInclude,
-                CsProjFilePath = Path.Combine(Settings.RootBuildDirectory, $"ru_{ConfigId.any_any}", "extensions.csproj")
+                OutputDirectoryPrefix = "ru",
+                CompressionLevel = CompressionLevel.Optimal
             };
 
-            CreateExtensionBundle(ruPackageConfig, configPrefix: "ru", compressionLevel: CompressionLevel.Optimal);
+            CreateExtensionBundle(ruPackageConfig);
         }
 
         public static void CreateCDNStoragePackage()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -245,6 +245,11 @@ namespace Build
                 var buildConfig = Settings.WindowsBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig) ??
                     Settings.LinuxBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig);
 
+                if (buildConfig == null)
+                {
+                    throw new InvalidOperationException($"Build configuration for ConfigId '{packageConfig}' not found.");
+                }
+
                 string sourceBinPath = bundlePackageConfig.OutputDirectoryPrefix != null
                     ? Path.Combine(Settings.RootBinDirectory, $"{bundlePackageConfig.OutputDirectoryPrefix}_{buildConfig.ConfigId}", buildConfig.PublishBinDirectorySubPath)
                     : buildConfig.PublishBinDirectoryPath;
@@ -309,38 +314,20 @@ namespace Build
             if (Settings.RUExclusions.Length > 0)
             {
                 Console.WriteLine($"Building RU package with exclusions: {string.Join(", ", Settings.RUExclusions)}");
-                BuildAndPackageRUWithExclusions();
             }
-            else
-            {
-                BuildRUFromWindowsPackage();
-            }
-        }
 
-        private static void BuildRUFromWindowsPackage()
-        {
-            FileUtility.EnsureDirectoryExists(Settings.RUPackagePath);
-
-            ZipFile.ExtractToDirectory(Settings.BundlePackageNetCoreWindows.GeneratedBundleZipFilePath, Settings.RUPackagePath);
-
-            var RURootPackagePath = Directory.GetParent(Settings.RUPackagePath);
-            ZipFile.CreateFromDirectory(RURootPackagePath.FullName, Path.Combine(Settings.ArtifactsDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package.zip"), CompressionLevel.Optimal, false);
-        }
-
-        private static void BuildAndPackageRUWithExclusions()
-        {
-            // Filter extensions once, pass the explicit list to the build pipeline
+            // Always build RU self-contained (filtered extension list, own output dirs)
             var allExtensions = GetExtensionList();
             var filteredExtensions = allExtensions
                 .Where(ext => !Settings.RUExclusions.Contains(ext.Id, StringComparer.OrdinalIgnoreCase))
                 .ToList();
-            Console.WriteLine($"RU build: including {filteredExtensions.Count} extensions (excluded {allExtensions.Count - filteredExtensions.Count})");
+            Console.WriteLine($"RU build: including {filteredExtensions.Count} of {allExtensions.Count} extensions");
 
-            // Rebuild Windows configs with filtered extension list
+            // Build Windows configs with filtered extension list
             Settings.WindowsBuildConfigurations.ForEach(config =>
                 BuildExtensionsBundle(config, configPrefix: "ru", extensionList: filteredExtensions).GetAwaiter().GetResult());
 
-            // Package using the same logic as other bundles, reading from RU output dirs
+            // Package into RU zip with version folder structure for downstream compatibility
             var ruPackageConfig = new BundlePackageConfiguration()
             {
                 PackageIdentifier = "RU_package",
@@ -349,7 +336,51 @@ namespace Build
                 CompressionLevel = CompressionLevel.Optimal
             };
 
-            CreateExtensionBundle(ruPackageConfig);
+            CreateRUExtensionBundle(ruPackageConfig);
+        }
+
+        private static void CreateRUExtensionBundle(BundlePackageConfiguration bundlePackageConfig)
+        {
+            // Stage bundle content under <root>/<version>/ to match legacy RU zip layout
+            string ruRootPath = Path.Combine(Settings.RootBuildDirectory, bundlePackageConfig.BundleName);
+            string bundlePath = Path.Combine(ruRootPath, BundleConfiguration.Instance.ExtensionBundleVersion);
+
+            foreach (var packageConfig in bundlePackageConfig.ConfigBinariesToInclude)
+            {
+                var buildConfig = Settings.WindowsBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig) ??
+                    Settings.LinuxBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig);
+
+                if (buildConfig == null)
+                {
+                    throw new InvalidOperationException($"Build configuration for ConfigId '{packageConfig}' not found.");
+                }
+
+                string sourceBinPath = bundlePackageConfig.OutputDirectoryPrefix != null
+                    ? Path.Combine(Settings.RootBinDirectory, $"{bundlePackageConfig.OutputDirectoryPrefix}_{buildConfig.ConfigId}", buildConfig.PublishBinDirectorySubPath)
+                    : buildConfig.PublishBinDirectoryPath;
+
+                string targetBundleBinariesPath = Path.Combine(bundlePath, buildConfig.PublishBinDirectorySubPath);
+
+                FileUtility.CopyDirectory(sourceBinPath, targetBundleBinariesPath);
+
+                string extensionJsonFilePath = Path.Join(targetBundleBinariesPath, Settings.ExtensionsJsonFileName);
+                AddBindingInfoToExtensionsJson(extensionJsonFilePath);
+            }
+
+            if (FileUtility.DirectoryExists(Settings.StaticContentDirectoryPath))
+            {
+                var staticContentDirectory = Path.Combine(bundlePath, Settings.StaticContentDirectoryName);
+                FileUtility.CopyDirectory(Settings.StaticContentDirectoryPath, staticContentDirectory);
+            }
+
+            CreateBundleJsonFile(bundlePath);
+
+            string projectPath = Path.Combine(bundlePath, "extensions.csproj");
+            File.Copy(bundlePackageConfig.CsProjFilePath, projectPath);
+
+            FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
+            // Zip from ruRootPath so the zip contains <version>/... at root
+            ZipFile.CreateFromDirectory(ruRootPath, bundlePackageConfig.GeneratedBundleZipFilePath, bundlePackageConfig.CompressionLevel, false);
         }
 
         public static void CreateCDNStoragePackage()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -241,7 +241,7 @@ namespace Build
             return JsonConvert.DeserializeObject<List<Extension>>(extensionsJsonFileContent);
         }
 
-        public static void CreateExtensionBundle(BundlePackageConfiguration bundlePackageConfig, string configPrefix = null)
+        public static void CreateExtensionBundle(BundlePackageConfiguration bundlePackageConfig, string configPrefix = null, CompressionLevel compressionLevel = CompressionLevel.NoCompression)
         {
             // Create a directory to hold the bundle content
             string bundlePath = Path.Combine(Settings.RootBuildDirectory, bundlePackageConfig.BundleName);
@@ -285,7 +285,7 @@ namespace Build
             File.Copy(bundlePackageConfig.CsProjFilePath, projectPath);
 
             FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
-            ZipFile.CreateFromDirectory(bundlePath, bundlePackageConfig.GeneratedBundleZipFilePath, CompressionLevel.NoCompression, false);
+            ZipFile.CreateFromDirectory(bundlePath, bundlePackageConfig.GeneratedBundleZipFilePath, compressionLevel, false);
         }
 
         public static void PackageNetCoreV3Bundle()
@@ -348,7 +348,7 @@ namespace Build
                 CsProjFilePath = Path.Combine(Settings.RootBuildDirectory, $"ru_{ConfigId.any_any}", "extensions.csproj")
             };
 
-            CreateExtensionBundle(ruPackageConfig, configPrefix: "ru");
+            CreateExtensionBundle(ruPackageConfig, configPrefix: "ru", compressionLevel: CompressionLevel.Optimal);
         }
 
         public static void CreateCDNStoragePackage()

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -242,6 +242,14 @@ namespace Build
             // Create a directory to hold the bundle content
             string bundlePath = Path.Combine(Settings.RootBuildDirectory, bundlePackageConfig.BundleName);
 
+            StageBundleContent(bundlePackageConfig, bundlePath);
+
+            FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
+            ZipFile.CreateFromDirectory(bundlePath, bundlePackageConfig.GeneratedBundleZipFilePath, bundlePackageConfig.CompressionLevel, false);
+        }
+
+        private static void StageBundleContent(BundlePackageConfiguration bundlePackageConfig, string bundlePath)
+        {
             foreach (var packageConfig in bundlePackageConfig.ConfigBinariesToInclude)
             {
                 // find the build configuration matching the config id
@@ -284,9 +292,6 @@ namespace Build
             // Add Csproj file
             string projectPath = Path.Combine(bundlePath, "extensions.csproj");
             File.Copy(bundlePackageConfig.CsProjFilePath, projectPath);
-
-            FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
-            ZipFile.CreateFromDirectory(bundlePath, bundlePackageConfig.GeneratedBundleZipFilePath, bundlePackageConfig.CompressionLevel, false);
         }
 
         public static void PackageNetCoreV3Bundle()
@@ -357,38 +362,7 @@ namespace Build
             }
             string bundlePath = Path.Combine(ruRootPath, BundleConfiguration.Instance.ExtensionBundleVersion);
 
-            foreach (var packageConfig in bundlePackageConfig.ConfigBinariesToInclude)
-            {
-                var buildConfig = Settings.WindowsBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig) ??
-                    Settings.LinuxBuildConfigurations.FirstOrDefault(b => b.ConfigId == packageConfig);
-
-                if (buildConfig == null)
-                {
-                    throw new InvalidOperationException($"Build configuration for ConfigId '{packageConfig}' not found.");
-                }
-
-                string sourceBinPath = bundlePackageConfig.OutputDirectoryPrefix != null
-                    ? Path.Combine(Settings.RootBinDirectory, $"{bundlePackageConfig.OutputDirectoryPrefix}_{buildConfig.ConfigId}", buildConfig.PublishBinDirectorySubPath)
-                    : buildConfig.PublishBinDirectoryPath;
-
-                string targetBundleBinariesPath = Path.Combine(bundlePath, buildConfig.PublishBinDirectorySubPath);
-
-                FileUtility.CopyDirectory(sourceBinPath, targetBundleBinariesPath);
-
-                string extensionJsonFilePath = Path.Join(targetBundleBinariesPath, Settings.ExtensionsJsonFileName);
-                AddBindingInfoToExtensionsJson(extensionJsonFilePath);
-            }
-
-            if (FileUtility.DirectoryExists(Settings.StaticContentDirectoryPath))
-            {
-                var staticContentDirectory = Path.Combine(bundlePath, Settings.StaticContentDirectoryName);
-                FileUtility.CopyDirectory(Settings.StaticContentDirectoryPath, staticContentDirectory);
-            }
-
-            CreateBundleJsonFile(bundlePath);
-
-            string projectPath = Path.Combine(bundlePath, "extensions.csproj");
-            File.Copy(bundlePackageConfig.CsProjFilePath, projectPath);
+            StageBundleContent(bundlePackageConfig, bundlePath);
 
             FileUtility.EnsureDirectoryExists(Settings.ArtifactsDirectory);
             // Zip from ruRootPath so the zip contains <version>/... at root

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -343,6 +343,10 @@ namespace Build
         {
             // Stage bundle content under <root>/<version>/ to match legacy RU zip layout
             string ruRootPath = Path.Combine(Settings.RootBuildDirectory, bundlePackageConfig.BundleName);
+            if (Directory.Exists(ruRootPath))
+            {
+                Directory.Delete(ruRootPath, recursive: true);
+            }
             string bundlePath = Path.Combine(ruRootPath, BundleConfiguration.Instance.ExtensionBundleVersion);
 
             foreach (var packageConfig in bundlePackageConfig.ConfigBinariesToInclude)

--- a/build/BundlePackageConfiguration.cs
+++ b/build/BundlePackageConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using static Build.Settings;
 
 namespace Build
@@ -10,13 +11,30 @@ namespace Build
 
         public List<ConfigId> ConfigBinariesToInclude { get; set; } = new List<ConfigId>();
 
+        public string OutputDirectoryPrefix { get; set; }
+
+        public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.NoCompression;
+
         public string BundleName => $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_{PackageIdentifier}".Trim('_');
 
         public string GeneratedBundleZipFileName => $"{BundleName}.zip";
 
         public string GeneratedBundleZipFilePath => Path.Combine(ArtifactsDirectory, GeneratedBundleZipFileName);
 
-        public string CsProjFilePath { get; set; }
+        public string CsProjFilePath
+        {
+            get => _csProjFilePath ?? GetDefaultCsProjFilePath();
+            set => _csProjFilePath = value;
+        }
+        private string _csProjFilePath;
+
+        private string GetDefaultCsProjFilePath()
+        {
+            string configDir = OutputDirectoryPrefix != null
+                ? $"{OutputDirectoryPrefix}_{ConfigId.any_any}"
+                : ConfigId.any_any.ToString();
+            return Path.Combine(Settings.RootBuildDirectory, configDir, "extensions.csproj");
+        }
     }
 
 }

--- a/build/BundlePackageConfiguration.cs
+++ b/build/BundlePackageConfiguration.cs
@@ -26,6 +26,7 @@ namespace Build
             get => _csProjFilePath ?? GetDefaultCsProjFilePath();
             set => _csProjFilePath = value;
         }
+
         private string _csProjFilePath;
 
         private string GetDefaultCsProjFilePath()

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -12,7 +12,9 @@ namespace Build
 
         public static readonly string RUExclusionsFilePath = Path.Combine(Path.GetFullPath(basePath), "src", "Microsoft.Azure.Functions.ExtensionBundle", "ruExclusions.json");
 
-        public static string[] RUExclusions { get; private set; } = LoadRUExclusions();
+        private static readonly Lazy<string[]> _ruExclusions = new Lazy<string[]>(LoadRUExclusions);
+
+        public static string[] RUExclusions => _ruExclusions.Value;
 
         private static string[] LoadRUExclusions()
         {

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -21,9 +21,17 @@ namespace Build
                 return Array.Empty<string>();
             }
 
-            var content = File.ReadAllText(RUExclusionsFilePath);
-            var exclusions = JsonConvert.DeserializeObject<string[]>(content);
-            return exclusions ?? Array.Empty<string>();
+            try
+            {
+                var content = File.ReadAllText(RUExclusionsFilePath);
+                var exclusions = JsonConvert.DeserializeObject<string[]>(content);
+                return exclusions ?? Array.Empty<string>();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to parse RU exclusions from '{RUExclusionsFilePath}': {ex.Message}", ex);
+            }
         }
 
         public static readonly string SourcePath = Path.GetFullPath(basePath + "/src/Microsoft.Azure.Functions.ExtensionBundle/");

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using Newtonsoft.Json;
 using static Build.BasePath;
 
 namespace Build
@@ -7,6 +9,22 @@ namespace Build
     public static class Settings
     {
         public static string basePath = path;
+
+        public static readonly string RUExclusionsFilePath = Path.Combine(Path.GetFullPath(basePath), "src", "Microsoft.Azure.Functions.ExtensionBundle", "ruExclusions.json");
+
+        public static string[] RUExclusions { get; private set; } = LoadRUExclusions();
+
+        private static string[] LoadRUExclusions()
+        {
+            if (!File.Exists(RUExclusionsFilePath))
+            {
+                return Array.Empty<string>();
+            }
+
+            var content = File.ReadAllText(RUExclusionsFilePath);
+            var exclusions = JsonConvert.DeserializeObject<string[]>(content);
+            return exclusions ?? Array.Empty<string>();
+        }
 
         public static readonly string SourcePath = Path.GetFullPath(basePath + "/src/Microsoft.Azure.Functions.ExtensionBundle/");
         public static readonly string BuildPath = Path.Combine(Path.GetFullPath(basePath), "build");

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -47,16 +47,17 @@ jobs:
       inputs:
         command: 'run'
         workingDirectory: '.\build'
-        arguments: 'skip:Clean,DownloadTemplates,BuildBundleBinariesForWindows,BuildBundleBinariesForLinux,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
+        arguments: 'CreateRUPackage skip:Clean,DownloadTemplates,BuildBundleBinariesForWindows,BuildBundleBinariesForLinux,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,PackageNetCoreV3BundlesLinux'
 
   - ${{ if eq(parameters.official, true) }}:
     - pwsh: |
         $maxSize = 183500800  # 175 MB
-        $ruZip = Get-ChildItem '$(Build.Repository.LocalPath)\artifacts\*_RU_package.zip'
-        if (-not $ruZip) {
+        $ruZips = @(Get-ChildItem '$(Build.Repository.LocalPath)\artifacts\*_RU_package.zip')
+        if ($ruZips.Count -eq 0) {
           Write-Error "RU package zip not found in artifacts directory"
           exit 1
         }
+        $ruZip = $ruZips[0]
         $size = $ruZip.Length
         Write-Host "RU package size: $([math]::Round($size / 1MB, 2)) MB ($size bytes)"
         if ($size -gt $maxSize) {

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -50,6 +50,23 @@ jobs:
         arguments: 'skip:Clean,DownloadTemplates,BuildBundleBinariesForWindows,BuildBundleBinariesForLinux,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
 
   - ${{ if eq(parameters.official, true) }}:
+    - pwsh: |
+        $maxSize = 466616320  # 445 MB
+        $ruZip = Get-ChildItem '$(Build.Repository.LocalPath)\artifacts\*_RU_package.zip'
+        if (-not $ruZip) {
+          Write-Error "RU package zip not found in artifacts directory"
+          exit 1
+        }
+        $size = $ruZip.Length
+        Write-Host "RU package size: $([math]::Round($size / 1MB, 2)) MB ($size bytes)"
+        if ($size -gt $maxSize) {
+          Write-Error "RU package size $size bytes ($([math]::Round($size / 1MB, 2)) MB) exceeds maximum allowed size of $maxSize bytes ($([math]::Round($maxSize / 1MB, 2)) MB). Review and consider optimizations"
+          exit 1
+        }
+        Write-Host "RU package size is within limits."
+      displayName: 'Validate RU Package Size'
+
+  - ${{ if eq(parameters.official, true) }}:
     - task: CopyFiles@2
       inputs:
         SourceFolder: '$(Build.Repository.LocalPath)\artifacts'

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -51,7 +51,7 @@ jobs:
 
   - ${{ if eq(parameters.official, true) }}:
     - pwsh: |
-        $maxSize = 193986560  # 185 MB
+        $maxSize = 183500800  # 175 MB
         $ruZip = Get-ChildItem '$(Build.Repository.LocalPath)\artifacts\*_RU_package.zip'
         if (-not $ruZip) {
           Write-Error "RU package zip not found in artifacts directory"

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -51,7 +51,7 @@ jobs:
 
   - ${{ if eq(parameters.official, true) }}:
     - pwsh: |
-        $maxSize = 466616320  # 445 MB
+        $maxSize = 193986560  # 185 MB
         $ruZip = Get-ChildItem '$(Build.Repository.LocalPath)\artifacts\*_RU_package.zip'
         if (-not $ruZip) {
           Write-Error "RU package zip not found in artifacts directory"

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -36,8 +36,18 @@ jobs:
     inputs:
       command: 'run'
       workingDirectory: '.\build'
+      ${{ if eq(parameters.official, true) }}:
+        arguments: 'skip:CreateRUPackage'
       ${{ if eq(parameters.official, false) }}:
         arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux'
+
+  - ${{ if eq(parameters.official, true) }}:
+    - task: DotNetCoreCLI@2
+      displayName: 'Build RU Package'
+      inputs:
+        command: 'run'
+        workingDirectory: '.\build'
+        arguments: 'skip:Clean,DownloadTemplates,BuildBundleBinariesForWindows,BuildBundleBinariesForLinux,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
 
   - ${{ if eq(parameters.official, true) }}:
     - task: CopyFiles@2

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/ruExclusions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/ruExclusions.json
@@ -1,0 +1,3 @@
+[
+  "Microsoft.Azure.WebJobs.Extensions.Fabric"
+]


### PR DESCRIPTION
# Pull Request

## Description
Implements dynamic extension exclusion for RU (Rapid Update) packages. Extensions listed in `ruExclusions.json` are excluded from the RU package build, reducing package size. Currently excludes `Microsoft.Azure.WebJobs.Extensions.Fabric`.

Key changes:
- Added `src/Microsoft.Azure.Functions.ExtensionBundle/ruExclusions.json` as the exclusion config
- Modified build pipeline to reuse existing build functions with `configPrefix`/`exclusions` parameters for RU
- Separated RU build as its own CI task (parallel-safe, no artifact conflicts)
- **Added RU package size validation step (fails if >175 MB) in Build stage** 
- Uses `CompressionLevel.Optimal` for the final RU zip

## Issue Link
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation
- [x] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist
- [x] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [x] I have added appropriate comments to complex code

## Additional Information
RU package size with Optimal compression and Fabric excluded: 451,791,411 bytes (optimal compressed - 170.35 MB 178620950 bytes)
