### PR TITLE
build: use cosmos majorVersion=4

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -113,7 +113,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.CosmosDB",
-    "version": "4.13.0-preview.1",
+    "majorVersion": "4",
     "name": "CosmosDB",
     "bindings": [
       "cosmosdbtrigger",


### PR DESCRIPTION
# Pull Request

## Description

Switch back to using `majorVersion: 4` for CosmosDB package. Two changes in CosmosDB packaging that will let us stick with that:

1. The preview features we were using have made their way into the stable package, so no need for preview package
2. In the future, we will keep preview packages a higher semantic version than stable (ie: 4.16.0 and 4.16.1-preview.1), so preview bundles will always grab the preview version _if_ there is one.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

Update package version in bundle.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

No port. main-preview only.

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated emulator tests that prove my fix or feature works
- [x] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [x] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->