### PR TITLE
Update test deps.json baseline due to bump of Microsoft.Extensions.DependencyInjection.Abstractions

### DIFF
--- a/tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -10,11 +10,11 @@
         "dependencies": {
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.3.6",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.3.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.14.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.15.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
           "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
@@ -25,13 +25,13 @@
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.527",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.536",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Tables": "1.4.0",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.10.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.10.1",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
           "Microsoft.IdentityModel.JsonWebTokens": "8.14.0",
@@ -62,7 +62,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -154,7 +154,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -326,7 +326,7 @@
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
@@ -337,24 +337,24 @@
           }
         }
       },
-      "Google.Protobuf/3.31.1": {
+      "Google.Protobuf/3.34.1": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.31.1.0",
-            "fileVersion": "3.31.1.0"
+            "assemblyVersion": "3.34.1.0",
+            "fileVersion": "3.34.1.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.72.0"
+          "Grpc.Tools": "2.78.0"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.71.0"
+          "Grpc.Net.Common": "2.76.0"
         },
         "runtime": {
           "lib/net7.0/Grpc.AspNetCore.Server.dll": {
@@ -375,29 +375,29 @@
           }
         }
       },
-      "Grpc.Core.Api/2.71.0": {
+      "Grpc.Core.Api/2.76.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.71.0": {
+      "Grpc.Net.Client/2.76.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.71.0",
+          "Grpc.Net.Common": "2.76.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         },
         "runtime": {
           "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.71.0",
+          "Grpc.Net.Client": "2.76.0",
           "Microsoft.Extensions.Http": "3.1.32"
         },
         "runtime": {
@@ -407,18 +407,18 @@
           }
         }
       },
-      "Grpc.Net.Common/2.71.0": {
+      "Grpc.Net.Common/2.76.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.71.0"
+          "Grpc.Core.Api": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
-      "Grpc.Tools/2.72.0": {},
+      "Grpc.Tools/2.78.0": {},
       "K4os.Compression.LZ4/1.3.8": {
         "runtime": {
           "lib/net6.0/K4os.Compression.LZ4.dll": {
@@ -645,7 +645,7 @@
       "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Extensions.Caching.Memory": "6.0.3",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "System.Diagnostics.PerformanceCounter": "4.7.0"
         },
         "runtime": {
@@ -958,10 +958,10 @@
       "Microsoft.Azure.Cosmos/3.56.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "6.0.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Memory": "4.6.0",
@@ -1016,36 +1016,36 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.10.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0"
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.10.0.0",
-            "fileVersion": "0.10.0.4735"
+            "assemblyVersion": "0.11.0.0",
+            "fileVersion": "0.11.0.12085"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.8.3": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.8.0.0",
-            "fileVersion": "2.8.3.4735"
+            "assemblyVersion": "2.9.0.0",
+            "fileVersion": "2.9.0.12085"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.7.1": {
+      "Microsoft.Azure.DurableTask.Core/3.8.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -1056,8 +1056,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.7.0.0",
-            "fileVersion": "3.7.1.4735"
+            "assemblyVersion": "3.8.0.0",
+            "fileVersion": "3.8.0.12085"
           }
         }
       },
@@ -1068,8 +1068,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1083,9 +1083,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1107,13 +1107,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.3.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1123,8 +1123,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.26160"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.0.26227"
           }
         }
       },
@@ -1249,7 +1249,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.15.0": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.56.0",
@@ -1259,8 +1259,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.14.0.0",
-            "fileVersion": "4.14.0.25611"
+            "assemblyVersion": "4.15.0.0",
+            "fileVersion": "4.15.0.26228"
           }
         }
       },
@@ -1282,13 +1282,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.3": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.10.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.8.3",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1297,30 +1297,30 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.3.0"
+            "fileVersion": "3.12.5.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.5.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Grpc.Tools": "2.72.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Grpc.Tools": "2.78.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
@@ -1416,7 +1416,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1489,7 +1489,7 @@
       "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.17.0": {
         "dependencies": {
           "Azure.Messaging.ServiceBus": "7.20.1",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
           "Microsoft.Extensions.Azure": "1.13.1"
@@ -1519,7 +1519,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.527": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.536": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
@@ -1532,8 +1532,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.527.0",
-            "fileVersion": "3.1.527.0"
+            "assemblyVersion": "3.1.536.0",
+            "fileVersion": "3.1.536.0"
           }
         }
       },
@@ -1597,7 +1597,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.0": {
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.1": {
         "dependencies": {
           "Azure.Messaging.WebPubSub": "1.6.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
@@ -1607,8 +1607,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.WebPubSub.dll": {
-            "assemblyVersion": "1.10.0.0",
-            "fileVersion": "1.1000.26.6801"
+            "assemblyVersion": "1.10.1.0",
+            "fileVersion": "1.1000.126.22602"
           }
         }
       },
@@ -1668,7 +1668,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "6.0.1"
+          "System.Collections.Immutable": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
@@ -1693,11 +1693,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.0",
-            "fileVersion": "10.0.25.52411"
+            "assemblyVersion": "10.0.0.5",
+            "fileVersion": "10.0.526.15411"
           }
         }
       },
@@ -1816,129 +1816,129 @@
           }
         }
       },
-      "Microsoft.DurableTask.Abstractions/1.16.2": {
+      "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "System.Collections.Immutable": "6.0.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Abstractions.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.5.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.5.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.5.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0"
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.Client/1.16.2": {
+      "Microsoft.DurableTask.Client/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Client.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Client.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Client.Grpc/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Client": "1.16.2",
-          "Microsoft.DurableTask.Grpc": "1.16.2",
+          "Microsoft.DurableTask.Client": "1.24.2",
+          "Microsoft.DurableTask.Grpc": "1.24.2",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Client.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Client.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.16.2": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.24.2": {
         "dependencies": {
           "Azure.Storage.Blobs": "12.27.0",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.DurableTask.Client": "1.16.2",
-          "Microsoft.DurableTask.Client.Grpc": "1.16.2",
-          "Microsoft.DurableTask.Worker": "1.16.2",
-          "Microsoft.DurableTask.Worker.Grpc": "1.16.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.DurableTask.Client": "1.24.2",
+          "Microsoft.DurableTask.Client.Grpc": "1.24.2",
+          "Microsoft.DurableTask.Worker": "1.24.2",
+          "Microsoft.DurableTask.Worker.Grpc": "1.24.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47514"
+          "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.5.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Grpc/1.24.2": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0"
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
@@ -1946,7 +1946,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "8.14.0",
           "SemanticVersion": "2.1.0",
@@ -1962,7 +1962,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -1972,31 +1972,32 @@
           }
         }
       },
-      "Microsoft.DurableTask.Worker/1.16.2": {
+      "Microsoft.DurableTask.Worker/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.Extensions.Caching.Memory": "6.0.3",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "Microsoft.Extensions.Options": "8.0.2",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Worker.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Worker.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Worker.Grpc/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.DurableTask.Grpc": "1.16.2",
-          "Microsoft.DurableTask.Worker": "1.16.2"
+          "Google.Protobuf": "3.34.1",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.DurableTask.Grpc": "1.24.2",
+          "Microsoft.DurableTask.Worker": "1.24.2"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Worker.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Worker.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
@@ -2015,7 +2016,7 @@
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
@@ -2027,18 +2028,24 @@
           }
         }
       },
-      "Microsoft.Extensions.Caching.Abstractions/6.0.1": {
+      "Microsoft.Extensions.Caching.Abstractions/8.0.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.Extensions.Caching.Memory/6.0.3": {
+      "Microsoft.Extensions.Caching.Memory/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "6.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.Caching.Memory.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
         }
       },
       "Microsoft.Extensions.Configuration/8.0.0": {
@@ -2120,7 +2127,7 @@
       },
       "Microsoft.Extensions.DependencyInjection/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.DependencyInjection.dll": {
@@ -2129,11 +2136,11 @@
           }
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+      "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.1": {
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.1024.46610"
+            "assemblyVersion": "9.0.0.0",
+            "fileVersion": "9.0.124.61010"
           }
         }
       },
@@ -2167,7 +2174,7 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
@@ -2201,7 +2208,7 @@
           "Microsoft.Extensions.Configuration.Json": "8.0.1",
           "Microsoft.Extensions.Configuration.UserSecrets": "8.0.1",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Diagnostics": "8.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
@@ -2225,7 +2232,7 @@
       "Microsoft.Extensions.Hosting.Abstractions/8.0.1": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
@@ -2239,7 +2246,7 @@
       },
       "Microsoft.Extensions.Http/3.1.32": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -2259,7 +2266,7 @@
       },
       "Microsoft.Extensions.Logging.Abstractions/8.0.3": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.Logging.Abstractions.dll": {
@@ -2285,7 +2292,7 @@
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2300,7 +2307,7 @@
       },
       "Microsoft.Extensions.Logging.Console/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Logging.Configuration": "8.0.1",
@@ -2315,7 +2322,7 @@
       },
       "Microsoft.Extensions.Logging.Debug/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         },
@@ -2328,7 +2335,7 @@
       },
       "Microsoft.Extensions.Logging.EventLog/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2343,7 +2350,7 @@
       },
       "Microsoft.Extensions.Logging.EventSource/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2366,7 +2373,7 @@
       },
       "Microsoft.Extensions.Options/8.0.2": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Primitives": "8.0.0"
         },
         "runtime": {
@@ -2380,7 +2387,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -2697,7 +2704,7 @@
       "MySql.Data/9.0.0": {
         "dependencies": {
           "BouncyCastle.Cryptography": "2.3.1",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "K4os.Compression.LZ4.Streams": "1.3.8",
           "System.Buffers": "4.6.0",
           "System.Configuration.ConfigurationManager": "8.0.1",
@@ -2986,7 +2993,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/6.0.1": {},
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -3289,7 +3296,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -4073,12 +4080,12 @@
       "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
       "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
-    "Google.Protobuf/3.31.1": {
+    "Google.Protobuf/3.34.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gSnJbUmGiOTdWddPhqzrEscHq9Ls6sqRDPB9WptckyjTUyx70JOOAaDLkFff8gManZNN3hllQ4aQInnQyq/Z/A==",
-      "path": "google.protobuf/3.31.1",
-      "hashPath": "google.protobuf.3.31.1.nupkg.sha512"
+      "sha512": "sha512-212vdYxRuVopGE5bess6Jg5oXWyizA6hcLPTI7G+qA4PthQEvfeof3njT+7VSY5v/+O0P22xTydiP5fSJJpGEA==",
+      "path": "google.protobuf/3.34.1",
+      "hashPath": "google.protobuf.3.34.1.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -4101,19 +4108,19 @@
       "path": "grpc.aspnetcore.server.clientfactory/2.49.0",
       "hashPath": "grpc.aspnetcore.server.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.71.0": {
+    "Grpc.Core.Api/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-QquqUC37yxsDzd1QaDRsH2+uuznWPTS8CVE2Yzwl3CvU4geTNkolQXoVN812M2IwT6zpv3jsZRc9ExJFNFslTg==",
-      "path": "grpc.core.api/2.71.0",
-      "hashPath": "grpc.core.api.2.71.0.nupkg.sha512"
+      "sha512": "sha512-cSxC2tdnFdXXuBgIn1pjc4YBx7LXTCp4M0qn+SMBS35VWZY+cEQYLWTBDDhdBH1HzU7BV+ncVZlniGQHMpRJKQ==",
+      "path": "grpc.core.api/2.76.0",
+      "hashPath": "grpc.core.api.2.76.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.71.0": {
+    "Grpc.Net.Client/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U1vr20r5ngoT9nlb7wejF28EKN+taMhJsV9XtK9MkiepTZwnKxxiarriiMfCHuDAfPUm9XUjFMn/RIuJ4YY61w==",
-      "path": "grpc.net.client/2.71.0",
-      "hashPath": "grpc.net.client.2.71.0.nupkg.sha512"
+      "sha512": "sha512-K1oldmqw2+Gn69nGRzZLhqSiUZwelX1GrBu/cUl9wNf1C0uB61vFS6JcxUUv9P8VoUJhFsmV44JA6lI2EUt4xw==",
+      "path": "grpc.net.client/2.76.0",
+      "hashPath": "grpc.net.client.2.76.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4122,19 +4129,19 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.71.0": {
+    "Grpc.Net.Common/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v0c8R97TwRYwNXlC8GyRXwYTCNufpDfUtj9la+wUrZFzVWkFJuNAltU+c0yI3zu0jl54k7en6u2WKgZgd57r2Q==",
-      "path": "grpc.net.common/2.71.0",
-      "hashPath": "grpc.net.common.2.71.0.nupkg.sha512"
+      "sha512": "sha512-bZpiMVYgvpB44/wBh1RotrkqC7bg2FOasLri2GhR3hMKyzsiTxCoDE49YjPrJeFc4RW0wS8u+EInI09sjxVFRA==",
+      "path": "grpc.net.common/2.76.0",
+      "hashPath": "grpc.net.common.2.76.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.72.0": {
+    "Grpc.Tools/2.78.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-BCiuQ03EYjLHCo9hqZmY5barsz5vvcz/+/ICt5wCbukaePHZmMPDGelKlkxWx3q+f5xOMNHa9zXQ2N6rQZ4B+w==",
-      "path": "grpc.tools/2.72.0",
-      "hashPath": "grpc.tools.2.72.0.nupkg.sha512"
+      "sha512": "sha512-6jPG2gHon+w2PczW8jjrCRnW/g9eEfCdd7aK6mDooptWtuPsV3ZxAwKKEx7LGEDVoT4c2SViRl8Yu3L1XiWIIg==",
+      "path": "grpc.tools/2.78.0",
+      "hashPath": "grpc.tools.2.78.0.nupkg.sha512"
     },
     "K4os.Compression.LZ4/1.3.8": {
       "type": "package",
@@ -4444,26 +4451,26 @@
       "path": "microsoft.azure.cosmos/3.56.0",
       "hashPath": "microsoft.azure.cosmos.3.56.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.10.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sQVeYEvnLmTxa9RAsHZw3Q81kOCOVUpfY/dFF/zRFosvYyuZRzHXmsgWx0Pw23gZMGa6KidxM7GO0nw499sR/w==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.10.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.10.0.nupkg.sha512"
+      "sha512": "sha512-e2Y0hqpzWFXLYuA/E1Cgg2ZUZgvTcxdw6q8Viw0nHsrvb2Jr6Gewd3KvoivEOv4dYFThO2SLRDeAI9uiwAPuug==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.8.3": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yXxVQ0Exfgh9o3fCsY+oZZLfwogdfUOWuA+xixY+UgSlfHqMCtbV/NFHVRPEr0iuaXD99U8nB9R+Z/ndxr0Xlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.8.3",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.8.3.nupkg.sha512"
+      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.7.1": {
+    "Microsoft.Azure.DurableTask.Core/3.8.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OGBnNs+bqrht4Rs9Uc6LB6GHTwBpoBOu0l5cWcQJwLmeGwRWZbnXGXR8t8tkZJt6ERK8KHt3XI8jXvao2gEOYg==",
-      "path": "microsoft.azure.durabletask.core/3.7.1",
-      "hashPath": "microsoft.azure.durabletask.core.3.7.1.nupkg.sha512"
+      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
+      "path": "microsoft.azure.durabletask.core/3.8.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4493,12 +4500,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.3.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UawFOLwFDXXDFQDcs1Cc8VO9ZHmlK3tOtdyze2y7BvRR5GsWhI7RrhzIycay3BxGW9asZ3k8mrvpQUnU+NLjig==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.3.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.3.0.nupkg.sha512"
+      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
@@ -4556,12 +4563,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aP5rAmaBbHgmkK9wAH/+KbDFkBvZTmdrAuZga+9R7XjU/jhCPZ7UXIpVIxws0CW2fmO9vmAiJyStGqyTlqOHow==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.14.0.nupkg.sha512"
+      "sha512": "sha512-2YqtkatW4jYcI9KbT+93lvd+LSLuSlFJoGdKZVT12LMaXF4NKVMPOquYlo7LEHEbBXl2lUkmYuWu34M8fYQ3fg==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -4570,12 +4577,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.3": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-75wrso+sAx2cisbHrY/la7cOc50qhLSVQdpZIYBYZErH7QKduud5aQNML1MvTMNJXeuoTnHhY7HavtVO2AkF/w==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.3.nupkg.sha512"
+      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4584,12 +4591,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.5.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ocFoKu8bzxpvIOami4Jz9PrsGSjumlSk3gUBb6dGryatfytrhrITNQlJ76y8sjqzVT8MNZDRD73ffeZMQOBBWw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.5.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.5.0.nupkg.sha512"
+      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4675,12 +4682,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.527": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.536": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-osb4Fq+hzCG6uZCMt8PsPMSx7Tb5W/ROv8D5LoTiZxCxmiN0PtqOehsEs18Fxq8BpmKOCltNEvu/7wVdwvRZsw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.527",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.527.nupkg.sha512"
+      "sha512": "sha512-fXwh/mvdTMZy3+i3UZgr9vl7RqwiT5I3p8Q5I5WCFjFyCTSjPZXw7Rt3hYK5rrF9ovQdP1HNgZmoCbVvMnn9hg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.536",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.536.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.7": {
       "type": "package",
@@ -4717,12 +4724,12 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.0": {
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-F3aQcjqoeDLbr2gfhrlTuDnA+6pJ9liqe/+XDqU7JRm2LkeRt8n85yJAhxSiRQOttPAzgcLhFEpAoKWdhgg8zA==",
-      "path": "microsoft.azure.webjobs.extensions.webpubsub/1.10.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.webpubsub.1.10.0.nupkg.sha512"
+      "sha512": "sha512-Dt+8xRNbl2ElmyQZIuAhR+MeFHzQD0ZnCfozc1i7Q8mcKPOzXEL31XKUD/s3rn7nyQlgzcxJSw8iJcFEBYUliQ==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsub/1.10.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsub.1.10.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
@@ -4766,12 +4773,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.0.nupkg.sha512"
+      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4808,61 +4815,61 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Abstractions/1.16.2": {
+    "Microsoft.DurableTask.Abstractions/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-MgpAziJGidtST4CAX6F2dpVEl1L6ZdQpSGqsD6LrW8lai4EmJIysEutaGlHC+F+YV05VEaWVrcoyCQwZvtQXXQ==",
-      "path": "microsoft.durabletask.abstractions/1.16.2",
-      "hashPath": "microsoft.durabletask.abstractions.1.16.2.nupkg.sha512"
+      "sha512": "sha512-TYaadlos7wg8O3SPlWDE7NhPo6oh5EMGe929LmEZouZSv+oX4kR96Vp7PdxyjSIa5Z1OtgNlz28L6fgSkpVpmQ==",
+      "path": "microsoft.durabletask.abstractions/1.24.2",
+      "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.5.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-QlCVFwZmlQlVivujnWbOb8Zh5jZyYV8v+R32qhf9evGD4p3jzwQl3BnoGfI9bqDq1GkxpCIOuMZ43Cdx+8IC2w==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.5.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.5.0.nupkg.sha512"
+      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.5.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWG8soxc1r7qMWPNmxAM+dkMMTn+3QMT2e0N/qWlk1XkwnKPwaPxJpsrtpqGdJOmrT1l3gUrmch5iTCEgBgPUw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.5.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.5.0.nupkg.sha512"
+      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Client/1.16.2": {
+    "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uUXplwwrfXKcy6Z/AZoZ0A9doj937B5sYA7YwQeR92wgywS5yj5hM5mNoTIJOczYiNDQFhnznK8XmK8NVAyd3A==",
-      "path": "microsoft.durabletask.client/1.16.2",
-      "hashPath": "microsoft.durabletask.client.1.16.2.nupkg.sha512"
+      "sha512": "sha512-4UGV8cpTQmuYR0HgHwIPDXwxpqxCVVYdDjUSlzMlDBtS/3GZLOQRED80W3xmsJ3GkRaNHmOotesLHTvdTl5WOg==",
+      "path": "microsoft.durabletask.client/1.24.2",
+      "hashPath": "microsoft.durabletask.client.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Client.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Client.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zb84NRgs2N1oAUGU1EpABsJXqgstGZA+QBMEghgMNDIaNRy6jpy6s0B5PcXxCZXJSGUfLMlpRkAW0h+1q41PtA==",
-      "path": "microsoft.durabletask.client.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.client.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-JaMmDFVT9A3f5tpT9pjnSeFSrXcebHpEvE4kvfbIHnCkYFG9fT2gg7A0Cv7Uc0DH19jiPunrbthPZZMunB0JmQ==",
+      "path": "microsoft.durabletask.client.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.client.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.16.2": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GE/PPaqshyfu5N1tYExIS+XYzG58xFTgNVP/LZ6t1sY162AQIjWY2fkOv+7GltOv2D+NcMx7c8cL+kG/opZnfA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads/1.16.2",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.16.2.nupkg.sha512"
+      "sha512": "sha512-EHmVruAJa0JYk6f7cGDZw/91vuDpypGU9C8hfFwzSpHIYmcbuz+c/eXcrHPv6fVzmTUAbDcbm6DicWUs0CmhIQ==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.5.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-algMPOHB24J82jKV/D3Uh/a6LsJyy6tnRkI6rZ4fgBDJyHXcFBqE9eR5G69kGZC8IVDle3DWkXAkjHyfEX9CcA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.5.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.5.0.nupkg.sha512"
+      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Ks/fxgIwK7vJcJzCJk5YjUWABNaNY2qqsHIbeAleZTLPp/IcHX2eEhP343mfkNUuEIefavnX60rnV2hmKVH9EQ==",
-      "path": "microsoft.durabletask.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-2dFlq58m9AKm9f8NQAQCkOmF9QzMh3AmITKptT8KSrpG8t/C0s3pMGuQQrPRks7WojWGJRW0AU/iKNMvTa+l7A==",
+      "path": "microsoft.durabletask.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
     "Microsoft.DurableTask.SqlServer/1.6.0": {
       "type": "package",
@@ -4878,19 +4885,19 @@
       "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
       "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Worker/1.16.2": {
+    "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zEygMgBX8Me2cyrQTbYZYHIyAeXHvC0vwNzoLzZvwkMVTaxfqAabNS8ekkHnIfChDBaAE21gKtBo9g1FscXgBg==",
-      "path": "microsoft.durabletask.worker/1.16.2",
-      "hashPath": "microsoft.durabletask.worker.1.16.2.nupkg.sha512"
+      "sha512": "sha512-dnYZRFlI0avNhmDEM2nzEWAOU650MtL/lyte96PNBavwU1Y70Xr6HZS6eE7nhyCqAQjmYgkgYhKxH2oOL22YdQ==",
+      "path": "microsoft.durabletask.worker/1.24.2",
+      "hashPath": "microsoft.durabletask.worker.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Worker.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Worker.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1md6VadF5mwnoL8XvfOB96sCu5eQSs7inAvhufKWZ7ta21NQHyjsY9Tb9tKYK2BGlwUKHO366OlRWvbJnN2LFA==",
-      "path": "microsoft.durabletask.worker.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.worker.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-vh1GHwREAPQuOIXIVlCIho2uaKqCQT+7mg7LFygYK7lUh4Bs+oJV7FgKIko+fpC7qKIh5SrG9ncAZiwC9skkaw==",
+      "path": "microsoft.durabletask.worker.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.worker.grpc.1.24.2.nupkg.sha512"
     },
     "Microsoft.Extensions.AI.Abstractions/9.10.0": {
       "type": "package",
@@ -4906,19 +4913,19 @@
       "path": "microsoft.extensions.azure/1.13.1",
       "hashPath": "microsoft.extensions.azure.1.13.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Caching.Abstractions/6.0.1": {
+    "Microsoft.Extensions.Caching.Abstractions/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zEtKmOJ3sZ9YxRgvgLtoQsqO069Kqp0aC6Ai+DkyE5uahtu1ynvuoDVFQgyyhVcJWnxCzZHax/3AodvAx2mhjA==",
-      "path": "microsoft.extensions.caching.abstractions/6.0.1",
-      "hashPath": "microsoft.extensions.caching.abstractions.6.0.1.nupkg.sha512"
+      "sha512": "sha512-3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+      "path": "microsoft.extensions.caching.abstractions/8.0.0",
+      "hashPath": "microsoft.extensions.caching.abstractions.8.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Caching.Memory/6.0.3": {
+    "Microsoft.Extensions.Caching.Memory/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GVNNcHoPDEUn4OQiBBGs5mE6nX7BA+LeQId9NeA+gB8xcbDUmFPAl8Er2ixNLbn4ffFr8t5jfMwdxgFG66k7BA==",
-      "path": "microsoft.extensions.caching.memory/6.0.3",
-      "hashPath": "microsoft.extensions.caching.memory.6.0.3.nupkg.sha512"
+      "sha512": "sha512-HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+      "path": "microsoft.extensions.caching.memory/8.0.1",
+      "hashPath": "microsoft.extensions.caching.memory.8.0.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/8.0.0": {
       "type": "package",
@@ -4983,12 +4990,12 @@
       "path": "microsoft.extensions.dependencyinjection/8.0.1",
       "hashPath": "microsoft.extensions.dependencyinjection.8.0.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
+      "sha512": "sha512-Tr74eP0oQ3AyC24ch17N8PuEkrPbD0JqIfENCYqmgKYNOmL8wQKzLJu3ObxTUDrjnn4rHoR1qKa37/eQyHmCDA==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/9.0.1",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.9.0.1.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5536,12 +5543,12 @@
       "path": "system.collections.concurrent/4.3.0",
       "hashPath": "system.collections.concurrent.4.3.0.nupkg.sha512"
     },
-    "System.Collections.Immutable/6.0.1": {
+    "System.Collections.Immutable/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Cc+SfP+jyCmA1TnRnDA7cRZy5jbLyWodfuUJKDJ+PJZBwWkv8szz+ztSCHAonqnL01DRaHaS2ptc4bYIEdgvWw==",
-      "path": "system.collections.immutable/6.0.1",
-      "hashPath": "system.collections.immutable.6.0.1.nupkg.sha512"
+      "sha512": "sha512-AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
+      "path": "system.collections.immutable/8.0.0",
+      "hashPath": "system.collections.immutable.8.0.0.nupkg.sha512"
     },
     "System.Collections.NonGeneric/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -11,11 +11,11 @@
         "dependencies": {
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.3.6",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.3.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.14.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.15.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
           "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
@@ -26,13 +26,13 @@
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.527",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.536",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Tables": "1.4.0",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.10.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.10.1",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
           "Microsoft.IdentityModel.JsonWebTokens": "8.14.0",
@@ -63,7 +63,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -155,7 +155,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -327,7 +327,7 @@
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
@@ -338,24 +338,24 @@
           }
         }
       },
-      "Google.Protobuf/3.31.1": {
+      "Google.Protobuf/3.34.1": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.31.1.0",
-            "fileVersion": "3.31.1.0"
+            "assemblyVersion": "3.34.1.0",
+            "fileVersion": "3.34.1.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.72.0"
+          "Grpc.Tools": "2.78.0"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.71.0"
+          "Grpc.Net.Common": "2.76.0"
         },
         "runtime": {
           "lib/net7.0/Grpc.AspNetCore.Server.dll": {
@@ -376,29 +376,29 @@
           }
         }
       },
-      "Grpc.Core.Api/2.71.0": {
+      "Grpc.Core.Api/2.76.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.71.0": {
+      "Grpc.Net.Client/2.76.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.71.0",
+          "Grpc.Net.Common": "2.76.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         },
         "runtime": {
           "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.71.0",
+          "Grpc.Net.Client": "2.76.0",
           "Microsoft.Extensions.Http": "3.1.32"
         },
         "runtime": {
@@ -408,18 +408,18 @@
           }
         }
       },
-      "Grpc.Net.Common/2.71.0": {
+      "Grpc.Net.Common/2.76.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.71.0"
+          "Grpc.Core.Api": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
-      "Grpc.Tools/2.72.0": {},
+      "Grpc.Tools/2.78.0": {},
       "K4os.Compression.LZ4/1.3.8": {
         "runtime": {
           "lib/net6.0/K4os.Compression.LZ4.dll": {
@@ -552,7 +552,7 @@
       "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Extensions.Caching.Memory": "6.0.3",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "System.Diagnostics.PerformanceCounter": "4.7.0"
         },
         "runtime": {
@@ -865,10 +865,10 @@
       "Microsoft.Azure.Cosmos/3.56.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "6.0.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Memory": "4.6.0",
@@ -913,36 +913,36 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.10.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0"
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.10.0.0",
-            "fileVersion": "0.10.0.4735"
+            "assemblyVersion": "0.11.0.0",
+            "fileVersion": "0.11.0.12085"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.8.3": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.8.0.0",
-            "fileVersion": "2.8.3.4735"
+            "assemblyVersion": "2.9.0.0",
+            "fileVersion": "2.9.0.12085"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.7.1": {
+      "Microsoft.Azure.DurableTask.Core/3.8.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -953,8 +953,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.7.0.0",
-            "fileVersion": "3.7.1.4735"
+            "assemblyVersion": "3.8.0.0",
+            "fileVersion": "3.8.0.12085"
           }
         }
       },
@@ -965,8 +965,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -980,9 +980,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1004,13 +1004,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.3.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1020,8 +1020,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.26160"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.0.26227"
           }
         }
       },
@@ -1146,7 +1146,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.15.0": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.56.0",
@@ -1156,8 +1156,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.14.0.0",
-            "fileVersion": "4.14.0.25611"
+            "assemblyVersion": "4.15.0.0",
+            "fileVersion": "4.15.0.26228"
           }
         }
       },
@@ -1179,13 +1179,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.3": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.10.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.8.3",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1194,30 +1194,30 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.3.0"
+            "fileVersion": "3.12.5.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.5.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Grpc.Tools": "2.72.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Grpc.Tools": "2.78.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
@@ -1313,7 +1313,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1386,7 +1386,7 @@
       "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.17.0": {
         "dependencies": {
           "Azure.Messaging.ServiceBus": "7.20.1",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
           "Microsoft.Extensions.Azure": "1.13.1"
@@ -1416,7 +1416,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.527": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.536": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
@@ -1429,8 +1429,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.527.0",
-            "fileVersion": "3.1.527.0"
+            "assemblyVersion": "3.1.536.0",
+            "fileVersion": "3.1.536.0"
           }
         }
       },
@@ -1494,7 +1494,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.0": {
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.1": {
         "dependencies": {
           "Azure.Messaging.WebPubSub": "1.6.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
@@ -1504,8 +1504,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.WebPubSub.dll": {
-            "assemblyVersion": "1.10.0.0",
-            "fileVersion": "1.1000.26.6801"
+            "assemblyVersion": "1.10.1.0",
+            "fileVersion": "1.1000.126.22602"
           }
         }
       },
@@ -1565,7 +1565,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "6.0.1"
+          "System.Collections.Immutable": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
@@ -1590,11 +1590,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.0",
-            "fileVersion": "10.0.25.52411"
+            "assemblyVersion": "10.0.0.5",
+            "fileVersion": "10.0.526.15411"
           }
         }
       },
@@ -1682,129 +1682,129 @@
           }
         }
       },
-      "Microsoft.DurableTask.Abstractions/1.16.2": {
+      "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "System.Collections.Immutable": "6.0.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Abstractions.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.5.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.5.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.5.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0"
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.Client/1.16.2": {
+      "Microsoft.DurableTask.Client/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Client.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Client.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Client.Grpc/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Client": "1.16.2",
-          "Microsoft.DurableTask.Grpc": "1.16.2",
+          "Microsoft.DurableTask.Client": "1.24.2",
+          "Microsoft.DurableTask.Grpc": "1.24.2",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Client.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Client.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.16.2": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.24.2": {
         "dependencies": {
           "Azure.Storage.Blobs": "12.27.0",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.DurableTask.Client": "1.16.2",
-          "Microsoft.DurableTask.Client.Grpc": "1.16.2",
-          "Microsoft.DurableTask.Worker": "1.16.2",
-          "Microsoft.DurableTask.Worker.Grpc": "1.16.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.DurableTask.Client": "1.24.2",
+          "Microsoft.DurableTask.Client.Grpc": "1.24.2",
+          "Microsoft.DurableTask.Worker": "1.24.2",
+          "Microsoft.DurableTask.Worker.Grpc": "1.24.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47514"
+          "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.5.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Grpc/1.24.2": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0"
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
@@ -1812,7 +1812,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "8.14.0",
           "SemanticVersion": "2.1.0",
@@ -1828,7 +1828,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -1838,31 +1838,32 @@
           }
         }
       },
-      "Microsoft.DurableTask.Worker/1.16.2": {
+      "Microsoft.DurableTask.Worker/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.Extensions.Caching.Memory": "6.0.3",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "Microsoft.Extensions.Options": "8.0.2",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Worker.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Worker.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Worker.Grpc/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.DurableTask.Grpc": "1.16.2",
-          "Microsoft.DurableTask.Worker": "1.16.2"
+          "Google.Protobuf": "3.34.1",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.DurableTask.Grpc": "1.24.2",
+          "Microsoft.DurableTask.Worker": "1.24.2"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Worker.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Worker.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
@@ -1881,7 +1882,7 @@
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
@@ -1893,18 +1894,24 @@
           }
         }
       },
-      "Microsoft.Extensions.Caching.Abstractions/6.0.1": {
+      "Microsoft.Extensions.Caching.Abstractions/8.0.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.Extensions.Caching.Memory/6.0.3": {
+      "Microsoft.Extensions.Caching.Memory/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "6.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.Caching.Memory.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
         }
       },
       "Microsoft.Extensions.Configuration/8.0.0": {
@@ -1986,7 +1993,7 @@
       },
       "Microsoft.Extensions.DependencyInjection/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.DependencyInjection.dll": {
@@ -1995,11 +2002,11 @@
           }
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+      "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.1": {
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.1024.46610"
+            "assemblyVersion": "9.0.0.0",
+            "fileVersion": "9.0.124.61010"
           }
         }
       },
@@ -2033,7 +2040,7 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
@@ -2067,7 +2074,7 @@
           "Microsoft.Extensions.Configuration.Json": "8.0.1",
           "Microsoft.Extensions.Configuration.UserSecrets": "8.0.1",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Diagnostics": "8.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
@@ -2091,7 +2098,7 @@
       "Microsoft.Extensions.Hosting.Abstractions/8.0.1": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
@@ -2105,7 +2112,7 @@
       },
       "Microsoft.Extensions.Http/3.1.32": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -2125,7 +2132,7 @@
       },
       "Microsoft.Extensions.Logging.Abstractions/8.0.3": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.Logging.Abstractions.dll": {
@@ -2151,7 +2158,7 @@
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2166,7 +2173,7 @@
       },
       "Microsoft.Extensions.Logging.Console/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Logging.Configuration": "8.0.1",
@@ -2181,7 +2188,7 @@
       },
       "Microsoft.Extensions.Logging.Debug/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         },
@@ -2194,7 +2201,7 @@
       },
       "Microsoft.Extensions.Logging.EventLog/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2209,7 +2216,7 @@
       },
       "Microsoft.Extensions.Logging.EventSource/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2232,7 +2239,7 @@
       },
       "Microsoft.Extensions.Options/8.0.2": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Primitives": "8.0.0"
         },
         "runtime": {
@@ -2246,7 +2253,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -2529,7 +2536,7 @@
       "MySql.Data/9.0.0": {
         "dependencies": {
           "BouncyCastle.Cryptography": "2.3.1",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "K4os.Compression.LZ4.Streams": "1.3.8",
           "System.Buffers": "4.6.0",
           "System.Configuration.ConfigurationManager": "8.0.1",
@@ -2914,7 +2921,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/6.0.1": {},
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -3195,7 +3202,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3985,12 +3992,12 @@
       "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
       "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
-    "Google.Protobuf/3.31.1": {
+    "Google.Protobuf/3.34.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gSnJbUmGiOTdWddPhqzrEscHq9Ls6sqRDPB9WptckyjTUyx70JOOAaDLkFff8gManZNN3hllQ4aQInnQyq/Z/A==",
-      "path": "google.protobuf/3.31.1",
-      "hashPath": "google.protobuf.3.31.1.nupkg.sha512"
+      "sha512": "sha512-212vdYxRuVopGE5bess6Jg5oXWyizA6hcLPTI7G+qA4PthQEvfeof3njT+7VSY5v/+O0P22xTydiP5fSJJpGEA==",
+      "path": "google.protobuf/3.34.1",
+      "hashPath": "google.protobuf.3.34.1.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -4013,19 +4020,19 @@
       "path": "grpc.aspnetcore.server.clientfactory/2.49.0",
       "hashPath": "grpc.aspnetcore.server.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.71.0": {
+    "Grpc.Core.Api/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-QquqUC37yxsDzd1QaDRsH2+uuznWPTS8CVE2Yzwl3CvU4geTNkolQXoVN812M2IwT6zpv3jsZRc9ExJFNFslTg==",
-      "path": "grpc.core.api/2.71.0",
-      "hashPath": "grpc.core.api.2.71.0.nupkg.sha512"
+      "sha512": "sha512-cSxC2tdnFdXXuBgIn1pjc4YBx7LXTCp4M0qn+SMBS35VWZY+cEQYLWTBDDhdBH1HzU7BV+ncVZlniGQHMpRJKQ==",
+      "path": "grpc.core.api/2.76.0",
+      "hashPath": "grpc.core.api.2.76.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.71.0": {
+    "Grpc.Net.Client/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U1vr20r5ngoT9nlb7wejF28EKN+taMhJsV9XtK9MkiepTZwnKxxiarriiMfCHuDAfPUm9XUjFMn/RIuJ4YY61w==",
-      "path": "grpc.net.client/2.71.0",
-      "hashPath": "grpc.net.client.2.71.0.nupkg.sha512"
+      "sha512": "sha512-K1oldmqw2+Gn69nGRzZLhqSiUZwelX1GrBu/cUl9wNf1C0uB61vFS6JcxUUv9P8VoUJhFsmV44JA6lI2EUt4xw==",
+      "path": "grpc.net.client/2.76.0",
+      "hashPath": "grpc.net.client.2.76.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4034,19 +4041,19 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.71.0": {
+    "Grpc.Net.Common/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v0c8R97TwRYwNXlC8GyRXwYTCNufpDfUtj9la+wUrZFzVWkFJuNAltU+c0yI3zu0jl54k7en6u2WKgZgd57r2Q==",
-      "path": "grpc.net.common/2.71.0",
-      "hashPath": "grpc.net.common.2.71.0.nupkg.sha512"
+      "sha512": "sha512-bZpiMVYgvpB44/wBh1RotrkqC7bg2FOasLri2GhR3hMKyzsiTxCoDE49YjPrJeFc4RW0wS8u+EInI09sjxVFRA==",
+      "path": "grpc.net.common/2.76.0",
+      "hashPath": "grpc.net.common.2.76.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.72.0": {
+    "Grpc.Tools/2.78.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-BCiuQ03EYjLHCo9hqZmY5barsz5vvcz/+/ICt5wCbukaePHZmMPDGelKlkxWx3q+f5xOMNHa9zXQ2N6rQZ4B+w==",
-      "path": "grpc.tools/2.72.0",
-      "hashPath": "grpc.tools.2.72.0.nupkg.sha512"
+      "sha512": "sha512-6jPG2gHon+w2PczW8jjrCRnW/g9eEfCdd7aK6mDooptWtuPsV3ZxAwKKEx7LGEDVoT4c2SViRl8Yu3L1XiWIIg==",
+      "path": "grpc.tools/2.78.0",
+      "hashPath": "grpc.tools.2.78.0.nupkg.sha512"
     },
     "K4os.Compression.LZ4/1.3.8": {
       "type": "package",
@@ -4356,26 +4363,26 @@
       "path": "microsoft.azure.cosmos/3.56.0",
       "hashPath": "microsoft.azure.cosmos.3.56.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.10.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sQVeYEvnLmTxa9RAsHZw3Q81kOCOVUpfY/dFF/zRFosvYyuZRzHXmsgWx0Pw23gZMGa6KidxM7GO0nw499sR/w==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.10.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.10.0.nupkg.sha512"
+      "sha512": "sha512-e2Y0hqpzWFXLYuA/E1Cgg2ZUZgvTcxdw6q8Viw0nHsrvb2Jr6Gewd3KvoivEOv4dYFThO2SLRDeAI9uiwAPuug==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.8.3": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yXxVQ0Exfgh9o3fCsY+oZZLfwogdfUOWuA+xixY+UgSlfHqMCtbV/NFHVRPEr0iuaXD99U8nB9R+Z/ndxr0Xlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.8.3",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.8.3.nupkg.sha512"
+      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.7.1": {
+    "Microsoft.Azure.DurableTask.Core/3.8.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OGBnNs+bqrht4Rs9Uc6LB6GHTwBpoBOu0l5cWcQJwLmeGwRWZbnXGXR8t8tkZJt6ERK8KHt3XI8jXvao2gEOYg==",
-      "path": "microsoft.azure.durabletask.core/3.7.1",
-      "hashPath": "microsoft.azure.durabletask.core.3.7.1.nupkg.sha512"
+      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
+      "path": "microsoft.azure.durabletask.core/3.8.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4405,12 +4412,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.3.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UawFOLwFDXXDFQDcs1Cc8VO9ZHmlK3tOtdyze2y7BvRR5GsWhI7RrhzIycay3BxGW9asZ3k8mrvpQUnU+NLjig==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.3.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.3.0.nupkg.sha512"
+      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
@@ -4468,12 +4475,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aP5rAmaBbHgmkK9wAH/+KbDFkBvZTmdrAuZga+9R7XjU/jhCPZ7UXIpVIxws0CW2fmO9vmAiJyStGqyTlqOHow==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.14.0.nupkg.sha512"
+      "sha512": "sha512-2YqtkatW4jYcI9KbT+93lvd+LSLuSlFJoGdKZVT12LMaXF4NKVMPOquYlo7LEHEbBXl2lUkmYuWu34M8fYQ3fg==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -4482,12 +4489,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.3": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-75wrso+sAx2cisbHrY/la7cOc50qhLSVQdpZIYBYZErH7QKduud5aQNML1MvTMNJXeuoTnHhY7HavtVO2AkF/w==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.3.nupkg.sha512"
+      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4496,12 +4503,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.5.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ocFoKu8bzxpvIOami4Jz9PrsGSjumlSk3gUBb6dGryatfytrhrITNQlJ76y8sjqzVT8MNZDRD73ffeZMQOBBWw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.5.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.5.0.nupkg.sha512"
+      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4587,12 +4594,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.527": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.536": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-osb4Fq+hzCG6uZCMt8PsPMSx7Tb5W/ROv8D5LoTiZxCxmiN0PtqOehsEs18Fxq8BpmKOCltNEvu/7wVdwvRZsw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.527",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.527.nupkg.sha512"
+      "sha512": "sha512-fXwh/mvdTMZy3+i3UZgr9vl7RqwiT5I3p8Q5I5WCFjFyCTSjPZXw7Rt3hYK5rrF9ovQdP1HNgZmoCbVvMnn9hg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.536",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.536.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.7": {
       "type": "package",
@@ -4629,12 +4636,12 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.0": {
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-F3aQcjqoeDLbr2gfhrlTuDnA+6pJ9liqe/+XDqU7JRm2LkeRt8n85yJAhxSiRQOttPAzgcLhFEpAoKWdhgg8zA==",
-      "path": "microsoft.azure.webjobs.extensions.webpubsub/1.10.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.webpubsub.1.10.0.nupkg.sha512"
+      "sha512": "sha512-Dt+8xRNbl2ElmyQZIuAhR+MeFHzQD0ZnCfozc1i7Q8mcKPOzXEL31XKUD/s3rn7nyQlgzcxJSw8iJcFEBYUliQ==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsub/1.10.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsub.1.10.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
@@ -4678,12 +4685,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.0.nupkg.sha512"
+      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4720,61 +4727,61 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Abstractions/1.16.2": {
+    "Microsoft.DurableTask.Abstractions/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-MgpAziJGidtST4CAX6F2dpVEl1L6ZdQpSGqsD6LrW8lai4EmJIysEutaGlHC+F+YV05VEaWVrcoyCQwZvtQXXQ==",
-      "path": "microsoft.durabletask.abstractions/1.16.2",
-      "hashPath": "microsoft.durabletask.abstractions.1.16.2.nupkg.sha512"
+      "sha512": "sha512-TYaadlos7wg8O3SPlWDE7NhPo6oh5EMGe929LmEZouZSv+oX4kR96Vp7PdxyjSIa5Z1OtgNlz28L6fgSkpVpmQ==",
+      "path": "microsoft.durabletask.abstractions/1.24.2",
+      "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.5.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-QlCVFwZmlQlVivujnWbOb8Zh5jZyYV8v+R32qhf9evGD4p3jzwQl3BnoGfI9bqDq1GkxpCIOuMZ43Cdx+8IC2w==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.5.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.5.0.nupkg.sha512"
+      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.5.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWG8soxc1r7qMWPNmxAM+dkMMTn+3QMT2e0N/qWlk1XkwnKPwaPxJpsrtpqGdJOmrT1l3gUrmch5iTCEgBgPUw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.5.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.5.0.nupkg.sha512"
+      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Client/1.16.2": {
+    "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uUXplwwrfXKcy6Z/AZoZ0A9doj937B5sYA7YwQeR92wgywS5yj5hM5mNoTIJOczYiNDQFhnznK8XmK8NVAyd3A==",
-      "path": "microsoft.durabletask.client/1.16.2",
-      "hashPath": "microsoft.durabletask.client.1.16.2.nupkg.sha512"
+      "sha512": "sha512-4UGV8cpTQmuYR0HgHwIPDXwxpqxCVVYdDjUSlzMlDBtS/3GZLOQRED80W3xmsJ3GkRaNHmOotesLHTvdTl5WOg==",
+      "path": "microsoft.durabletask.client/1.24.2",
+      "hashPath": "microsoft.durabletask.client.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Client.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Client.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zb84NRgs2N1oAUGU1EpABsJXqgstGZA+QBMEghgMNDIaNRy6jpy6s0B5PcXxCZXJSGUfLMlpRkAW0h+1q41PtA==",
-      "path": "microsoft.durabletask.client.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.client.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-JaMmDFVT9A3f5tpT9pjnSeFSrXcebHpEvE4kvfbIHnCkYFG9fT2gg7A0Cv7Uc0DH19jiPunrbthPZZMunB0JmQ==",
+      "path": "microsoft.durabletask.client.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.client.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.16.2": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GE/PPaqshyfu5N1tYExIS+XYzG58xFTgNVP/LZ6t1sY162AQIjWY2fkOv+7GltOv2D+NcMx7c8cL+kG/opZnfA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads/1.16.2",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.16.2.nupkg.sha512"
+      "sha512": "sha512-EHmVruAJa0JYk6f7cGDZw/91vuDpypGU9C8hfFwzSpHIYmcbuz+c/eXcrHPv6fVzmTUAbDcbm6DicWUs0CmhIQ==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.5.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-algMPOHB24J82jKV/D3Uh/a6LsJyy6tnRkI6rZ4fgBDJyHXcFBqE9eR5G69kGZC8IVDle3DWkXAkjHyfEX9CcA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.5.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.5.0.nupkg.sha512"
+      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Ks/fxgIwK7vJcJzCJk5YjUWABNaNY2qqsHIbeAleZTLPp/IcHX2eEhP343mfkNUuEIefavnX60rnV2hmKVH9EQ==",
-      "path": "microsoft.durabletask.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-2dFlq58m9AKm9f8NQAQCkOmF9QzMh3AmITKptT8KSrpG8t/C0s3pMGuQQrPRks7WojWGJRW0AU/iKNMvTa+l7A==",
+      "path": "microsoft.durabletask.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
     "Microsoft.DurableTask.SqlServer/1.6.0": {
       "type": "package",
@@ -4790,19 +4797,19 @@
       "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
       "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Worker/1.16.2": {
+    "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zEygMgBX8Me2cyrQTbYZYHIyAeXHvC0vwNzoLzZvwkMVTaxfqAabNS8ekkHnIfChDBaAE21gKtBo9g1FscXgBg==",
-      "path": "microsoft.durabletask.worker/1.16.2",
-      "hashPath": "microsoft.durabletask.worker.1.16.2.nupkg.sha512"
+      "sha512": "sha512-dnYZRFlI0avNhmDEM2nzEWAOU650MtL/lyte96PNBavwU1Y70Xr6HZS6eE7nhyCqAQjmYgkgYhKxH2oOL22YdQ==",
+      "path": "microsoft.durabletask.worker/1.24.2",
+      "hashPath": "microsoft.durabletask.worker.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Worker.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Worker.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1md6VadF5mwnoL8XvfOB96sCu5eQSs7inAvhufKWZ7ta21NQHyjsY9Tb9tKYK2BGlwUKHO366OlRWvbJnN2LFA==",
-      "path": "microsoft.durabletask.worker.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.worker.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-vh1GHwREAPQuOIXIVlCIho2uaKqCQT+7mg7LFygYK7lUh4Bs+oJV7FgKIko+fpC7qKIh5SrG9ncAZiwC9skkaw==",
+      "path": "microsoft.durabletask.worker.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.worker.grpc.1.24.2.nupkg.sha512"
     },
     "Microsoft.Extensions.AI.Abstractions/9.10.0": {
       "type": "package",
@@ -4818,19 +4825,19 @@
       "path": "microsoft.extensions.azure/1.13.1",
       "hashPath": "microsoft.extensions.azure.1.13.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Caching.Abstractions/6.0.1": {
+    "Microsoft.Extensions.Caching.Abstractions/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zEtKmOJ3sZ9YxRgvgLtoQsqO069Kqp0aC6Ai+DkyE5uahtu1ynvuoDVFQgyyhVcJWnxCzZHax/3AodvAx2mhjA==",
-      "path": "microsoft.extensions.caching.abstractions/6.0.1",
-      "hashPath": "microsoft.extensions.caching.abstractions.6.0.1.nupkg.sha512"
+      "sha512": "sha512-3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+      "path": "microsoft.extensions.caching.abstractions/8.0.0",
+      "hashPath": "microsoft.extensions.caching.abstractions.8.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Caching.Memory/6.0.3": {
+    "Microsoft.Extensions.Caching.Memory/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GVNNcHoPDEUn4OQiBBGs5mE6nX7BA+LeQId9NeA+gB8xcbDUmFPAl8Er2ixNLbn4ffFr8t5jfMwdxgFG66k7BA==",
-      "path": "microsoft.extensions.caching.memory/6.0.3",
-      "hashPath": "microsoft.extensions.caching.memory.6.0.3.nupkg.sha512"
+      "sha512": "sha512-HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+      "path": "microsoft.extensions.caching.memory/8.0.1",
+      "hashPath": "microsoft.extensions.caching.memory.8.0.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/8.0.0": {
       "type": "package",
@@ -4895,12 +4902,12 @@
       "path": "microsoft.extensions.dependencyinjection/8.0.1",
       "hashPath": "microsoft.extensions.dependencyinjection.8.0.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
+      "sha512": "sha512-Tr74eP0oQ3AyC24ch17N8PuEkrPbD0JqIfENCYqmgKYNOmL8wQKzLJu3ObxTUDrjnn4rHoR1qKa37/eQyHmCDA==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/9.0.1",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.9.0.1.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5616,12 +5623,12 @@
       "path": "system.collections.concurrent/4.3.0",
       "hashPath": "system.collections.concurrent.4.3.0.nupkg.sha512"
     },
-    "System.Collections.Immutable/6.0.1": {
+    "System.Collections.Immutable/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Cc+SfP+jyCmA1TnRnDA7cRZy5jbLyWodfuUJKDJ+PJZBwWkv8szz+ztSCHAonqnL01DRaHaS2ptc4bYIEdgvWw==",
-      "path": "system.collections.immutable/6.0.1",
-      "hashPath": "system.collections.immutable.6.0.1.nupkg.sha512"
+      "sha512": "sha512-AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
+      "path": "system.collections.immutable/8.0.0",
+      "hashPath": "system.collections.immutable.8.0.0.nupkg.sha512"
     },
     "System.Collections.NonGeneric/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -11,11 +11,11 @@
         "dependencies": {
           "Microsoft.AspNetCore.Server.Kestrel.Core": "2.3.6",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.3.0",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.14.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.15.0",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "1.0.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.5.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
           "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
@@ -26,13 +26,13 @@
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.527",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "3.1.536",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Tables": "1.4.0",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
-          "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.10.0",
+          "Microsoft.Azure.WebJobs.Extensions.WebPubSub": "1.10.1",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
           "Microsoft.IdentityModel.JsonWebTokens": "8.14.0",
@@ -63,7 +63,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -155,7 +155,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -327,7 +327,7 @@
         "dependencies": {
           "Confluent.Kafka": "2.4.0",
           "Confluent.SchemaRegistry": "2.4.0",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "System.Net.NameResolution": "4.3.0",
           "System.Net.Sockets": "4.3.0"
         },
@@ -338,24 +338,24 @@
           }
         }
       },
-      "Google.Protobuf/3.31.1": {
+      "Google.Protobuf/3.34.1": {
         "runtime": {
           "lib/net5.0/Google.Protobuf.dll": {
-            "assemblyVersion": "3.31.1.0",
-            "fileVersion": "3.31.1.0"
+            "assemblyVersion": "3.34.1.0",
+            "fileVersion": "3.34.1.0"
           }
         }
       },
       "Grpc.AspNetCore/2.49.0": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "Grpc.AspNetCore.Server.ClientFactory": "2.49.0",
-          "Grpc.Tools": "2.72.0"
+          "Grpc.Tools": "2.78.0"
         }
       },
       "Grpc.AspNetCore.Server/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.71.0"
+          "Grpc.Net.Common": "2.76.0"
         },
         "runtime": {
           "lib/net7.0/Grpc.AspNetCore.Server.dll": {
@@ -376,29 +376,29 @@
           }
         }
       },
-      "Grpc.Core.Api/2.71.0": {
+      "Grpc.Core.Api/2.76.0": {
         "runtime": {
           "lib/netstandard2.1/Grpc.Core.Api.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
-      "Grpc.Net.Client/2.71.0": {
+      "Grpc.Net.Client/2.76.0": {
         "dependencies": {
-          "Grpc.Net.Common": "2.71.0",
+          "Grpc.Net.Common": "2.76.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         },
         "runtime": {
           "lib/net8.0/Grpc.Net.Client.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
       "Grpc.Net.ClientFactory/2.49.0": {
         "dependencies": {
-          "Grpc.Net.Client": "2.71.0",
+          "Grpc.Net.Client": "2.76.0",
           "Microsoft.Extensions.Http": "3.1.32"
         },
         "runtime": {
@@ -408,18 +408,18 @@
           }
         }
       },
-      "Grpc.Net.Common/2.71.0": {
+      "Grpc.Net.Common/2.76.0": {
         "dependencies": {
-          "Grpc.Core.Api": "2.71.0"
+          "Grpc.Core.Api": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Grpc.Net.Common.dll": {
             "assemblyVersion": "2.0.0.0",
-            "fileVersion": "2.71.0.0"
+            "fileVersion": "2.76.0.0"
           }
         }
       },
-      "Grpc.Tools/2.72.0": {},
+      "Grpc.Tools/2.78.0": {},
       "K4os.Compression.LZ4/1.3.8": {
         "runtime": {
           "lib/net6.0/K4os.Compression.LZ4.dll": {
@@ -558,7 +558,7 @@
       "Microsoft.ApplicationInsights.PerfCounterCollector/2.21.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Extensions.Caching.Memory": "6.0.3",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "System.Diagnostics.PerformanceCounter": "4.7.0"
         },
         "runtime": {
@@ -871,10 +871,10 @@
       "Microsoft.Azure.Cosmos/3.56.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
-          "System.Collections.Immutable": "6.0.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Configuration.ConfigurationManager": "8.0.1",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Memory": "4.6.0",
@@ -902,36 +902,36 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.ApplicationInsights/0.10.0": {
+      "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0"
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
-            "assemblyVersion": "0.10.0.0",
-            "fileVersion": "0.10.0.4735"
+            "assemblyVersion": "0.11.0.0",
+            "fileVersion": "0.11.0.12085"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.8.3": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
-            "assemblyVersion": "2.8.0.0",
-            "fileVersion": "2.8.3.4735"
+            "assemblyVersion": "2.9.0.0",
+            "fileVersion": "2.9.0.12085"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.7.1": {
+      "Microsoft.Azure.DurableTask.Core/3.8.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -942,8 +942,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.7.0.0",
-            "fileVersion": "3.7.1.4735"
+            "assemblyVersion": "3.8.0.0",
+            "fileVersion": "3.8.0.12085"
           }
         }
       },
@@ -954,8 +954,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -969,9 +969,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -993,13 +993,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.3.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1009,8 +1009,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.3.0.0",
-            "fileVersion": "1.3.0.26160"
+            "assemblyVersion": "1.5.0.0",
+            "fileVersion": "1.5.0.26227"
           }
         }
       },
@@ -1135,7 +1135,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.14.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.15.0": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.56.0",
@@ -1145,8 +1145,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.14.0.0",
-            "fileVersion": "4.14.0.25611"
+            "assemblyVersion": "4.15.0.0",
+            "fileVersion": "4.15.0.26228"
           }
         }
       },
@@ -1168,13 +1168,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.3": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.10.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.8.3",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1183,30 +1183,30 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.3.0"
+            "fileVersion": "3.12.5.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.5.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Grpc.Tools": "2.72.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Grpc.Tools": "2.78.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
@@ -1302,7 +1302,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1375,7 +1375,7 @@
       "Microsoft.Azure.WebJobs.Extensions.ServiceBus/5.17.0": {
         "dependencies": {
           "Azure.Messaging.ServiceBus": "7.20.1",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
           "Microsoft.Extensions.Azure": "1.13.1"
@@ -1405,7 +1405,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.527": {
+      "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.536": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
@@ -1418,8 +1418,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Sql.dll": {
-            "assemblyVersion": "3.1.527.0",
-            "fileVersion": "3.1.527.0"
+            "assemblyVersion": "3.1.536.0",
+            "fileVersion": "3.1.536.0"
           }
         }
       },
@@ -1483,7 +1483,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.0": {
+      "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.1": {
         "dependencies": {
           "Azure.Messaging.WebPubSub": "1.6.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
@@ -1493,8 +1493,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.WebPubSub.dll": {
-            "assemblyVersion": "1.10.0.0",
-            "fileVersion": "1.1000.26.6801"
+            "assemblyVersion": "1.10.1.0",
+            "fileVersion": "1.1000.126.22602"
           }
         }
       },
@@ -1554,7 +1554,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.Collections.Immutable": "6.0.1"
+          "System.Collections.Immutable": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
@@ -1579,11 +1579,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.0",
-            "fileVersion": "10.0.25.52411"
+            "assemblyVersion": "10.0.0.5",
+            "fileVersion": "10.0.526.15411"
           }
         }
       },
@@ -1671,129 +1671,129 @@
           }
         }
       },
-      "Microsoft.DurableTask.Abstractions/1.16.2": {
+      "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "System.Collections.Immutable": "6.0.1",
+          "System.Collections.Immutable": "8.0.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Abstractions.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.5.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.5.0",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.5.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0"
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.Client/1.16.2": {
+      "Microsoft.DurableTask.Client/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Client.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Client.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Client.Grpc/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Client": "1.16.2",
-          "Microsoft.DurableTask.Grpc": "1.16.2",
+          "Microsoft.DurableTask.Client": "1.24.2",
+          "Microsoft.DurableTask.Grpc": "1.24.2",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Client.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Client.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.16.2": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.24.2": {
         "dependencies": {
           "Azure.Storage.Blobs": "12.27.0",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.DurableTask.Client": "1.16.2",
-          "Microsoft.DurableTask.Client.Grpc": "1.16.2",
-          "Microsoft.DurableTask.Worker": "1.16.2",
-          "Microsoft.DurableTask.Worker.Grpc": "1.16.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.DurableTask.Client": "1.24.2",
+          "Microsoft.DurableTask.Client.Grpc": "1.24.2",
+          "Microsoft.DurableTask.Worker": "1.24.2",
+          "Microsoft.DurableTask.Worker.Grpc": "1.24.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47514"
+          "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.5.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.5.0",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.16.2",
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.31253"
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.58242"
           }
         }
       },
-      "Microsoft.DurableTask.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Grpc/1.24.2": {
         "dependencies": {
-          "Google.Protobuf": "3.31.1",
-          "Grpc.Net.Client": "2.71.0"
+          "Google.Protobuf": "3.34.1",
+          "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
@@ -1801,7 +1801,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.7.1",
+          "Microsoft.Azure.DurableTask.Core": "3.8.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "8.14.0",
           "SemanticVersion": "2.1.0",
@@ -1817,7 +1817,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.3",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -1827,31 +1827,32 @@
           }
         }
       },
-      "Microsoft.DurableTask.Worker/1.16.2": {
+      "Microsoft.DurableTask.Worker/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.Extensions.Caching.Memory": "6.0.3",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "Microsoft.Extensions.Options": "8.0.2",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.DurableTask.Worker.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
-      "Microsoft.DurableTask.Worker.Grpc/1.16.2": {
+      "Microsoft.DurableTask.Worker.Grpc/1.24.2": {
         "dependencies": {
-          "Microsoft.DurableTask.Abstractions": "1.16.2",
-          "Microsoft.DurableTask.Grpc": "1.16.2",
-          "Microsoft.DurableTask.Worker": "1.16.2"
+          "Google.Protobuf": "3.34.1",
+          "Microsoft.DurableTask.Abstractions": "1.24.2",
+          "Microsoft.DurableTask.Grpc": "1.24.2",
+          "Microsoft.DurableTask.Worker": "1.24.2"
         },
         "runtime": {
-          "lib/net6.0/Microsoft.DurableTask.Worker.Grpc.dll": {
-            "assemblyVersion": "1.16.2.0",
-            "fileVersion": "1.16.2.47492"
+          "lib/net8.0/Microsoft.DurableTask.Worker.Grpc.dll": {
+            "assemblyVersion": "1.24.2.0",
+            "fileVersion": "1.24.2.14302"
           }
         }
       },
@@ -1870,7 +1871,7 @@
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
@@ -1882,18 +1883,24 @@
           }
         }
       },
-      "Microsoft.Extensions.Caching.Abstractions/6.0.1": {
+      "Microsoft.Extensions.Caching.Abstractions/8.0.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.Extensions.Caching.Memory/6.0.3": {
+      "Microsoft.Extensions.Caching.Memory/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "6.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.Extensions.Caching.Memory.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.1024.46610"
+          }
         }
       },
       "Microsoft.Extensions.Configuration/8.0.0": {
@@ -1975,7 +1982,7 @@
       },
       "Microsoft.Extensions.DependencyInjection/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.DependencyInjection.dll": {
@@ -1984,11 +1991,11 @@
           }
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+      "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.1": {
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.1024.46610"
+            "assemblyVersion": "9.0.0.0",
+            "fileVersion": "9.0.124.61010"
           }
         }
       },
@@ -2022,7 +2029,7 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         },
         "runtime": {
@@ -2056,7 +2063,7 @@
           "Microsoft.Extensions.Configuration.Json": "8.0.1",
           "Microsoft.Extensions.Configuration.UserSecrets": "8.0.1",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Diagnostics": "8.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
@@ -2080,7 +2087,7 @@
       "Microsoft.Extensions.Hosting.Abstractions/8.0.1": {
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.1",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
@@ -2094,7 +2101,7 @@
       },
       "Microsoft.Extensions.Http/3.1.32": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -2114,7 +2121,7 @@
       },
       "Microsoft.Extensions.Logging.Abstractions/8.0.3": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Extensions.Logging.Abstractions.dll": {
@@ -2140,7 +2147,7 @@
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2155,7 +2162,7 @@
       },
       "Microsoft.Extensions.Logging.Console/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Logging.Configuration": "8.0.1",
@@ -2170,7 +2177,7 @@
       },
       "Microsoft.Extensions.Logging.Debug/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
         },
@@ -2183,7 +2190,7 @@
       },
       "Microsoft.Extensions.Logging.EventLog/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2198,7 +2205,7 @@
       },
       "Microsoft.Extensions.Logging.EventSource/8.0.1": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2",
@@ -2221,7 +2228,7 @@
       },
       "Microsoft.Extensions.Options/8.0.2": {
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Primitives": "8.0.0"
         },
         "runtime": {
@@ -2235,7 +2242,7 @@
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
           "Microsoft.Extensions.Configuration.Binder": "8.0.2",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Options": "8.0.2",
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -2518,7 +2525,7 @@
       "MySql.Data/9.0.0": {
         "dependencies": {
           "BouncyCastle.Cryptography": "2.3.1",
-          "Google.Protobuf": "3.31.1",
+          "Google.Protobuf": "3.34.1",
           "K4os.Compression.LZ4.Streams": "1.3.8",
           "System.Buffers": "4.6.0",
           "System.Configuration.ConfigurationManager": "8.0.1",
@@ -2886,7 +2893,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
-      "System.Collections.Immutable/6.0.1": {},
+      "System.Collections.Immutable/8.0.0": {},
       "System.Collections.NonGeneric/4.3.0": {
         "dependencies": {
           "System.Diagnostics.Debug": "4.3.0",
@@ -3167,7 +3174,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.0"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3957,12 +3964,12 @@
       "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
       "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
     },
-    "Google.Protobuf/3.31.1": {
+    "Google.Protobuf/3.34.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-gSnJbUmGiOTdWddPhqzrEscHq9Ls6sqRDPB9WptckyjTUyx70JOOAaDLkFff8gManZNN3hllQ4aQInnQyq/Z/A==",
-      "path": "google.protobuf/3.31.1",
-      "hashPath": "google.protobuf.3.31.1.nupkg.sha512"
+      "sha512": "sha512-212vdYxRuVopGE5bess6Jg5oXWyizA6hcLPTI7G+qA4PthQEvfeof3njT+7VSY5v/+O0P22xTydiP5fSJJpGEA==",
+      "path": "google.protobuf/3.34.1",
+      "hashPath": "google.protobuf.3.34.1.nupkg.sha512"
     },
     "Grpc.AspNetCore/2.49.0": {
       "type": "package",
@@ -3985,19 +3992,19 @@
       "path": "grpc.aspnetcore.server.clientfactory/2.49.0",
       "hashPath": "grpc.aspnetcore.server.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Core.Api/2.71.0": {
+    "Grpc.Core.Api/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-QquqUC37yxsDzd1QaDRsH2+uuznWPTS8CVE2Yzwl3CvU4geTNkolQXoVN812M2IwT6zpv3jsZRc9ExJFNFslTg==",
-      "path": "grpc.core.api/2.71.0",
-      "hashPath": "grpc.core.api.2.71.0.nupkg.sha512"
+      "sha512": "sha512-cSxC2tdnFdXXuBgIn1pjc4YBx7LXTCp4M0qn+SMBS35VWZY+cEQYLWTBDDhdBH1HzU7BV+ncVZlniGQHMpRJKQ==",
+      "path": "grpc.core.api/2.76.0",
+      "hashPath": "grpc.core.api.2.76.0.nupkg.sha512"
     },
-    "Grpc.Net.Client/2.71.0": {
+    "Grpc.Net.Client/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U1vr20r5ngoT9nlb7wejF28EKN+taMhJsV9XtK9MkiepTZwnKxxiarriiMfCHuDAfPUm9XUjFMn/RIuJ4YY61w==",
-      "path": "grpc.net.client/2.71.0",
-      "hashPath": "grpc.net.client.2.71.0.nupkg.sha512"
+      "sha512": "sha512-K1oldmqw2+Gn69nGRzZLhqSiUZwelX1GrBu/cUl9wNf1C0uB61vFS6JcxUUv9P8VoUJhFsmV44JA6lI2EUt4xw==",
+      "path": "grpc.net.client/2.76.0",
+      "hashPath": "grpc.net.client.2.76.0.nupkg.sha512"
     },
     "Grpc.Net.ClientFactory/2.49.0": {
       "type": "package",
@@ -4006,19 +4013,19 @@
       "path": "grpc.net.clientfactory/2.49.0",
       "hashPath": "grpc.net.clientfactory.2.49.0.nupkg.sha512"
     },
-    "Grpc.Net.Common/2.71.0": {
+    "Grpc.Net.Common/2.76.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-v0c8R97TwRYwNXlC8GyRXwYTCNufpDfUtj9la+wUrZFzVWkFJuNAltU+c0yI3zu0jl54k7en6u2WKgZgd57r2Q==",
-      "path": "grpc.net.common/2.71.0",
-      "hashPath": "grpc.net.common.2.71.0.nupkg.sha512"
+      "sha512": "sha512-bZpiMVYgvpB44/wBh1RotrkqC7bg2FOasLri2GhR3hMKyzsiTxCoDE49YjPrJeFc4RW0wS8u+EInI09sjxVFRA==",
+      "path": "grpc.net.common/2.76.0",
+      "hashPath": "grpc.net.common.2.76.0.nupkg.sha512"
     },
-    "Grpc.Tools/2.72.0": {
+    "Grpc.Tools/2.78.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-BCiuQ03EYjLHCo9hqZmY5barsz5vvcz/+/ICt5wCbukaePHZmMPDGelKlkxWx3q+f5xOMNHa9zXQ2N6rQZ4B+w==",
-      "path": "grpc.tools/2.72.0",
-      "hashPath": "grpc.tools.2.72.0.nupkg.sha512"
+      "sha512": "sha512-6jPG2gHon+w2PczW8jjrCRnW/g9eEfCdd7aK6mDooptWtuPsV3ZxAwKKEx7LGEDVoT4c2SViRl8Yu3L1XiWIIg==",
+      "path": "grpc.tools/2.78.0",
+      "hashPath": "grpc.tools.2.78.0.nupkg.sha512"
     },
     "K4os.Compression.LZ4/1.3.8": {
       "type": "package",
@@ -4328,26 +4335,26 @@
       "path": "microsoft.azure.cosmos/3.56.0",
       "hashPath": "microsoft.azure.cosmos.3.56.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.ApplicationInsights/0.10.0": {
+    "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sQVeYEvnLmTxa9RAsHZw3Q81kOCOVUpfY/dFF/zRFosvYyuZRzHXmsgWx0Pw23gZMGa6KidxM7GO0nw499sR/w==",
-      "path": "microsoft.azure.durabletask.applicationinsights/0.10.0",
-      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.10.0.nupkg.sha512"
+      "sha512": "sha512-e2Y0hqpzWFXLYuA/E1Cgg2ZUZgvTcxdw6q8Viw0nHsrvb2Jr6Gewd3KvoivEOv4dYFThO2SLRDeAI9uiwAPuug==",
+      "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
+      "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.8.3": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yXxVQ0Exfgh9o3fCsY+oZZLfwogdfUOWuA+xixY+UgSlfHqMCtbV/NFHVRPEr0iuaXD99U8nB9R+Z/ndxr0Xlw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.8.3",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.8.3.nupkg.sha512"
+      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.7.1": {
+    "Microsoft.Azure.DurableTask.Core/3.8.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OGBnNs+bqrht4Rs9Uc6LB6GHTwBpoBOu0l5cWcQJwLmeGwRWZbnXGXR8t8tkZJt6ERK8KHt3XI8jXvao2gEOYg==",
-      "path": "microsoft.azure.durabletask.core/3.7.1",
-      "hashPath": "microsoft.azure.durabletask.core.3.7.1.nupkg.sha512"
+      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
+      "path": "microsoft.azure.durabletask.core/3.8.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4377,12 +4384,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/1.0.1",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.3.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UawFOLwFDXXDFQDcs1Cc8VO9ZHmlK3tOtdyze2y7BvRR5GsWhI7RrhzIycay3BxGW9asZ3k8mrvpQUnU+NLjig==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.3.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.3.0.nupkg.sha512"
+      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
     },
     "Microsoft.Azure.SignalR/1.29.0": {
       "type": "package",
@@ -4440,12 +4447,12 @@
       "path": "microsoft.azure.webjobs.extensions/3.0.6",
       "hashPath": "microsoft.azure.webjobs.extensions.3.0.6.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.14.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aP5rAmaBbHgmkK9wAH/+KbDFkBvZTmdrAuZga+9R7XjU/jhCPZ7UXIpVIxws0CW2fmO9vmAiJyStGqyTlqOHow==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.14.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.14.0.nupkg.sha512"
+      "sha512": "sha512-2YqtkatW4jYcI9KbT+93lvd+LSLuSlFJoGdKZVT12LMaXF4NKVMPOquYlo7LEHEbBXl2lUkmYuWu34M8fYQ3fg==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/1.0.1": {
       "type": "package",
@@ -4454,12 +4461,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/1.0.1",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.1.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.3": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-75wrso+sAx2cisbHrY/la7cOc50qhLSVQdpZIYBYZErH7QKduud5aQNML1MvTMNJXeuoTnHhY7HavtVO2AkF/w==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.3",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.3.nupkg.sha512"
+      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4468,12 +4475,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.5.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ocFoKu8bzxpvIOami4Jz9PrsGSjumlSk3gUBb6dGryatfytrhrITNQlJ76y8sjqzVT8MNZDRD73ffeZMQOBBWw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.5.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.5.0.nupkg.sha512"
+      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4559,12 +4566,12 @@
       "path": "microsoft.azure.webjobs.extensions.signalrservice/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.signalrservice.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.527": {
+    "Microsoft.Azure.WebJobs.Extensions.Sql/3.1.536": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-osb4Fq+hzCG6uZCMt8PsPMSx7Tb5W/ROv8D5LoTiZxCxmiN0PtqOehsEs18Fxq8BpmKOCltNEvu/7wVdwvRZsw==",
-      "path": "microsoft.azure.webjobs.extensions.sql/3.1.527",
-      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.527.nupkg.sha512"
+      "sha512": "sha512-fXwh/mvdTMZy3+i3UZgr9vl7RqwiT5I3p8Q5I5WCFjFyCTSjPZXw7Rt3hYK5rrF9ovQdP1HNgZmoCbVvMnn9hg==",
+      "path": "microsoft.azure.webjobs.extensions.sql/3.1.536",
+      "hashPath": "microsoft.azure.webjobs.extensions.sql.3.1.536.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Storage/5.3.7": {
       "type": "package",
@@ -4601,12 +4608,12 @@
       "path": "microsoft.azure.webjobs.extensions.twilio/3.0.2",
       "hashPath": "microsoft.azure.webjobs.extensions.twilio.3.0.2.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.0": {
+    "Microsoft.Azure.WebJobs.Extensions.WebPubSub/1.10.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-F3aQcjqoeDLbr2gfhrlTuDnA+6pJ9liqe/+XDqU7JRm2LkeRt8n85yJAhxSiRQOttPAzgcLhFEpAoKWdhgg8zA==",
-      "path": "microsoft.azure.webjobs.extensions.webpubsub/1.10.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.webpubsub.1.10.0.nupkg.sha512"
+      "sha512": "sha512-Dt+8xRNbl2ElmyQZIuAhR+MeFHzQD0ZnCfozc1i7Q8mcKPOzXEL31XKUD/s3rn7nyQlgzcxJSw8iJcFEBYUliQ==",
+      "path": "microsoft.azure.webjobs.extensions.webpubsub/1.10.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.webpubsub.1.10.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Host.Storage/3.0.14": {
       "type": "package",
@@ -4650,12 +4657,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vFuwSLj9QJBbNR0NeNO4YVASUbokxs+i/xbuu8B+Fs4FAZg5QaFa6eGrMaRqTzzNI5tAb97T7BhSxtLckFyiRA==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.0.nupkg.sha512"
+      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -4692,61 +4699,61 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Abstractions/1.16.2": {
+    "Microsoft.DurableTask.Abstractions/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-MgpAziJGidtST4CAX6F2dpVEl1L6ZdQpSGqsD6LrW8lai4EmJIysEutaGlHC+F+YV05VEaWVrcoyCQwZvtQXXQ==",
-      "path": "microsoft.durabletask.abstractions/1.16.2",
-      "hashPath": "microsoft.durabletask.abstractions.1.16.2.nupkg.sha512"
+      "sha512": "sha512-TYaadlos7wg8O3SPlWDE7NhPo6oh5EMGe929LmEZouZSv+oX4kR96Vp7PdxyjSIa5Z1OtgNlz28L6fgSkpVpmQ==",
+      "path": "microsoft.durabletask.abstractions/1.24.2",
+      "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.5.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-QlCVFwZmlQlVivujnWbOb8Zh5jZyYV8v+R32qhf9evGD4p3jzwQl3BnoGfI9bqDq1GkxpCIOuMZ43Cdx+8IC2w==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.5.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.5.0.nupkg.sha512"
+      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.5.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yWG8soxc1r7qMWPNmxAM+dkMMTn+3QMT2e0N/qWlk1XkwnKPwaPxJpsrtpqGdJOmrT1l3gUrmch5iTCEgBgPUw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.5.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.5.0.nupkg.sha512"
+      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Client/1.16.2": {
+    "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uUXplwwrfXKcy6Z/AZoZ0A9doj937B5sYA7YwQeR92wgywS5yj5hM5mNoTIJOczYiNDQFhnznK8XmK8NVAyd3A==",
-      "path": "microsoft.durabletask.client/1.16.2",
-      "hashPath": "microsoft.durabletask.client.1.16.2.nupkg.sha512"
+      "sha512": "sha512-4UGV8cpTQmuYR0HgHwIPDXwxpqxCVVYdDjUSlzMlDBtS/3GZLOQRED80W3xmsJ3GkRaNHmOotesLHTvdTl5WOg==",
+      "path": "microsoft.durabletask.client/1.24.2",
+      "hashPath": "microsoft.durabletask.client.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Client.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Client.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zb84NRgs2N1oAUGU1EpABsJXqgstGZA+QBMEghgMNDIaNRy6jpy6s0B5PcXxCZXJSGUfLMlpRkAW0h+1q41PtA==",
-      "path": "microsoft.durabletask.client.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.client.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-JaMmDFVT9A3f5tpT9pjnSeFSrXcebHpEvE4kvfbIHnCkYFG9fT2gg7A0Cv7Uc0DH19jiPunrbthPZZMunB0JmQ==",
+      "path": "microsoft.durabletask.client.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.client.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.16.2": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GE/PPaqshyfu5N1tYExIS+XYzG58xFTgNVP/LZ6t1sY162AQIjWY2fkOv+7GltOv2D+NcMx7c8cL+kG/opZnfA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads/1.16.2",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.16.2.nupkg.sha512"
+      "sha512": "sha512-EHmVruAJa0JYk6f7cGDZw/91vuDpypGU9C8hfFwzSpHIYmcbuz+c/eXcrHPv6fVzmTUAbDcbm6DicWUs0CmhIQ==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.5.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-algMPOHB24J82jKV/D3Uh/a6LsJyy6tnRkI6rZ4fgBDJyHXcFBqE9eR5G69kGZC8IVDle3DWkXAkjHyfEX9CcA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.5.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.5.0.nupkg.sha512"
+      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Ks/fxgIwK7vJcJzCJk5YjUWABNaNY2qqsHIbeAleZTLPp/IcHX2eEhP343mfkNUuEIefavnX60rnV2hmKVH9EQ==",
-      "path": "microsoft.durabletask.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-2dFlq58m9AKm9f8NQAQCkOmF9QzMh3AmITKptT8KSrpG8t/C0s3pMGuQQrPRks7WojWGJRW0AU/iKNMvTa+l7A==",
+      "path": "microsoft.durabletask.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
     "Microsoft.DurableTask.SqlServer/1.6.0": {
       "type": "package",
@@ -4762,19 +4769,19 @@
       "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
       "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Worker/1.16.2": {
+    "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zEygMgBX8Me2cyrQTbYZYHIyAeXHvC0vwNzoLzZvwkMVTaxfqAabNS8ekkHnIfChDBaAE21gKtBo9g1FscXgBg==",
-      "path": "microsoft.durabletask.worker/1.16.2",
-      "hashPath": "microsoft.durabletask.worker.1.16.2.nupkg.sha512"
+      "sha512": "sha512-dnYZRFlI0avNhmDEM2nzEWAOU650MtL/lyte96PNBavwU1Y70Xr6HZS6eE7nhyCqAQjmYgkgYhKxH2oOL22YdQ==",
+      "path": "microsoft.durabletask.worker/1.24.2",
+      "hashPath": "microsoft.durabletask.worker.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Worker.Grpc/1.16.2": {
+    "Microsoft.DurableTask.Worker.Grpc/1.24.2": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1md6VadF5mwnoL8XvfOB96sCu5eQSs7inAvhufKWZ7ta21NQHyjsY9Tb9tKYK2BGlwUKHO366OlRWvbJnN2LFA==",
-      "path": "microsoft.durabletask.worker.grpc/1.16.2",
-      "hashPath": "microsoft.durabletask.worker.grpc.1.16.2.nupkg.sha512"
+      "sha512": "sha512-vh1GHwREAPQuOIXIVlCIho2uaKqCQT+7mg7LFygYK7lUh4Bs+oJV7FgKIko+fpC7qKIh5SrG9ncAZiwC9skkaw==",
+      "path": "microsoft.durabletask.worker.grpc/1.24.2",
+      "hashPath": "microsoft.durabletask.worker.grpc.1.24.2.nupkg.sha512"
     },
     "Microsoft.Extensions.AI.Abstractions/9.10.0": {
       "type": "package",
@@ -4790,19 +4797,19 @@
       "path": "microsoft.extensions.azure/1.13.1",
       "hashPath": "microsoft.extensions.azure.1.13.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.Caching.Abstractions/6.0.1": {
+    "Microsoft.Extensions.Caching.Abstractions/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zEtKmOJ3sZ9YxRgvgLtoQsqO069Kqp0aC6Ai+DkyE5uahtu1ynvuoDVFQgyyhVcJWnxCzZHax/3AodvAx2mhjA==",
-      "path": "microsoft.extensions.caching.abstractions/6.0.1",
-      "hashPath": "microsoft.extensions.caching.abstractions.6.0.1.nupkg.sha512"
+      "sha512": "sha512-3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+      "path": "microsoft.extensions.caching.abstractions/8.0.0",
+      "hashPath": "microsoft.extensions.caching.abstractions.8.0.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Caching.Memory/6.0.3": {
+    "Microsoft.Extensions.Caching.Memory/8.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-GVNNcHoPDEUn4OQiBBGs5mE6nX7BA+LeQId9NeA+gB8xcbDUmFPAl8Er2ixNLbn4ffFr8t5jfMwdxgFG66k7BA==",
-      "path": "microsoft.extensions.caching.memory/6.0.3",
-      "hashPath": "microsoft.extensions.caching.memory.6.0.3.nupkg.sha512"
+      "sha512": "sha512-HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+      "path": "microsoft.extensions.caching.memory/8.0.1",
+      "hashPath": "microsoft.extensions.caching.memory.8.0.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Configuration/8.0.0": {
       "type": "package",
@@ -4867,12 +4874,12 @@
       "path": "microsoft.extensions.dependencyinjection/8.0.1",
       "hashPath": "microsoft.extensions.dependencyinjection.8.0.1.nupkg.sha512"
     },
-    "Microsoft.Extensions.DependencyInjection.Abstractions/8.0.2": {
+    "Microsoft.Extensions.DependencyInjection.Abstractions/9.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg==",
-      "path": "microsoft.extensions.dependencyinjection.abstractions/8.0.2",
-      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.8.0.2.nupkg.sha512"
+      "sha512": "sha512-Tr74eP0oQ3AyC24ch17N8PuEkrPbD0JqIfENCYqmgKYNOmL8wQKzLJu3ObxTUDrjnn4rHoR1qKa37/eQyHmCDA==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/9.0.1",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.9.0.1.nupkg.sha512"
     },
     "Microsoft.Extensions.DependencyModel/2.1.0": {
       "type": "package",
@@ -5588,12 +5595,12 @@
       "path": "system.collections.concurrent/4.3.0",
       "hashPath": "system.collections.concurrent.4.3.0.nupkg.sha512"
     },
-    "System.Collections.Immutable/6.0.1": {
+    "System.Collections.Immutable/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Cc+SfP+jyCmA1TnRnDA7cRZy5jbLyWodfuUJKDJ+PJZBwWkv8szz+ztSCHAonqnL01DRaHaS2ptc4bYIEdgvWw==",
-      "path": "system.collections.immutable/6.0.1",
-      "hashPath": "system.collections.immutable.6.0.1.nupkg.sha512"
+      "sha512": "sha512-AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
+      "path": "system.collections.immutable/8.0.0",
+      "hashPath": "system.collections.immutable.8.0.0.nupkg.sha512"
     },
     "System.Collections.NonGeneric/4.3.0": {
       "type": "package",


### PR DESCRIPTION
## Description

Refresh the `extensions.deps.json` baselines used by `DependencyValidationTests` to account for the latest extension bumps in the bundle build. The change of note is that `Microsoft.Extensions.DependencyInjection.Abstractions` now resolves to `9.0.0.0` (file `9.0.124.61010`) instead of `8.0.0.0` (file `8.0.1024.46610`).

Root cause: `Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged` 1.7.0+ pulls in `Microsoft.DurableTask.*` 1.24.2, and `Microsoft.DurableTask.Abstractions` 1.24.2 raised its floor on `Microsoft.Extensions.DependencyInjection.Abstractions` from `8.0.2` to `9.0.1`.

Runtime impact analysis (shared with the Durable team):
- The Functions host's `runtimeassemblies.json` marks `Microsoft.Extensions.DependencyInjection.Abstractions` with `resolutionPolicy: runtimeVersion`, so the host always loads its own shared-framework copy regardless of what the bundle ships:
  - Hosts `< v4.1049.*` (net8): host loads DI.Abstractions **8.0.x**.
  - Hosts `>= v4.1049.*` (net10): host loads DI.Abstractions **10.0.x**.
- `dotnet apicompat` between DI.Abstractions 8.0.2 and 9.0.x is clean (9.0 is a strict API superset of 8.0).
- Metadata scan of every `Microsoft.DurableTask.*` 1.24.2 binary's `TypeRef`/`MemberRef` into DI.Abstractions confirms that none of them call a 9.0-only member, so the worst-case `runtimeVersion` redirect down to 8.0.x will not throw `MissingMethodException` / `TypeLoadException`.

Files updated (regenerated from the latest local build under `build_temp\<rid>\bin\Release\net8.0\...\extensions.deps.json`):
- [x] `tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json`
- [x] `tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json`
- [x] `tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
- [x] `linux_x64_extensions.deps.json`

## Issue Link

Resolves #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Testing

## Branch Propagation

- [x] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [x] I have added appropriate comments to complex code

## Documentation Updates

N/A

## Additional Information