### PR TITLE
Add ACR artifact cache deployment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,8 @@ __queuestorage__/
 
 # Agent plan files
 PLAN-*.md
+
+# Azure Developer CLI local environment files
+.azure/
+# Bicep build output
+infra/acr-artifact-cache/infra/main.json

--- a/eng/deploy-acr-artifact-cache.yml
+++ b/eng/deploy-acr-artifact-cache.yml
@@ -1,0 +1,70 @@
+# Manual-only pipeline for provisioning the ACR Artifact Cache used by mirror CI.
+trigger: none
+pr: none
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+variables:
+- group: acr-artifact-cache
+- name: AZD_ENV_NAME
+  value: acr-artifact-cache
+- name: ACR_ARTIFACT_CACHE_DIR
+  value: infra/acr-artifact-cache
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+    stages:
+    - stage: ProvisionAcrArtifactCache
+      displayName: Provision ACR Artifact Cache
+      dependsOn: []
+      jobs:
+      - job: Provision
+        displayName: Provision ACR Artifact Cache
+        timeoutInMinutes: 60
+        templateContext:
+          outputs: []
+        steps:
+        - checkout: self
+          fetchDepth: 1
+
+        - task: AzureCLI@2
+          displayName: Validate and provision ACR Artifact Cache
+          inputs:
+            azureSubscription: $(AZURE_SERVICE_CONNECTION)
+            scriptType: pscore
+            scriptLocation: inlineScript
+            workingDirectory: $(Build.Repository.LocalPath)/$(ACR_ARTIFACT_CACHE_DIR)
+            inlineScript: |
+              $ErrorActionPreference = 'Stop'
+
+              if (-not (Get-Command azd -ErrorAction SilentlyContinue)) {
+                curl -fsSL https://aka.ms/install-azd.sh | bash
+                $env:PATH = "$env:HOME/.azd/bin:$env:PATH"
+              }
+
+              azd version
+
+              azd env new $(AZD_ENV_NAME) --no-prompt
+              azd env set AZURE_SUBSCRIPTION_ID $(AZURE_SUBSCRIPTION_ID)
+              azd env set AZURE_LOCATION $(AZURE_LOCATION)
+              azd env set AZURE_RESOURCE_GROUP $(AZURE_RESOURCE_GROUP)
+              azd env set ACR_NAME $(ACR_NAME)
+              azd env set ACR_SKU $(ACR_SKU)
+              azd env set ACR_ANONYMOUS_PULL_ENABLED $(ACR_ANONYMOUS_PULL_ENABLED)
+              azd env set DOCKERHUB_USERNAME_SECRET_URI $(DOCKERHUB_USERNAME_SECRET_URI)
+              azd env set DOCKERHUB_TOKEN_SECRET_URI $(DOCKERHUB_TOKEN_SECRET_URI)
+
+              azd provision --preview --no-prompt
+              azd provision --no-prompt
+          env:
+            AZURE_ENV_NAME: $(AZD_ENV_NAME)

--- a/infra/acr-artifact-cache/README.md
+++ b/infra/acr-artifact-cache/README.md
@@ -44,10 +44,13 @@ azd env set AZURE_LOCATION westus2
 azd env set AZURE_RESOURCE_GROUP rg-acr-artifact-cache
 azd env set ACR_NAME <globally-unique-acr-name>
 azd env set ACR_SKU Standard
+azd env set ACR_ANONYMOUS_PULL_ENABLED false
 azd env set DOCKERHUB_USERNAME_SECRET_URI $dockerHubUsernameSecretUri
 azd env set DOCKERHUB_TOKEN_SECRET_URI $dockerHubTokenSecretUri
 azd provision
 ```
+
+Set `ACR_ANONYMOUS_PULL_ENABLED` to `true` only when cached images should be pullable without ACR authentication. Anonymous pull removes the need for `az acr login` or Docker credentials for image pulls, but anyone who can reach the registry login server can pull repositories that allow anonymous access.
 
 ## Cache rules and pull paths
 
@@ -78,6 +81,12 @@ docker pull "$acr/cache/library/mysql:9.0"
 ```
 
 The `confluentinc/cp-schema-registry` and `rabbitmq` entries are intentionally shared by duplicate image requirements.
+
+If anonymous pull is disabled, authenticate before pulling:
+
+```powershell
+az acr login --name <acr-name>
+```
 
 ## Security scanning
 

--- a/infra/acr-artifact-cache/README.md
+++ b/infra/acr-artifact-cache/README.md
@@ -52,6 +52,32 @@ azd provision
 
 Set `ACR_ANONYMOUS_PULL_ENABLED` to `true` only when cached images should be pullable without ACR authentication. Anonymous pull removes the need for `az acr login` or Docker credentials for image pulls, but anyone who can reach the registry login server can pull repositories that allow anonymous access.
 
+## Deploy from 1ES pipeline
+
+Use `eng/deploy-acr-artifact-cache.yml` from the mirror repository to reprovision the same ACR after cache rule changes. The pipeline is manual-only and uses the 1ES official template.
+
+Recommended setup:
+
+1. Run the first deployment locally to choose and verify stable names for the resource group, ACR, and Key Vault secrets.
+2. Create an Azure Resource Manager service connection in Azure DevOps that uses Workload Identity Federation.
+3. Grant the service connection identity `Contributor` on the subscription or target resource group.
+4. If Key Vault access is managed by the deployment identity, grant the service connection identity the required Key Vault management permissions. The preferred steady-state model is that ACR reads Docker Hub credentials through Key Vault secret URIs.
+5. Create an Azure DevOps variable group named `acr-artifact-cache` with these values:
+
+| Variable | Secret | Description |
+|---|---:|---|
+| `AZURE_SERVICE_CONNECTION` | No | Name of the Azure Resource Manager service connection used by `AzureCLI@2`. |
+| `AZURE_SUBSCRIPTION_ID` | No | Subscription for the deployment. |
+| `AZURE_LOCATION` | No | Azure region, for example `westus2`. |
+| `AZURE_RESOURCE_GROUP` | No | Stable resource group name. |
+| `ACR_NAME` | No | Stable, globally unique ACR name. Keep this unchanged after first deployment. |
+| `ACR_SKU` | No | ACR SKU, for example `Standard`. |
+| `ACR_ANONYMOUS_PULL_ENABLED` | No | `true` or `false`. Keep `false` unless unauthenticated pulls are intended. |
+| `DOCKERHUB_USERNAME_SECRET_URI` | Yes | Key Vault secret URI containing the Docker Hub username. |
+| `DOCKERHUB_TOKEN_SECRET_URI` | Yes | Key Vault secret URI containing the Docker Hub token. |
+
+When cache rules or image paths change, update the Bicep files and run the pipeline. Because `ACR_NAME` and `AZURE_RESOURCE_GROUP` are fixed in the variable group, the deployment updates the existing registry instead of creating a new one.
+
 ## Cache rules and pull paths
 
 Artifact Cache creates rules, but it does not pre-populate tags. A tag is cached only after the first successful pull through the ACR login server.

--- a/infra/acr-artifact-cache/README.md
+++ b/infra/acr-artifact-cache/README.md
@@ -1,0 +1,68 @@
+# ACR Artifact Cache
+
+This azd project deploys an Azure Container Registry with Artifact Cache rules for the Docker Hub images used by the Kafka, RabbitMQ, and extension bundle emulator tests.
+
+## Prerequisites
+
+- Azure Developer CLI (`azd`)
+- Azure CLI (`az`)
+- Docker Hub account and access token
+
+Docker Hub upstreams require authenticated pulls for ACR Artifact Cache. Use a Docker Hub personal access token instead of an account password when possible.
+
+## Deploy
+
+```powershell
+cd infra\acr-artifact-cache
+azd auth login
+azd env new acr-artifact-cache
+azd env set AZURE_LOCATION westus2
+azd env set AZURE_RESOURCE_GROUP rg-acr-artifact-cache
+azd env set ACR_NAME <globally-unique-acr-name>
+azd env set ACR_SKU Standard
+azd env set DOCKERHUB_USERNAME <docker-hub-username>
+azd env set DOCKERHUB_PASSWORD <docker-hub-token>
+azd provision
+```
+
+## Cache rules and pull paths
+
+Artifact Cache creates rules, but it does not pre-populate tags. A tag is cached only after the first successful pull through the ACR login server.
+
+After deployment, get the ACR login server:
+
+```powershell
+azd env get-values
+```
+
+Then warm the cache by pulling each required tag through ACR:
+
+```powershell
+$acr = "<acr-login-server>"
+
+docker pull "$acr/cache/confluentinc/cp-kafka:7.6.0"
+docker pull "$acr/cache/confluentinc/cp-schema-registry:7.6.0"
+docker pull "$acr/cache/confluentinc/cp-zookeeper:5.3.1"
+docker pull "$acr/cache/confluentinc/cp-enterprise-kafka:5.3.1"
+docker pull "$acr/cache/confluentinc/cp-schema-registry:5.3.1"
+docker pull "$acr/cache/confluentinc/cp-kafka-rest:5.3.1"
+docker pull "$acr/cache/confluentinc/cp-enterprise-control-center:5.3.1"
+docker pull "$acr/cache/cnfldemos/kafka-connect-datagen:0.1.3-5.3.1"
+docker pull "$acr/cache/library/openjdk:8-jdk-alpine"
+docker pull "$acr/cache/library/rabbitmq:3-management"
+docker pull "$acr/cache/library/mysql:9.0"
+```
+
+The `confluentinc/cp-schema-registry` and `rabbitmq` entries are intentionally shared by duplicate image requirements.
+
+## Security scanning
+
+This template creates ACR and cache rules. Vulnerability assessment is performed by Microsoft Defender for Cloud for registries in supported plans, not directly by the Bicep cache rule itself.
+
+Enable Defender for Containers or the relevant Defender for Cloud registry vulnerability assessment in the subscription, then warm the cache. Scans are triggered after images are imported into ACR by the first pull. Review findings in Microsoft Defender for Cloud.
+
+## Sharing azd files
+
+It is safe to share source files such as `azure.yaml`, Bicep templates, and this README. Do not commit `.azure` environment files if they contain secrets.
+
+Resource names like an ACR name or resource group name are not secrets by themselves, but they can reveal environment naming and subscription organization details. Sharing them in a repo is usually acceptable for non-sensitive test infrastructure, but avoid committing Docker Hub credentials, access tokens, subscription IDs, tenant IDs, or production-only naming details.

--- a/infra/acr-artifact-cache/README.md
+++ b/infra/acr-artifact-cache/README.md
@@ -6,9 +6,33 @@ This azd project deploys an Azure Container Registry with Artifact Cache rules f
 
 - Azure Developer CLI (`azd`)
 - Azure CLI (`az`)
-- Docker Hub account and access token
+- Docker Hub account and personal access token
+- Azure Key Vault that stores the Docker Hub username and token as secrets
 
-Docker Hub upstreams require authenticated pulls for ACR Artifact Cache. Use a Docker Hub personal access token instead of an account password when possible.
+Docker Hub upstreams require authenticated pulls for ACR Artifact Cache. Use a Docker Hub personal access token instead of an account password.
+
+The Bicep template expects Key Vault secret URIs, not raw Docker Hub credentials.
+
+## Prepare Key Vault secrets
+
+Create or choose a Key Vault, then store the Docker Hub credentials as secrets:
+
+```powershell
+$resourceGroup = "rg-acr-artifact-cache"
+$location = "westus2"
+$keyVaultName = "<globally-unique-key-vault-name>"
+
+az group create --name $resourceGroup --location $location
+az keyvault create --resource-group $resourceGroup --name $keyVaultName --location $location --enable-rbac-authorization false
+
+az keyvault secret set --vault-name $keyVaultName --name dockerhub-username --value "<docker-hub-username>"
+az keyvault secret set --vault-name $keyVaultName --name dockerhub-token --value "<docker-hub-token>"
+
+$dockerHubUsernameSecretUri = az keyvault secret show --vault-name $keyVaultName --name dockerhub-username --query id -o tsv
+$dockerHubTokenSecretUri = az keyvault secret show --vault-name $keyVaultName --name dockerhub-token --query id -o tsv
+```
+
+The deploying identity must be able to read the secrets and create the ACR credential set. Keep the Key Vault in the same tenant as the deployment.
 
 ## Deploy
 
@@ -20,8 +44,8 @@ azd env set AZURE_LOCATION westus2
 azd env set AZURE_RESOURCE_GROUP rg-acr-artifact-cache
 azd env set ACR_NAME <globally-unique-acr-name>
 azd env set ACR_SKU Standard
-azd env set DOCKERHUB_USERNAME <docker-hub-username>
-azd env set DOCKERHUB_PASSWORD <docker-hub-token>
+azd env set DOCKERHUB_USERNAME_SECRET_URI $dockerHubUsernameSecretUri
+azd env set DOCKERHUB_TOKEN_SECRET_URI $dockerHubTokenSecretUri
 azd provision
 ```
 
@@ -63,6 +87,6 @@ Enable Defender for Containers or the relevant Defender for Cloud registry vulne
 
 ## Sharing azd files
 
-It is safe to share source files such as `azure.yaml`, Bicep templates, and this README. Do not commit `.azure` environment files if they contain secrets.
+It is safe to share source files such as `azure.yaml`, Bicep templates, and this README. Do not commit `.azure` environment files if they contain secrets or Key Vault secret URIs.
 
-Resource names like an ACR name or resource group name are not secrets by themselves, but they can reveal environment naming and subscription organization details. Sharing them in a repo is usually acceptable for non-sensitive test infrastructure, but avoid committing Docker Hub credentials, access tokens, subscription IDs, tenant IDs, or production-only naming details.
+Resource names like an ACR name, resource group name, or Key Vault name are not secrets by themselves, but they can reveal environment naming and subscription organization details. Sharing them in a repo is usually acceptable for non-sensitive test infrastructure, but avoid committing Docker Hub credentials, access tokens, Key Vault secret URIs, subscription IDs, tenant IDs, or production-only naming details.

--- a/infra/acr-artifact-cache/azure.yaml
+++ b/infra/acr-artifact-cache/azure.yaml
@@ -1,0 +1,5 @@
+name: acr-artifact-cache
+metadata:
+  template: acr-artifact-cache@0.0.1
+infra:
+  provider: bicep

--- a/infra/acr-artifact-cache/infra/main.bicep
+++ b/infra/acr-artifact-cache/infra/main.bicep
@@ -19,13 +19,11 @@ param acrName string = toLower('acr${uniqueString(subscription().id, resourceGro
 ])
 param acrSku string = 'Standard'
 
-@secure()
-@description('Docker Hub username used by the ACR artifact cache credential set.')
-param dockerHubUsername string
+@description('Key Vault secret URI for the Docker Hub username used by the ACR artifact cache credential set.')
+param dockerHubUsernameSecretUri string
 
-@secure()
-@description('Docker Hub personal access token or password used by the ACR artifact cache credential set.')
-param dockerHubPassword string
+@description('Key Vault secret URI for the Docker Hub personal access token used by the ACR artifact cache credential set.')
+param dockerHubTokenSecretUri string
 
 resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   name: resourceGroupName
@@ -39,8 +37,8 @@ module registry 'registry.bicep' = {
     acrName: acrName
     acrSku: acrSku
     location: location
-    dockerHubUsername: dockerHubUsername
-    dockerHubPassword: dockerHubPassword
+    dockerHubUsernameSecretUri: dockerHubUsernameSecretUri
+    dockerHubTokenSecretUri: dockerHubTokenSecretUri
   }
 }
 

--- a/infra/acr-artifact-cache/infra/main.bicep
+++ b/infra/acr-artifact-cache/infra/main.bicep
@@ -19,6 +19,9 @@ param acrName string = toLower('acr${uniqueString(subscription().id, resourceGro
 ])
 param acrSku string = 'Standard'
 
+@description('Allow anonymous pull access to cached images in the registry. Keep disabled unless the cache is intended to be public within the registry network boundary.')
+param anonymousPullEnabled bool = false
+
 @description('Key Vault secret URI for the Docker Hub username used by the ACR artifact cache credential set.')
 param dockerHubUsernameSecretUri string
 
@@ -36,6 +39,7 @@ module registry 'registry.bicep' = {
   params: {
     acrName: acrName
     acrSku: acrSku
+    anonymousPullEnabled: anonymousPullEnabled
     location: location
     dockerHubUsernameSecretUri: dockerHubUsernameSecretUri
     dockerHubTokenSecretUri: dockerHubTokenSecretUri

--- a/infra/acr-artifact-cache/infra/main.bicep
+++ b/infra/acr-artifact-cache/infra/main.bicep
@@ -1,0 +1,49 @@
+targetScope = 'subscription'
+
+@description('Azure region for the resource group and Azure Container Registry.')
+param location string = deployment().location
+
+@description('Resource group name to create or update.')
+param resourceGroupName string = 'rg-acr-artifact-cache'
+
+@description('Globally unique Azure Container Registry name. Use lowercase letters and numbers only.')
+@minLength(5)
+@maxLength(50)
+param acrName string = toLower('acr${uniqueString(subscription().id, resourceGroupName)}')
+
+@description('ACR SKU. Artifact cache is supported on Basic, Standard, and Premium.')
+@allowed([
+  'Basic'
+  'Standard'
+  'Premium'
+])
+param acrSku string = 'Standard'
+
+@secure()
+@description('Docker Hub username used by the ACR artifact cache credential set.')
+param dockerHubUsername string
+
+@secure()
+@description('Docker Hub personal access token or password used by the ACR artifact cache credential set.')
+param dockerHubPassword string
+
+resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module registry 'registry.bicep' = {
+  name: 'acr-artifact-cache'
+  scope: rg
+  params: {
+    acrName: acrName
+    acrSku: acrSku
+    location: location
+    dockerHubUsername: dockerHubUsername
+    dockerHubPassword: dockerHubPassword
+  }
+}
+
+output acrName string = registry.outputs.acrName
+output acrLoginServer string = registry.outputs.acrLoginServer
+output resourceGroupName string = rg.name

--- a/infra/acr-artifact-cache/infra/main.parameters.json
+++ b/infra/acr-artifact-cache/infra/main.parameters.json
@@ -14,6 +14,9 @@
     "acrSku": {
       "value": "${ACR_SKU=Standard}"
     },
+    "anonymousPullEnabled": {
+      "value": "${ACR_ANONYMOUS_PULL_ENABLED=false}"
+    },
     "dockerHubUsernameSecretUri": {
       "value": "${DOCKERHUB_USERNAME_SECRET_URI}"
     },

--- a/infra/acr-artifact-cache/infra/main.parameters.json
+++ b/infra/acr-artifact-cache/infra/main.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    },
+    "resourceGroupName": {
+      "value": "${AZURE_RESOURCE_GROUP}"
+    },
+    "acrName": {
+      "value": "${ACR_NAME}"
+    },
+    "acrSku": {
+      "value": "${ACR_SKU=Standard}"
+    },
+    "dockerHubUsername": {
+      "value": "${DOCKERHUB_USERNAME}"
+    },
+    "dockerHubPassword": {
+      "value": "${DOCKERHUB_PASSWORD}"
+    }
+  }
+}

--- a/infra/acr-artifact-cache/infra/main.parameters.json
+++ b/infra/acr-artifact-cache/infra/main.parameters.json
@@ -14,11 +14,11 @@
     "acrSku": {
       "value": "${ACR_SKU=Standard}"
     },
-    "dockerHubUsername": {
-      "value": "${DOCKERHUB_USERNAME}"
+    "dockerHubUsernameSecretUri": {
+      "value": "${DOCKERHUB_USERNAME_SECRET_URI}"
     },
-    "dockerHubPassword": {
-      "value": "${DOCKERHUB_PASSWORD}"
+    "dockerHubTokenSecretUri": {
+      "value": "${DOCKERHUB_TOKEN_SECRET_URI}"
     }
   }
 }

--- a/infra/acr-artifact-cache/infra/registry.bicep
+++ b/infra/acr-artifact-cache/infra/registry.bicep
@@ -1,0 +1,127 @@
+@description('Azure Container Registry name.')
+param acrName string
+
+@description('Azure Container Registry SKU.')
+param acrSku string
+
+@description('Azure region for the registry.')
+param location string
+
+@secure()
+@description('Docker Hub username used by the ACR artifact cache credential set.')
+param dockerHubUsername string
+
+@secure()
+@description('Docker Hub personal access token or password used by the ACR artifact cache credential set.')
+param dockerHubPassword string
+
+var dockerHubLoginServer = 'docker.io'
+var dockerHubCredentialName = 'dockerhub'
+
+var cacheRules = [
+  {
+    name: 'confluent-cp-kafka-760'
+    sourceRepository: 'docker.io/confluentinc/cp-kafka'
+    targetRepository: 'cache/confluentinc/cp-kafka'
+  }
+  {
+    name: 'confluent-cp-schema-registry'
+    sourceRepository: 'docker.io/confluentinc/cp-schema-registry'
+    targetRepository: 'cache/confluentinc/cp-schema-registry'
+  }
+  {
+    name: 'confluent-cp-zookeeper-531'
+    sourceRepository: 'docker.io/confluentinc/cp-zookeeper'
+    targetRepository: 'cache/confluentinc/cp-zookeeper'
+  }
+  {
+    name: 'confluent-cp-enterprise-kafka-531'
+    sourceRepository: 'docker.io/confluentinc/cp-enterprise-kafka'
+    targetRepository: 'cache/confluentinc/cp-enterprise-kafka'
+  }
+  {
+    name: 'confluent-cp-kafka-rest-531'
+    sourceRepository: 'docker.io/confluentinc/cp-kafka-rest'
+    targetRepository: 'cache/confluentinc/cp-kafka-rest'
+  }
+  {
+    name: 'confluent-cp-enterprise-control-center-531'
+    sourceRepository: 'docker.io/confluentinc/cp-enterprise-control-center'
+    targetRepository: 'cache/confluentinc/cp-enterprise-control-center'
+  }
+  {
+    name: 'cnfldemos-kafka-connect-datagen-013-531'
+    sourceRepository: 'docker.io/cnfldemos/kafka-connect-datagen'
+    targetRepository: 'cache/cnfldemos/kafka-connect-datagen'
+  }
+  {
+    name: 'openjdk-8-jdk-alpine'
+    sourceRepository: 'docker.io/library/openjdk'
+    targetRepository: 'cache/library/openjdk'
+  }
+  {
+    name: 'rabbitmq-3-management'
+    sourceRepository: 'docker.io/library/rabbitmq'
+    targetRepository: 'cache/library/rabbitmq'
+  }
+  {
+    name: 'mysql-90'
+    sourceRepository: 'docker.io/library/mysql'
+    targetRepository: 'cache/library/mysql'
+  }
+]
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
+  name: acrName
+  location: location
+  sku: {
+    name: acrSku
+  }
+  properties: {
+    adminUserEnabled: false
+    anonymousPullEnabled: false
+    dataEndpointEnabled: false
+    networkRuleBypassOptions: 'AzureServices'
+    policies: {
+      quarantinePolicy: {
+        status: 'disabled'
+      }
+      retentionPolicy: {
+        days: 7
+        status: 'disabled'
+      }
+      trustPolicy: {
+        status: 'disabled'
+        type: 'Notary'
+      }
+    }
+  }
+}
+
+resource credentialSet 'Microsoft.ContainerRegistry/registries/credentialSets@2023-11-01-preview' = {
+  parent: registry
+  name: dockerHubCredentialName
+  properties: {
+    loginServer: dockerHubLoginServer
+    authCredentials: [
+      {
+        name: 'Credential1'
+        usernameSecretIdentifier: dockerHubUsername
+        passwordSecretIdentifier: dockerHubPassword
+      }
+    ]
+  }
+}
+
+resource cacheRule 'Microsoft.ContainerRegistry/registries/cacheRules@2023-11-01-preview' = [for rule in cacheRules: {
+  parent: registry
+  name: rule.name
+  properties: {
+    sourceRepository: rule.sourceRepository
+    targetRepository: rule.targetRepository
+    credentialSetResourceId: credentialSet.id
+  }
+}]
+
+output acrName string = registry.name
+output acrLoginServer string = registry.properties.loginServer

--- a/infra/acr-artifact-cache/infra/registry.bicep
+++ b/infra/acr-artifact-cache/infra/registry.bicep
@@ -4,6 +4,9 @@ param acrName string
 @description('Azure Container Registry SKU.')
 param acrSku string
 
+@description('Allow anonymous pull access to cached images in the registry.')
+param anonymousPullEnabled bool
+
 @description('Azure region for the registry.')
 param location string
 
@@ -77,7 +80,7 @@ resource registry 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = 
   }
   properties: {
     adminUserEnabled: false
-    anonymousPullEnabled: false
+    anonymousPullEnabled: anonymousPullEnabled
     dataEndpointEnabled: false
     networkRuleBypassOptions: 'AzureServices'
     policies: {

--- a/infra/acr-artifact-cache/infra/registry.bicep
+++ b/infra/acr-artifact-cache/infra/registry.bicep
@@ -7,13 +7,11 @@ param acrSku string
 @description('Azure region for the registry.')
 param location string
 
-@secure()
-@description('Docker Hub username used by the ACR artifact cache credential set.')
-param dockerHubUsername string
+@description('Key Vault secret URI for the Docker Hub username used by the ACR artifact cache credential set.')
+param dockerHubUsernameSecretUri string
 
-@secure()
-@description('Docker Hub personal access token or password used by the ACR artifact cache credential set.')
-param dockerHubPassword string
+@description('Key Vault secret URI for the Docker Hub personal access token used by the ACR artifact cache credential set.')
+param dockerHubTokenSecretUri string
 
 var dockerHubLoginServer = 'docker.io'
 var dockerHubCredentialName = 'dockerhub'
@@ -106,8 +104,8 @@ resource credentialSet 'Microsoft.ContainerRegistry/registries/credentialSets@20
     authCredentials: [
       {
         name: 'Credential1'
-        usernameSecretIdentifier: dockerHubUsername
-        passwordSecretIdentifier: dockerHubPassword
+        usernameSecretIdentifier: dockerHubUsernameSecretUri
+        passwordSecretIdentifier: dockerHubTokenSecretUri
       }
     ]
   }


### PR DESCRIPTION
Adds an azd/Bicep template for an Azure Container Registry Artifact Cache used by Kafka, RabbitMQ, and extension bundle emulator test images.\n\nNotes:\n- Docker Hub upstream credentials are provided through azd environment variables.\n- Artifact Cache rules are created by Bicep; tags are cached after first pull through ACR.\n- .azure local environment files are ignored to avoid committing secrets.