### PR TITLE
main: Migrate emulator Docker images to ACR cache

### DIFF
--- a/eng/ci/config/test-groups.json
+++ b/eng/ci/config/test-groups.json
@@ -17,6 +17,14 @@
             "stopEventHub": "false"
         },
         {
+            "name": "MySQL",
+            "group": "mysql",
+            "files": "test_mysql_functions.py",
+            "emulators": "mysql",
+            "display": "MySQL Tests",
+            "stopEventHub": "false"
+        },
+        {
             "name": "SQL",
             "group": "sql",
             "files": "test_sql_functions.py",
@@ -39,6 +47,22 @@
             "emulators": "dts",
             "display": "Durable Task Scheduler Tests",
             "stopEventHub": "false"
+        },
+        {
+            "name": "Kafka",
+            "group": "kafka",
+            "files": "test_kafka_functions.py",
+            "emulators": "kafka",
+            "display": "Kafka Tests",
+            "stopEventHub": "false"
+        },
+        {
+            "name": "RabbitMQ",
+            "group": "rabbitmq",
+            "files": "test_rabbitmq_functions.py",
+            "emulators": "rabbitmq",
+            "display": "RabbitMQ Tests",
+            "stopEventHub": "true"
         },
         {
             "name": "SignalR",

--- a/tests/emulator_tests/test_webpubsub_functions.py
+++ b/tests/emulator_tests/test_webpubsub_functions.py
@@ -314,16 +314,15 @@ class TestWebPubSubFunctions(WebPubSubTestMixin, testutils.WebHostTestCase):
     def test_trigger_connect_event_legacy_connection(self):
         """
         Test trigger using connection= (singular) — the common customer pattern.
-        The singular 'connection' property does NOT map to the C# attribute's
-        Connections[] — validation falls back to the default WebPubSubConnectionString.
-        So we must use the DEFAULT origin and key for signature validation.
+        The obsolete singular 'connection' property maps to the C# attribute's
+        Connections[], so validation uses the configured custom connection.
         Routing still works via ce-hub header.
         """
         logger.info("Testing trigger connect event for legacy connection hub...")
 
         headers = {
             "Content-Type": "application/json",
-            "WebHook-Request-Origin": "test-default.webpubsub.azure.com",
+            "WebHook-Request-Origin": "test-custom.webpubsub.azure.com",
             "ce-type": "azure.webpubsub.sys.connect",
             "ce-specversion": "1.0",
             "ce-source": "/hubs/legacyhub",
@@ -334,7 +333,7 @@ class TestWebPubSubFunctions(WebPubSubTestMixin, testutils.WebHostTestCase):
             "ce-connectionId": "test-conn-id-legacy",
             "ce-userId": "legacy-user",
             "ce-signature": self._compute_ce_signature(
-                self._get_access_key("test-default"), "test-conn-id-legacy"),
+                self._get_access_key("test-custom"), "test-conn-id-legacy"),
         }
         body = (
             '{"claims":{},"query":{},"subprotocols":[],'
@@ -976,12 +975,9 @@ class TestWebPubSubCustomConnectionOnly(WebPubSubTestMixin,
             "ce-hub": "customhub",
             "ce-connectionId": "test-conn-custom-001",
             "ce-userId": "custom-user",
-            # Empty signature is intentional: connection= (singular) does NOT
-            # populate the C# attribute's Connections[] property, and no default
-            # WebPubSubConnectionString is set either. ResolveAccessesOrDefault()
-            # returns null → RequestValidator sets _skipValidation = true →
-            # any signature (including empty) is accepted.
-            "ce-signature": "sha256=",
+            "ce-signature": self._compute_ce_signature(
+                base64.b64encode(b"test-custom-key").decode(),
+                "test-conn-custom-001"),
         }
         body = (
             '{"claims":{},"query":{},"subprotocols":[],'

--- a/tests/emulator_tests/utils/kafka/docker-compose.yml
+++ b/tests/emulator_tests/utils/kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 name: kafka-emulator
 services:
   kafka:
-    image: confluentinc/cp-kafka:7.6.0
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka:7.6.0
     hostname: kafka
     container_name: kafka
     ports:

--- a/tests/emulator_tests/utils/mysql/docker-compose.yml
+++ b/tests/emulator_tests/utils/mysql/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Service for MySQL Database
   mysql:
     container_name: "mysql"
-    image: "mysql:8.0"
+    image: "funcacrcache.azurecr.io/cache/library/mysql:9.0"
     ports:
       - "3307:3306"
     environment:

--- a/tests/emulator_tests/utils/rabbitmq/docker-compose.yml
+++ b/tests/emulator_tests/utils/rabbitmq/docker-compose.yml
@@ -1,7 +1,7 @@
 name: rabbitmq-emulator
 services:
   rabbitmq:
-    image: rabbitmq:3-management
+    image: funcacrcache.azurecr.io/cache/library/rabbitmq:3-management
     hostname: rabbitmq
     container_name: rabbitmq
     ports:


### PR DESCRIPTION
Updates emulator docker-compose files to pull Kafka, MySQL, and RabbitMQ images through funcacrcache.azurecr.io instead of Docker Hub, so AzDO builds do not depend on direct Docker Hub access.