### PR TITLE
Migrate preview emulator images to ACR cache

### DIFF
--- a/eng/ci/config/test-groups.json
+++ b/eng/ci/config/test-groups.json
@@ -17,6 +17,14 @@
             "stopEventHub": "false"
         },
         {
+            "name": "MySQL",
+            "group": "mysql",
+            "files": "test_mysql_functions.py",
+            "emulators": "mysql",
+            "display": "MySQL Tests",
+            "stopEventHub": "false"
+        },
+        {
             "name": "SQL",
             "group": "sql",
             "files": "test_sql_functions.py",
@@ -39,6 +47,22 @@
             "emulators": "dts",
             "display": "Durable Task Scheduler Tests",
             "stopEventHub": "false"
+        },
+        {
+            "name": "Kafka",
+            "group": "kafka",
+            "files": "test_kafka_functions.py",
+            "emulators": "kafka",
+            "display": "Kafka Tests",
+            "stopEventHub": "false"
+        },
+        {
+            "name": "RabbitMQ",
+            "group": "rabbitmq",
+            "files": "test_rabbitmq_functions.py",
+            "emulators": "rabbitmq",
+            "display": "RabbitMQ Tests",
+            "stopEventHub": "true"
         },
         {
             "name": "SignalR",

--- a/tests/emulator_tests/utils/kafka/docker-compose.yml
+++ b/tests/emulator_tests/utils/kafka/docker-compose.yml
@@ -1,7 +1,7 @@
 name: kafka-emulator
 services:
   kafka:
-    image: confluentinc/cp-kafka:7.6.0
+    image: funcacrcache.azurecr.io/cache/confluentinc/cp-kafka:7.6.0
     hostname: kafka
     container_name: kafka
     ports:

--- a/tests/emulator_tests/utils/mysql/docker-compose.yml
+++ b/tests/emulator_tests/utils/mysql/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Service for MySQL Database
   mysql:
     container_name: "mysql"
-    image: "mysql:8.0"
+    image: "funcacrcache.azurecr.io/cache/library/mysql:9.0"
     ports:
       - "3307:3306"
     environment:

--- a/tests/emulator_tests/utils/rabbitmq/docker-compose.yml
+++ b/tests/emulator_tests/utils/rabbitmq/docker-compose.yml
@@ -1,7 +1,7 @@
 name: rabbitmq-emulator
 services:
   rabbitmq:
-    image: rabbitmq:3-management
+    image: funcacrcache.azurecr.io/cache/library/rabbitmq:3-management
     hostname: rabbitmq
     container_name: rabbitmq
     ports:


### PR DESCRIPTION
Migrate Kafka, MySQL, and RabbitMQ emulator Docker images to the ACR cache for main-preview and re-enable their test groups in eng/ci/config/test-groups.json.