### PR TITLE
Pin MessagePack to patched version

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -277,5 +277,11 @@
       "mcpResourceTrigger",
       "mcpPromptTrigger"
     ]
+  },
+  {
+    "id": "MessagePack",
+    "version": "2.5.301",
+    "name": "MessagePack",
+    "bindings": []
   }
 ]


### PR DESCRIPTION
## Summary
- Pin `MessagePack` to `2.5.301` in `extensions.json` so bundle restore resolves the patched 2.5.x version.
- Addresses main CI failure in build 284645 where `dotnet list --vulnerable` detected `MessagePack 2.5.192` as High severity (`GHSA-hv8m-jj95-wg3x`).

## Validation
- `extensions.json` parses successfully with PowerShell `ConvertFrom-Json`
- `git diff --check`

## Notes
- Local bundle build could not be run because this machine has .NET SDK 8.0.300 but the repo `global.json` requires 8.0.416. PR CI should verify the generated dependency graph and vulnerability report.