### PR TITLE
main-preview: optimise emulator test build task and temp pin OpenAI extension packages

### DIFF
--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -79,7 +79,7 @@ jobs:
     displayName: Build Extension Bundle
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     # 1ES-compliant artifact publication via templateContext.outputs
     templateContext:
@@ -90,46 +90,19 @@ jobs:
           artifact: bundle-artifacts
 
     steps:
-      # Download template artifacts for the build
-      # Official templates
-      - task: DownloadBuildArtifacts@1
-        inputs:
-          buildType: 'specific'
-          project: '3f99e810-c336-441f-8892-84983093ad7f'
-          pipeline: '963'
-          buildVersionToDownload: 'latestFromBranch'
-          branchName: 'refs/heads/dev'
-          downloadType: 'single'
-          artifactName: 'drop'
-          downloadPath: '$(Build.Repository.LocalPath)/templatesArtifacts'
-        condition: ${{ parameters.official }}
-
-      # Public templates
-      - task: DownloadBuildArtifacts@1
-        inputs:
-          buildType: 'specific'
-          project: 'ae7e3bf3-d41a-4480-9ac0-b6cf9df9ac24'
-          pipeline: '976'
-          buildVersionToDownload: 'latestFromBranch'
-          branchName: 'refs/heads/dev'
-          downloadType: 'single'
-          artifactName: 'drop'
-          downloadPath: '$(Build.Repository.LocalPath)/templatesArtifacts'
-        condition: ${{ eq(parameters.official, false) }}
 
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Authenticate'
 
-      # Build the Linux bundle first
+      # Build the any-any bundle
       - task: DotNetCoreCLI@2
-        displayName: 'Build Linux Bundle (once)'
+        displayName: 'Build any-any Bundle (once)'
         inputs:
           command: 'run'
           workingDirectory: './build'
-          arguments: 'PackageBundlesLinux'
+          arguments: 'skip:DownloadTemplates,BuildBundleBinariesForLinux,PackageBundle,PackageBundlesLinux,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
         env:
           BUILD_REPOSITORY_LOCALPATH: '$(Build.Repository.LocalPath)'
-          TEMPLATES_ARTIFACTS_DIRECTORY: '$(Build.Repository.LocalPath)/templatesArtifacts'
 
       - script: |
           echo "Checking for build artifacts..."

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -79,7 +79,7 @@ jobs:
     displayName: Build Extension Bundle
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04
+      image: 1es-ubuntu-22.04
       os: linux
     # 1ES-compliant artifact publication via templateContext.outputs
     templateContext:

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -79,7 +79,7 @@ jobs:
     displayName: Build Extension Bundle
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-24.04
       os: linux
     # 1ES-compliant artifact publication via templateContext.outputs
     templateContext:

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -220,6 +220,7 @@
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.OpenAI",
     "majorVersion": "0",
+    "Version": "0.19.0-alpha",
     "name": "OpenAI",
     "bindings": [
       "TextCompletion",
@@ -244,6 +245,7 @@
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.OpenAI.AzureAISearch",
     "majorVersion": "0",
+    "Version": "0.5.0-alpha",
     "name": "OpenAIAzureAISearch",
     "bindings": [
       "SemanticSearch",
@@ -253,6 +255,7 @@
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch",
     "majorVersion": "0",
+    "Version": "0.4.0-alpha",
     "name": "OpenAICosmosDBSearch",
     "bindings": [
       "SemanticSearch",
@@ -262,6 +265,7 @@
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBNoSqlSearch",
     "majorVersion": "0",
+    "Version": "0.1.0-alpha",
     "name": "OpenAICosmosDBNoSqlSearch",
     "bindings": [
       "SemanticSearch",
@@ -271,6 +275,7 @@
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto",
     "majorVersion": "0",
+    "Version": "0.17.0-alpha",
     "name": "OpenAIKusto",
     "bindings": [
       "SemanticSearch",


### PR DESCRIPTION
# Pull Request

## Description

- Skip unnecessary bundle zip creations for emulator tests stage (only any_any package is consumed by core tools)
- Temporary pinning of OpenAI extension packages until we are ready to release new versions in the bundle.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->