### PR TITLE
main-preview: emulator build - use min agent and install dotnet

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -31,6 +31,12 @@ jobs:
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
+  - task: UseDotNet@2
+    displayName: 'Install current .NET SDK'
+    inputs:
+      packageType: 'sdk'
+      useGlobalJson: true
+
   - task: DotNetCoreCLI@2
     displayName: 'Build'
     inputs:

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -45,6 +45,12 @@ jobs:
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Authenticate'
 
+      - task: UseDotNet@2
+        displayName: 'Install current .NET SDK'
+        inputs:
+          packageType: 'sdk'
+          useGlobalJson: true
+
       - task: PowerShell@2
         displayName: 'Build Azure Functions Core Tools'
         inputs:

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Build Core Tools
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-22.04
       os: linux
     templateContext:
       outputs:
@@ -44,13 +44,6 @@ jobs:
 
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Authenticate'
-
-      - task: UseDotNet@2
-        displayName: 'Install current .NET SDK'
-        inputs:
-          packageType: 'sdk'
-          useGlobalJson: true
-          workingDirectory: '$(Agent.BuildDirectory)/core-tools'
 
       - task: PowerShell@2
         displayName: 'Build Azure Functions Core Tools'

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Build Core Tools
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     templateContext:
       outputs:
@@ -50,6 +50,7 @@ jobs:
         inputs:
           packageType: 'sdk'
           useGlobalJson: true
+          workingDirectory: '$(Agent.BuildDirectory)/core-tools'
 
       - task: PowerShell@2
         displayName: 'Build Azure Functions Core Tools'

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Build Core Tools
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     templateContext:
       outputs:
@@ -79,7 +79,7 @@ jobs:
     displayName: Build Extension Bundle
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     # 1ES-compliant artifact publication via templateContext.outputs
     templateContext:
@@ -93,6 +93,12 @@ jobs:
 
       - task: NuGetAuthenticate@1
         displayName: 'NuGet Authenticate'
+
+      - task: UseDotNet@2
+        displayName: 'Install current .NET SDK'
+        inputs:
+          packageType: 'sdk'
+          useGlobalJson: true
 
       # Build the any-any bundle
       - task: DotNetCoreCLI@2
@@ -120,7 +126,7 @@ jobs:
     dependsOn: PrepareCoreTools
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
 
     steps:
@@ -213,7 +219,7 @@ jobs:
       - GenerateTestMatrix
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     strategy:
       maxParallel: 5
@@ -294,7 +300,7 @@ jobs:
           if [ "$(ADDITIONAL_EMULATORS)" = "sql" ]; then
             echo "Installing Microsoft ODBC Driver 18 for SQL Server..."
             curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-            curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+            curl https://packages.microsoft.com/config/ubuntu/24.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
             sudo apt-get update
             sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
             echo "ODBC Driver 18 installed successfully"

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Build Core Tools
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-22.04
       os: linux
     templateContext:
       outputs:
@@ -132,7 +132,7 @@ jobs:
     dependsOn: PrepareCoreTools
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-22.04
       os: linux
 
     steps:
@@ -225,7 +225,7 @@ jobs:
       - GenerateTestMatrix
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-22.04
       os: linux
     strategy:
       maxParallel: 5
@@ -306,7 +306,7 @@ jobs:
           if [ "$(ADDITIONAL_EMULATORS)" = "sql" ]; then
             echo "Installing Microsoft ODBC Driver 18 for SQL Server..."
             curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-            curl https://packages.microsoft.com/config/ubuntu/24.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+            curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
             sudo apt-get update
             sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
             echo "ODBC Driver 18 installed successfully"


### PR DESCRIPTION
# Pull Request

## Description

Use `image: 1es-ubuntu-24.04-min` for emulator tests, official pipeline still experiences space crunch.
Previous optimizations were not enough for official pipeline agent which probably consumes more space with 1ES injected tasks

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [x] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->