### PR TITLE
main: pin message pack to 2.5.301 until SignalR releases new package

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -249,6 +249,12 @@
     "bindings": []
   },
   {
+    "id": "MessagePack",
+    "version": "2.5.301",
+    "name": "MessagePack",
+    "bindings": []
+  },
+  {
     "id": "Microsoft.Azure.WebJobs.Extensions.MySql",
     "majorVersion": "1",
     "name": "MySqlBinding",


### PR DESCRIPTION
# Pull Request

## Description

Pins MessagePack 2.5.301 until SignalR can do a new package release.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->