### PR TITLE
Update Kafka extension to 4.3.2

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -159,7 +159,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Kafka",
-    "version": "4.2.0",
+    "version": "4.3.2",
     "name": "Kafka",
     "bindings": [
       "kafkatrigger",


### PR DESCRIPTION
## Summary
- Update `Microsoft.Azure.WebJobs.Extensions.Kafka` in the v4 extension bundle from `4.2.0` to `4.3.2`.

## Compatibility Notes
- `4.3.2` is the latest published WebJobs Kafka extension package.
- NuGet dependencies are unchanged from `4.2.0`: `Confluent.Kafka` and `Confluent.SchemaRegistry*` remain at `2.4.0`, and the package still targets `netstandard2.0`.
- The new `KafkaRecord` path is opt-in via deferred binding/`ParameterBindingData`; existing Python/Node/Java string/binary Kafka trigger scenarios continue using the existing conversion path.
- `4.3.1` is intentionally skipped because the Kafka extension release notes call out a `KafkaRecord` issue fixed by `4.3.2`.

## Testing
- Parsed `src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json` and verified the Kafka entry resolves to `4.3.2`.
- `dotnet test ExtensionBundle.Tests.sln`