### PR TITLE
main: pack unfiltered portable bundle in cdnProd_Windows and prep 4.37.0

### DIFF
--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -412,26 +412,14 @@ namespace Build
 
         public static void CreateCDNStoragePackageWindows()
         {
-            // Stage filtered portable bundle content (reused across CDN index directories)
-            var portableConfig = Settings.PortableBuildConfiguration;
-            string filteredPortableBundlePath = Path.Combine(Settings.RootBuildDirectory, "filtered_any_any_bundle");
-            string filteredAnyBinPath = Path.Combine(Settings.RootBinDirectory, $"{WindowsConfigPrefix}_{portableConfig.ConfigId}", portableConfig.PublishBinDirectorySubPath);
-            string targetBinPath = Path.Combine(filteredPortableBundlePath, portableConfig.PublishBinDirectorySubPath);
-            FileUtility.CopyDirectory(filteredAnyBinPath, targetBinPath);
-            AddBindingInfoToExtensionsJson(Path.Join(targetBinPath, Settings.ExtensionsJsonFileName));
-
-            string filteredCsProjPath = Path.Combine(Settings.RootBuildDirectory, $"{WindowsConfigPrefix}_{portableConfig.ConfigId}", "extensions.csproj");
-            StageCommonBundleFiles(filteredPortableBundlePath, filteredCsProjPath);
-
             foreach (var indexFileMetadata in Settings.IndexFiles)
             {
                 string packageRootDirectoryPath = Path.Combine(Settings.RootBinDirectory, $"{indexFileMetadata.IndexFileDirectory}_windows");
                 string packageBundleDirectory = Path.Combine(packageRootDirectoryPath, BundleConfiguration.Instance.ExtensionBundleId, BundleConfiguration.Instance.ExtensionBundleVersion);
                 FileUtility.EnsureDirectoryExists(packageBundleDirectory);
 
-                // Create filtered any-any.zip directly in the CDN package directory
-                string filteredPortableZipPath = Path.Combine(packageBundleDirectory, Settings.BundlePackagePortable.GeneratedBundleZipFileName);
-                ZipFile.CreateFromDirectory(filteredPortableBundlePath, filteredPortableZipPath, CompressionLevel.NoCompression, false);
+                // Include the full unfiltered any-any.zip (all extensions including Fabric)
+                AddBundleZipFile(packageBundleDirectory, Settings.BundlePackagePortable);
 
                 AddBundleZipFile(packageBundleDirectory, Settings.BundlePackageWindows);
 

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,5 +1,5 @@
 {
   "bundleId": "Microsoft.Azure.Functions.ExtensionBundle",
-  "bundleVersion": "4.36.0",
+  "bundleVersion": "4.37.0",
   "isPreviewBundle": false
 }


### PR DESCRIPTION
# Pull Request

## Description

### Fix 

(introduced in PR #702 with assumption that cdnProd_windows is only meant for windows package)

`cdnProd_Windows` contains two ZIP packages:

- `any_any.zip` – Portable binaries package
- `win_any.zip` – Windows Runtime Identifier (RID) binaries package

  This folder is used to upload both packages to the CDN.
  
  The `any_any.zip` package should contain the complete portable bundle with **no exclusions**, enabling Core Tools users to debug with all extensions available.
  
  Exclusions should be applied only to the highlighted package(s) and **not** to `any_any.zip`.
      <img width="310" height="251" alt="image" src="https://github.com/user-attachments/assets/aa690c65-5284-4fa2-95e5-6bfa6cd9f814" /> 
-  Bundle version bumped to 4.37.0 for preparation

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->