### PR TITLE
main-preview: update Redis extension major version and bindings to match main

### DIFF
--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -194,12 +194,13 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Redis",
-    "majorVersion": "0",
+    "majorVersion": "1",
     "name": "Redis",
     "bindings": [
-      "RedisPubSubTrigger",
-      "RedisStreamTrigger",
-      "RedisListTrigger"
+      "redisPubSubTrigger",
+      "redisStreamTrigger",
+      "redisListTrigger",
+      "redis"
     ]
   },
   {

--- a/tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -8,18 +8,19 @@
     ".NETCoreApp,Version=v8.0": {
       "extensions/1.0.0": {
         "dependencies": {
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
           "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.4-preview",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.0",
+          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
           "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
@@ -29,7 +30,7 @@
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.4.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.17.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
+          "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
@@ -77,7 +78,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -169,11 +170,11 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
@@ -606,23 +607,23 @@
           }
         }
       },
-      "MessagePack/2.5.192": {
+      "MessagePack/2.5.301": {
         "dependencies": {
-          "MessagePack.Annotations": "2.5.192",
+          "MessagePack.Annotations": "2.5.301",
           "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
           "lib/net6.0/MessagePack.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
-      "MessagePack.Annotations/2.5.192": {
+      "MessagePack.Annotations/2.5.301": {
         "runtime": {
           "lib/netstandard2.0/MessagePack.Annotations.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
@@ -746,30 +747,30 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0"
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Authorization/2.2.0": {
+      "Microsoft.AspNetCore.Authorization/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+      "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Authorization": "2.2.0"
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Authorization": "2.3.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
@@ -780,9 +781,9 @@
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "8.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.1",
@@ -795,14 +796,14 @@
           "System.Reflection.Metadata": "1.6.0"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.3.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
@@ -823,7 +824,7 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+      "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
@@ -836,78 +837,77 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+      "Microsoft.AspNetCore.JsonPatch/2.3.0": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.JsonPatch.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.18316"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Net.Http.Headers": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Core": "2.2.0",
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Core": "2.3.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.3.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.JsonPatch": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0"
+          "Microsoft.AspNetCore.JsonPatch": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.Mvc.WebApiCompatShim.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.0"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Routing/2.2.2": {
+      "Microsoft.AspNetCore.Routing/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.ObjectPool": "8.0.11",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0"
         }
@@ -922,7 +922,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0",
@@ -934,7 +934,7 @@
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.Cryptography.Cng": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Https/2.2.0": {
@@ -962,7 +962,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -996,7 +996,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -1005,7 +1005,7 @@
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
@@ -1057,8 +1057,8 @@
       "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -1067,23 +1067,23 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
             "assemblyVersion": "2.9.0.0",
-            "fileVersion": "2.9.0.12085"
+            "fileVersion": "2.9.1.24919"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.8.0": {
+      "Microsoft.Azure.DurableTask.Core/3.9.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -1094,8 +1094,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.8.0.0",
-            "fileVersion": "3.8.0.12085"
+            "assemblyVersion": "3.9.0.0",
+            "fileVersion": "3.9.0.19481"
           }
         }
       },
@@ -1106,8 +1106,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1121,9 +1121,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1174,7 +1174,7 @@
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1387,7 +1387,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1401,7 +1401,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.60.0",
@@ -1411,8 +1411,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.16.0.0",
-            "fileVersion": "4.16.0.26269"
+            "assemblyVersion": "4.16.1.0",
+            "fileVersion": "4.16.1.26276"
           }
         }
       },
@@ -1421,7 +1421,7 @@
           "CloudNative.CloudEvents": "2.6.0",
           "CloudNative.CloudEvents.SystemTextJson": "2.6.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1434,13 +1434,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1449,30 +1449,31 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.5.0"
+            "fileVersion": "3.13.1.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -1504,7 +1505,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1520,12 +1521,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           }
         }
       },
@@ -1533,9 +1534,9 @@
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45"
         },
         "runtime": {
@@ -1582,7 +1583,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1682,7 +1683,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1692,8 +1693,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Redis.dll": {
-            "assemblyVersion": "0.5.0.0",
-            "fileVersion": "0.5.0.0"
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
@@ -1738,7 +1739,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.1.0": {
         "dependencies": {
-          "MessagePack": "2.5.192",
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Azure.SignalR.Management": "1.29.0",
           "Microsoft.Azure.SignalR.Protocols": "1.29.0",
@@ -1859,7 +1860,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -1917,11 +1918,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.5",
-            "fileVersion": "10.0.526.15411"
+            "assemblyVersion": "10.0.0.8",
+            "fileVersion": "10.0.826.23019"
           }
         }
       },
@@ -2042,8 +2043,8 @@
       },
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -2056,36 +2057,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -2134,23 +2136,24 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -2170,7 +2173,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
@@ -2186,7 +2189,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -2975,7 +2978,7 @@
           "System.Security.Permissions": "8.0.0",
           "System.Text.Encoding.CodePages": "8.0.0",
           "System.Text.Json": "8.0.6",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "ZstdSharp.Port": "0.8.0"
         },
         "runtime": {
@@ -3585,7 +3588,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3721,7 +3724,7 @@
       "System.Reactive.Core/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Core.dll": {
@@ -3733,7 +3736,7 @@
       "System.Reactive.Interfaces/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Interfaces.dll": {
@@ -3745,7 +3748,7 @@
       "System.Reactive.Linq/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Linq.dll": {
@@ -3757,7 +3760,7 @@
       "System.Reactive.PlatformServices/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.PlatformServices.dll": {
@@ -3769,7 +3772,7 @@
       "System.Reactive.Providers/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Providers.dll": {
@@ -4081,7 +4084,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
-      "System.Threading.Tasks.Extensions/4.5.4": {},
+      "System.Threading.Tasks.Extensions/4.6.0": {},
       "System.Threading.Thread/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -4127,7 +4130,7 @@
           "System.Text.Encoding.Extensions": "4.3.0",
           "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "System.Xml.XDocument/4.3.0": {
@@ -4471,19 +4474,19 @@
       "path": "librdkafka.redist/2.4.0",
       "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/2.5.192": {
+    "MessagePack/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
-      "path": "messagepack/2.5.192",
-      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+      "sha512": "sha512-WUnJgmYc06ngIxZxLe9sa0P6rOTyOZIQn8SuDvJSjyMn7e8/AdlNAdt81WPUhWKeQ7hDkgxKU1vTrJqX/4L79A==",
+      "path": "messagepack/2.5.301",
+      "hashPath": "messagepack.2.5.301.nupkg.sha512"
     },
-    "MessagePack.Annotations/2.5.192": {
+    "MessagePack.Annotations/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
-      "path": "messagepack.annotations/2.5.192",
-      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
+      "sha512": "sha512-3PyBiSeKTfvtyzUv3+9eXGIw7vBBZ0GAc4k3+RVT0tz2vKv3l0pviiA2b6DrmHyDvj1Au8lSVDDw/wKPMxUQ4A==",
+      "path": "messagepack.annotations/2.5.301",
+      "hashPath": "messagepack.annotations.2.5.301.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
@@ -4548,33 +4551,33 @@
       "path": "microsoft.aspnet.webapi.client/5.2.9",
       "hashPath": "microsoft.aspnet.webapi.client.5.2.9.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-VloMLDJMf3n/9ic5lCBOa42IBYJgyB1JhzLsL68Zqg+2bEPWfGBj/xCJy/LrKTArN0coOcZp3wyVTZlx0y9pHQ==",
-      "path": "microsoft.aspnetcore.authentication.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ve6uvLwKNRkfnO/QeN9M8eUJ49lCnWv/6/9p6iTEuiI6Rtsz+myaBAjdMzLuTViQY032xbTF5AdZF5BJzJJyXQ==",
+      "path": "microsoft.aspnetcore.authentication.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XlVJzJ5wPOYW+Y0J6Q/LVTEyfS4ssLXmt60T0SPP+D8abVhBTl+cgw2gDHlyKYIkcJg7btMVh383NDkMVqD/fg==",
-      "path": "microsoft.aspnetcore.authentication.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-gnLnKGawBjqBnU9fEuel3VcYAARkjyONAliaGDfMc8o8HBtfh+HrOPEoR8Xx4b2RnMb7uxdBDOvEAC7sul79ig==",
+      "path": "microsoft.aspnetcore.authentication.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization/2.2.0": {
+    "Microsoft.AspNetCore.Authorization/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/L0W8H3jMYWyaeA9gBJqS/tSWBegP9aaTM0mjRhxTttBY9z4RVDRYJ2CwPAmAXIuPr3r1sOw+CS8jFVRGHRezQ==",
-      "path": "microsoft.aspnetcore.authorization/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.2.2.0.nupkg.sha512"
+      "sha512": "sha512-2/aBgLqBXva/+w8pzRNY8ET43Gi+dr1gv/7ySfbsh23lTK6IAgID5MGUEa1hreNIF+0XpW4tX7QwVe70+YvaPg==",
+      "path": "microsoft.aspnetcore.authorization/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+    "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aJCo6niDRKuNg2uS2WMEmhJTooQUGARhV2ENQ2tO5443zVHUo19MSgrgGo9FIrfD+4yKPF8Q+FF33WkWfPbyKw==",
-      "path": "microsoft.aspnetcore.authorization.policy/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.policy.2.2.0.nupkg.sha512"
+      "sha512": "sha512-vn31uQ1dA1MIV2WNNDOOOm88V5KgR9esfi0LyQ6eVaGq2h0Yw+R29f5A6qUNJt+RccS3qkYayylAy9tP1wV+7Q==",
+      "path": "microsoft.aspnetcore.authorization.policy/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.policy.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
       "type": "package",
@@ -4590,19 +4593,19 @@
       "path": "microsoft.aspnetcore.hosting/2.2.0",
       "hashPath": "microsoft.aspnetcore.hosting.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ubycklv+ZY7Kutdwuy1W4upWcZ6VFR8WUXU7l7B2+mvbDBBPAcfpi+E+Y5GFe+Q157YfA3C49D2GCjAZc7Mobw==",
-      "path": "microsoft.aspnetcore.hosting.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-4ivq53W2k6Nj4eez9wc81ytfGj6HR1NaZJCpOrvghJo9zHuQF57PLhPoQH5ItyCpHXnrN/y7yJDUm+TGYzrx0w==",
+      "path": "microsoft.aspnetcore.hosting.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1PMijw8RMtuQF60SsD/JlKtVfvh4NORAhF4wjysdABhlhTrYmtgssqyncR0Stq5vqtjplZcj6kbT4LRTglt9IQ==",
-      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-F5iHx7odAbFKBV1DNPDkFFcVmD5Tk7rk+tYm3LMQxHEFFdjlg5QcYb5XhHAefl5YaaPeG6ad+/ck8kSG3/D6kw==",
+      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http/2.3.0": {
       "type": "package",
@@ -4618,12 +4621,12 @@
       "path": "microsoft.aspnetcore.http.abstractions/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+    "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2DgZ9rWrJtuR7RYiew01nGRzuQBDaGHGmK56Rk54vsLLsCdzuFUPqbDTJCS1qJQWTbmbIQ9wGIOjpxA1t0l7/w==",
-      "path": "microsoft.aspnetcore.http.extensions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.http.extensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-EY2u/wFF5jsYwGXXswfQWrSsFPmiXsniAlUWo3rv/MGYf99ZFsENDnZcQP6W3c/+xQmQXq0NauzQ7jyy+o1LDQ==",
+      "path": "microsoft.aspnetcore.http.extensions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.http.extensions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Features/2.3.0": {
       "type": "package",
@@ -4632,61 +4635,61 @@
       "path": "microsoft.aspnetcore.http.features/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.features.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+    "Microsoft.AspNetCore.JsonPatch/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o9BB9hftnCsyJalz9IT0DUFxz8Xvgh3TOfGWolpuf19duxB4FySq7c25XDYBmBMS+sun5/PsEUAi58ra4iJAoA==",
-      "path": "microsoft.aspnetcore.jsonpatch/2.2.0",
-      "hashPath": "microsoft.aspnetcore.jsonpatch.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrcdmMlZxwZM0n65T8gq8/erN0aW8HyBXJYhBk3cyfboVQsE/S9h9R59wILMgA4wal3glih+6l06XGs8AnELWA==",
+      "path": "microsoft.aspnetcore.jsonpatch/2.3.0",
+      "hashPath": "microsoft.aspnetcore.jsonpatch.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ET6uZpfVbGR1NjCuLaLy197cQ3qZUjzl7EG5SL4GfJH/c9KRE89MMBrQegqWsh0w1iRUB/zQaK0anAjxa/pz4g==",
-      "path": "microsoft.aspnetcore.mvc.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrF8Fh10hEAS6Qp967IgPqNw2iz3/3Q8FQo+Jowbytaj1JJN86p0z851hSH4XP/sFnI5gFu7mGdkplirAJMWPw==",
+      "path": "microsoft.aspnetcore.mvc.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ALiY4a6BYsghw8PT5+VU593Kqp911U3w9f/dH9/ZoI3ezDsDAGiObqPu/HP1oXK80Ceu0XdQ3F0bx5AXBeuN/Q==",
-      "path": "microsoft.aspnetcore.mvc.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-WRXKrQ4wpzbo6Oo3+n6RegL83B/wXGo4/+Uo8yFFejMNCuNIyk/NL3Qe8MMRC3Mr9NqlOWwJr3qiWv/nKwg7dw==",
+      "path": "microsoft.aspnetcore.mvc.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ScWwXrkAvw6PekWUFkIr5qa9NKn4uZGRvxtt3DvtUrBYW5Iu2y4SS/vx79JN0XDHNYgAJ81nVs+4M7UE1Y/O+g==",
-      "path": "microsoft.aspnetcore.mvc.formatters.json/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.2.0.nupkg.sha512"
+      "sha512": "sha512-bh/nygMBuGoMNitOsstyoqWQj2L4SICecHhVdOVCsMXmkr0KQgzpTE5RwB34ZbxRTERG0p+eG5xnGGdgeoZ/eA==",
+      "path": "microsoft.aspnetcore.mvc.formatters.json/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YKovpp46Fgah0N8H4RGb+7x9vdjj50mS3NON910pYJFQmn20Cd1mYVkTunjy/DrZpvwmJ8o5Es0VnONSYVXEAQ==",
-      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OuJQe9manFUSsDRFCzIHsdLqxkc9N5xTYVTshsMv5DIwgGntSx7tCRFTCAZ5u9Wl7MUJBeQ9DTrlUWtG3v4s2g==",
+      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CIHWEKrHzZfFp7t57UXsueiSA/raku56TgRYauV/W1+KAQq6vevz60zjEKaazt3BI76zwMz3B4jGWnCwd8kwQw==",
-      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-VTqhxnUiawKS22fss5fr/NMJ4MVQHFUgqyWOIaJ9pUY+jmYGCAa+VYfB5DLJYmsD4AhdKnlO6I9lML5tUbDNNA==",
+      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing/2.2.2": {
+    "Microsoft.AspNetCore.Routing/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HcmJmmGYewdNZ6Vcrr5RkQbc/YWU4F79P3uPPBi6fCFOgUewXNM1P4kbPuoem7tN4f7x8mq7gTsm5QGohQ5g/w==",
-      "path": "microsoft.aspnetcore.routing/2.2.2",
-      "hashPath": "microsoft.aspnetcore.routing.2.2.2.nupkg.sha512"
+      "sha512": "sha512-no5/VC0CAQuT4PK4rp2K5fqwuSfzr2mdB6m1XNfWVhHnwzpRQzKAu9flChiT/JTLKwVI0Vq2MSmSW2OFMDCNXg==",
+      "path": "microsoft.aspnetcore.routing/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lRRaPN7jDlUCVCp9i0W+PB0trFaKB0bgMJD7hEJS9Uo4R9MXaMC8X2tJhPLmeVE3SGDdYI4QNKdVmhNvMJGgPQ==",
-      "path": "microsoft.aspnetcore.routing.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ZkFpUrSmp6TocxZLBEX3IBv5dPMbQuMs6L/BPl0WRfn32UVOtNYJQ0bLdh3cL9LMV0rmTW/5R0w8CBYxr0AOUw==",
+      "path": "microsoft.aspnetcore.routing.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Server.Kestrel/2.2.0": {
       "type": "package",
@@ -4758,19 +4761,19 @@
       "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
       "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
+      "sha512": "sha512-lfCjGsc6KRRnYC1NZNmdpDJyyNqO4VgnwpUG3qIIhZbAhdLdjwQiMGAIe2qdb6WTRgPlA6vMPfrT857YH83KiA==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.8.0": {
+    "Microsoft.Azure.DurableTask.Core/3.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
-      "path": "microsoft.azure.durabletask.core/3.8.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
+      "sha512": "sha512-wnB/MYS/qlYM87O1JMbIdhQW5qtFx4VEpVQ95l7D5NZSku9upjelHJ3jlmuhdIwpInMqVaPGcCd8E3fmmmgV5w==",
+      "path": "microsoft.azure.durabletask.core/3.9.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4912,19 +4915,19 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMm6eVLGif1uxv5GBrnE2DvprsLc9Dxe9hd2rathPWYQH1Hdj0k6FogIgmniaVwHPgQa5iJuz8MoRUKODjlBBg==",
-      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.4-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.4-preview.nupkg.sha512"
+      "sha512": "sha512-CqQruJSaqpGjeCRjNxm44VbgnTvPvgOJ5pFjuRfhf0VX/g9WzuSU0N6fhiufet1NHZVtt7tV+XozUHWhR7+47g==",
+      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.5-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.5-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bN08fXiB33HnHNckexkhmMT98podFCj/MtMnmcplF6rhj898nfoxfmu4CFpxFc+QvOOwg8Ousrf0cUgD69Nk3w==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.0.nupkg.sha512"
+      "sha512": "sha512-KFh0HvMTqESPmCmZ7AilxIegw47WgXi8wnVXAwFmfhFCWynUZ9i3q72+Ije9XS6oL4gM/8zr16wOQzCroZ07/A==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4933,12 +4936,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
+      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4947,12 +4950,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4968,12 +4971,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kej0MnZNRtnMYzxchmP+12+Dfrl8CoOluNXRZkWSh2IfX9NYvtquE/zcMfRsqlA16I2VJARbp0rExWr1iVhvqA==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.70",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.70.nupkg.sha512"
+      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -5045,12 +5048,12 @@
       "path": "microsoft.azure.webjobs.extensions.rabbitmq/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.rabbitmq.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vixrIn4FMZsIVezuQvw1RpTBkEkddxDFd1Pi50I2fycsOGbQId6fGE9e6kslznJcxTBUCCvEPwJqRi4bQp06Xg==",
-      "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
+      "sha512": "sha512-RZRFzOTOrb/NWIPYuih19tel4CdOkINHsS7r3/gNzDhXhvvi1XK5pcKNutBC12X0BIRDH+dyfn2U0CMBfX8olA==",
+      "path": "microsoft.azure.webjobs.extensions.redis/1.0.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.redis.1.0.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
@@ -5164,12 +5167,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
+      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5213,19 +5216,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
+      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
+      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5248,12 +5251,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -6592,12 +6595,12 @@
       "path": "system.threading.tasks.dataflow/4.8.0",
       "hashPath": "system.threading.tasks.dataflow.4.8.0.nupkg.sha512"
     },
-    "System.Threading.Tasks.Extensions/4.5.4": {
+    "System.Threading.Tasks.Extensions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-      "path": "system.threading.tasks.extensions/4.5.4",
-      "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
+      "sha512": "sha512-I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg==",
+      "path": "system.threading.tasks.extensions/4.6.0",
+      "hashPath": "system.threading.tasks.extensions.4.6.0.nupkg.sha512"
     },
     "System.Threading.Thread/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
@@ -9,18 +9,19 @@
     ".NETCoreApp,Version=v8.0/linux-x64": {
       "extensions/1.0.0": {
         "dependencies": {
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
           "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.4-preview",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.0",
+          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
           "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
@@ -30,7 +31,7 @@
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.4.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.17.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
+          "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
@@ -78,7 +79,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -170,11 +171,11 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
@@ -504,23 +505,23 @@
           }
         }
       },
-      "MessagePack/2.5.192": {
+      "MessagePack/2.5.301": {
         "dependencies": {
-          "MessagePack.Annotations": "2.5.192",
+          "MessagePack.Annotations": "2.5.301",
           "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
           "lib/net6.0/MessagePack.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
-      "MessagePack.Annotations/2.5.192": {
+      "MessagePack.Annotations/2.5.301": {
         "runtime": {
           "lib/netstandard2.0/MessagePack.Annotations.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
@@ -644,30 +645,30 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0"
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Authorization/2.2.0": {
+      "Microsoft.AspNetCore.Authorization/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+      "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Authorization": "2.2.0"
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Authorization": "2.3.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
@@ -678,9 +679,9 @@
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "8.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.1",
@@ -693,14 +694,14 @@
           "System.Reflection.Metadata": "1.6.0"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.3.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
@@ -721,7 +722,7 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+      "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
@@ -734,78 +735,77 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+      "Microsoft.AspNetCore.JsonPatch/2.3.0": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.JsonPatch.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.18316"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Net.Http.Headers": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Core": "2.2.0",
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Core": "2.3.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.3.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.JsonPatch": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0"
+          "Microsoft.AspNetCore.JsonPatch": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.Mvc.WebApiCompatShim.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.0"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Routing/2.2.2": {
+      "Microsoft.AspNetCore.Routing/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.ObjectPool": "8.0.11",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0"
         }
@@ -820,7 +820,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0",
@@ -832,7 +832,7 @@
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.Cryptography.Cng": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Https/2.2.0": {
@@ -860,7 +860,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -894,7 +894,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -903,7 +903,7 @@
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
@@ -928,8 +928,8 @@
       "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -938,23 +938,23 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
             "assemblyVersion": "2.9.0.0",
-            "fileVersion": "2.9.0.12085"
+            "fileVersion": "2.9.1.24919"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.8.0": {
+      "Microsoft.Azure.DurableTask.Core/3.9.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -965,8 +965,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.8.0.0",
-            "fileVersion": "3.8.0.12085"
+            "assemblyVersion": "3.9.0.0",
+            "fileVersion": "3.9.0.19481"
           }
         }
       },
@@ -977,8 +977,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -992,9 +992,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1045,7 +1045,7 @@
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1258,7 +1258,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1272,7 +1272,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.60.0",
@@ -1282,8 +1282,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.16.0.0",
-            "fileVersion": "4.16.0.26269"
+            "assemblyVersion": "4.16.1.0",
+            "fileVersion": "4.16.1.26276"
           }
         }
       },
@@ -1292,7 +1292,7 @@
           "CloudNative.CloudEvents": "2.6.0",
           "CloudNative.CloudEvents.SystemTextJson": "2.6.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1305,13 +1305,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1320,30 +1320,31 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.5.0"
+            "fileVersion": "3.13.1.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -1375,7 +1376,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1391,12 +1392,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           }
         }
       },
@@ -1404,9 +1405,9 @@
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45"
         },
         "runtime": {
@@ -1453,7 +1454,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1553,7 +1554,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1563,8 +1564,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Redis.dll": {
-            "assemblyVersion": "0.5.0.0",
-            "fileVersion": "0.5.0.0"
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
@@ -1609,7 +1610,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.1.0": {
         "dependencies": {
-          "MessagePack": "2.5.192",
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Azure.SignalR.Management": "1.29.0",
           "Microsoft.Azure.SignalR.Protocols": "1.29.0",
@@ -1730,7 +1731,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -1788,11 +1789,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.5",
-            "fileVersion": "10.0.526.15411"
+            "assemblyVersion": "10.0.0.8",
+            "fileVersion": "10.0.826.23019"
           }
         }
       },
@@ -1876,8 +1877,8 @@
       },
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -1890,36 +1891,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -1968,23 +1970,24 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -2004,7 +2007,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
@@ -2020,7 +2023,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -2775,7 +2778,7 @@
           "System.Security.Permissions": "8.0.0",
           "System.Text.Encoding.CodePages": "8.0.0",
           "System.Text.Json": "8.0.6",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "ZstdSharp.Port": "0.8.0"
         },
         "runtime": {
@@ -3458,7 +3461,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3603,60 +3606,60 @@
       "System.Reactive.Core/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Core.dll": {
             "assemblyVersion": "3.0.6000.0",
-            "fileVersion": "0.0.0.0"
+            "fileVersion": "3.0.6000.0"
           }
         }
       },
       "System.Reactive.Interfaces/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Interfaces.dll": {
             "assemblyVersion": "3.0.6000.0",
-            "fileVersion": "0.0.0.0"
+            "fileVersion": "3.0.6000.0"
           }
         }
       },
       "System.Reactive.Linq/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Linq.dll": {
             "assemblyVersion": "3.0.6000.0",
-            "fileVersion": "0.0.0.0"
+            "fileVersion": "3.0.6000.0"
           }
         }
       },
       "System.Reactive.PlatformServices/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.PlatformServices.dll": {
             "assemblyVersion": "3.0.6000.0",
-            "fileVersion": "0.0.0.0"
+            "fileVersion": "3.0.6000.0"
           }
         }
       },
       "System.Reactive.Providers/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Providers.dll": {
             "assemblyVersion": "3.0.6000.0",
-            "fileVersion": "0.0.0.0"
+            "fileVersion": "3.0.6000.0"
           }
         }
       },
@@ -3966,7 +3969,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
-      "System.Threading.Tasks.Extensions/4.5.4": {},
+      "System.Threading.Tasks.Extensions/4.6.0": {},
       "System.Threading.Thread/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -4011,7 +4014,7 @@
           "System.Text.Encoding.Extensions": "4.3.0",
           "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "System.Xml.XDocument/4.3.0": {
@@ -4355,19 +4358,19 @@
       "path": "librdkafka.redist/2.4.0",
       "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/2.5.192": {
+    "MessagePack/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
-      "path": "messagepack/2.5.192",
-      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+      "sha512": "sha512-WUnJgmYc06ngIxZxLe9sa0P6rOTyOZIQn8SuDvJSjyMn7e8/AdlNAdt81WPUhWKeQ7hDkgxKU1vTrJqX/4L79A==",
+      "path": "messagepack/2.5.301",
+      "hashPath": "messagepack.2.5.301.nupkg.sha512"
     },
-    "MessagePack.Annotations/2.5.192": {
+    "MessagePack.Annotations/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
-      "path": "messagepack.annotations/2.5.192",
-      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
+      "sha512": "sha512-3PyBiSeKTfvtyzUv3+9eXGIw7vBBZ0GAc4k3+RVT0tz2vKv3l0pviiA2b6DrmHyDvj1Au8lSVDDw/wKPMxUQ4A==",
+      "path": "messagepack.annotations/2.5.301",
+      "hashPath": "messagepack.annotations.2.5.301.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
@@ -4432,33 +4435,33 @@
       "path": "microsoft.aspnet.webapi.client/5.2.9",
       "hashPath": "microsoft.aspnet.webapi.client.5.2.9.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-VloMLDJMf3n/9ic5lCBOa42IBYJgyB1JhzLsL68Zqg+2bEPWfGBj/xCJy/LrKTArN0coOcZp3wyVTZlx0y9pHQ==",
-      "path": "microsoft.aspnetcore.authentication.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ve6uvLwKNRkfnO/QeN9M8eUJ49lCnWv/6/9p6iTEuiI6Rtsz+myaBAjdMzLuTViQY032xbTF5AdZF5BJzJJyXQ==",
+      "path": "microsoft.aspnetcore.authentication.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XlVJzJ5wPOYW+Y0J6Q/LVTEyfS4ssLXmt60T0SPP+D8abVhBTl+cgw2gDHlyKYIkcJg7btMVh383NDkMVqD/fg==",
-      "path": "microsoft.aspnetcore.authentication.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-gnLnKGawBjqBnU9fEuel3VcYAARkjyONAliaGDfMc8o8HBtfh+HrOPEoR8Xx4b2RnMb7uxdBDOvEAC7sul79ig==",
+      "path": "microsoft.aspnetcore.authentication.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization/2.2.0": {
+    "Microsoft.AspNetCore.Authorization/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/L0W8H3jMYWyaeA9gBJqS/tSWBegP9aaTM0mjRhxTttBY9z4RVDRYJ2CwPAmAXIuPr3r1sOw+CS8jFVRGHRezQ==",
-      "path": "microsoft.aspnetcore.authorization/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.2.2.0.nupkg.sha512"
+      "sha512": "sha512-2/aBgLqBXva/+w8pzRNY8ET43Gi+dr1gv/7ySfbsh23lTK6IAgID5MGUEa1hreNIF+0XpW4tX7QwVe70+YvaPg==",
+      "path": "microsoft.aspnetcore.authorization/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+    "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aJCo6niDRKuNg2uS2WMEmhJTooQUGARhV2ENQ2tO5443zVHUo19MSgrgGo9FIrfD+4yKPF8Q+FF33WkWfPbyKw==",
-      "path": "microsoft.aspnetcore.authorization.policy/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.policy.2.2.0.nupkg.sha512"
+      "sha512": "sha512-vn31uQ1dA1MIV2WNNDOOOm88V5KgR9esfi0LyQ6eVaGq2h0Yw+R29f5A6qUNJt+RccS3qkYayylAy9tP1wV+7Q==",
+      "path": "microsoft.aspnetcore.authorization.policy/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.policy.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
       "type": "package",
@@ -4474,19 +4477,19 @@
       "path": "microsoft.aspnetcore.hosting/2.2.0",
       "hashPath": "microsoft.aspnetcore.hosting.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ubycklv+ZY7Kutdwuy1W4upWcZ6VFR8WUXU7l7B2+mvbDBBPAcfpi+E+Y5GFe+Q157YfA3C49D2GCjAZc7Mobw==",
-      "path": "microsoft.aspnetcore.hosting.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-4ivq53W2k6Nj4eez9wc81ytfGj6HR1NaZJCpOrvghJo9zHuQF57PLhPoQH5ItyCpHXnrN/y7yJDUm+TGYzrx0w==",
+      "path": "microsoft.aspnetcore.hosting.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1PMijw8RMtuQF60SsD/JlKtVfvh4NORAhF4wjysdABhlhTrYmtgssqyncR0Stq5vqtjplZcj6kbT4LRTglt9IQ==",
-      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-F5iHx7odAbFKBV1DNPDkFFcVmD5Tk7rk+tYm3LMQxHEFFdjlg5QcYb5XhHAefl5YaaPeG6ad+/ck8kSG3/D6kw==",
+      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http/2.3.0": {
       "type": "package",
@@ -4502,12 +4505,12 @@
       "path": "microsoft.aspnetcore.http.abstractions/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+    "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2DgZ9rWrJtuR7RYiew01nGRzuQBDaGHGmK56Rk54vsLLsCdzuFUPqbDTJCS1qJQWTbmbIQ9wGIOjpxA1t0l7/w==",
-      "path": "microsoft.aspnetcore.http.extensions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.http.extensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-EY2u/wFF5jsYwGXXswfQWrSsFPmiXsniAlUWo3rv/MGYf99ZFsENDnZcQP6W3c/+xQmQXq0NauzQ7jyy+o1LDQ==",
+      "path": "microsoft.aspnetcore.http.extensions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.http.extensions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Features/2.3.0": {
       "type": "package",
@@ -4516,61 +4519,61 @@
       "path": "microsoft.aspnetcore.http.features/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.features.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+    "Microsoft.AspNetCore.JsonPatch/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o9BB9hftnCsyJalz9IT0DUFxz8Xvgh3TOfGWolpuf19duxB4FySq7c25XDYBmBMS+sun5/PsEUAi58ra4iJAoA==",
-      "path": "microsoft.aspnetcore.jsonpatch/2.2.0",
-      "hashPath": "microsoft.aspnetcore.jsonpatch.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrcdmMlZxwZM0n65T8gq8/erN0aW8HyBXJYhBk3cyfboVQsE/S9h9R59wILMgA4wal3glih+6l06XGs8AnELWA==",
+      "path": "microsoft.aspnetcore.jsonpatch/2.3.0",
+      "hashPath": "microsoft.aspnetcore.jsonpatch.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ET6uZpfVbGR1NjCuLaLy197cQ3qZUjzl7EG5SL4GfJH/c9KRE89MMBrQegqWsh0w1iRUB/zQaK0anAjxa/pz4g==",
-      "path": "microsoft.aspnetcore.mvc.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrF8Fh10hEAS6Qp967IgPqNw2iz3/3Q8FQo+Jowbytaj1JJN86p0z851hSH4XP/sFnI5gFu7mGdkplirAJMWPw==",
+      "path": "microsoft.aspnetcore.mvc.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ALiY4a6BYsghw8PT5+VU593Kqp911U3w9f/dH9/ZoI3ezDsDAGiObqPu/HP1oXK80Ceu0XdQ3F0bx5AXBeuN/Q==",
-      "path": "microsoft.aspnetcore.mvc.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-WRXKrQ4wpzbo6Oo3+n6RegL83B/wXGo4/+Uo8yFFejMNCuNIyk/NL3Qe8MMRC3Mr9NqlOWwJr3qiWv/nKwg7dw==",
+      "path": "microsoft.aspnetcore.mvc.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ScWwXrkAvw6PekWUFkIr5qa9NKn4uZGRvxtt3DvtUrBYW5Iu2y4SS/vx79JN0XDHNYgAJ81nVs+4M7UE1Y/O+g==",
-      "path": "microsoft.aspnetcore.mvc.formatters.json/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.2.0.nupkg.sha512"
+      "sha512": "sha512-bh/nygMBuGoMNitOsstyoqWQj2L4SICecHhVdOVCsMXmkr0KQgzpTE5RwB34ZbxRTERG0p+eG5xnGGdgeoZ/eA==",
+      "path": "microsoft.aspnetcore.mvc.formatters.json/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YKovpp46Fgah0N8H4RGb+7x9vdjj50mS3NON910pYJFQmn20Cd1mYVkTunjy/DrZpvwmJ8o5Es0VnONSYVXEAQ==",
-      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OuJQe9manFUSsDRFCzIHsdLqxkc9N5xTYVTshsMv5DIwgGntSx7tCRFTCAZ5u9Wl7MUJBeQ9DTrlUWtG3v4s2g==",
+      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CIHWEKrHzZfFp7t57UXsueiSA/raku56TgRYauV/W1+KAQq6vevz60zjEKaazt3BI76zwMz3B4jGWnCwd8kwQw==",
-      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-VTqhxnUiawKS22fss5fr/NMJ4MVQHFUgqyWOIaJ9pUY+jmYGCAa+VYfB5DLJYmsD4AhdKnlO6I9lML5tUbDNNA==",
+      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing/2.2.2": {
+    "Microsoft.AspNetCore.Routing/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HcmJmmGYewdNZ6Vcrr5RkQbc/YWU4F79P3uPPBi6fCFOgUewXNM1P4kbPuoem7tN4f7x8mq7gTsm5QGohQ5g/w==",
-      "path": "microsoft.aspnetcore.routing/2.2.2",
-      "hashPath": "microsoft.aspnetcore.routing.2.2.2.nupkg.sha512"
+      "sha512": "sha512-no5/VC0CAQuT4PK4rp2K5fqwuSfzr2mdB6m1XNfWVhHnwzpRQzKAu9flChiT/JTLKwVI0Vq2MSmSW2OFMDCNXg==",
+      "path": "microsoft.aspnetcore.routing/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lRRaPN7jDlUCVCp9i0W+PB0trFaKB0bgMJD7hEJS9Uo4R9MXaMC8X2tJhPLmeVE3SGDdYI4QNKdVmhNvMJGgPQ==",
-      "path": "microsoft.aspnetcore.routing.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ZkFpUrSmp6TocxZLBEX3IBv5dPMbQuMs6L/BPl0WRfn32UVOtNYJQ0bLdh3cL9LMV0rmTW/5R0w8CBYxr0AOUw==",
+      "path": "microsoft.aspnetcore.routing.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Server.Kestrel/2.2.0": {
       "type": "package",
@@ -4642,19 +4645,19 @@
       "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
       "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
+      "sha512": "sha512-lfCjGsc6KRRnYC1NZNmdpDJyyNqO4VgnwpUG3qIIhZbAhdLdjwQiMGAIe2qdb6WTRgPlA6vMPfrT857YH83KiA==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.8.0": {
+    "Microsoft.Azure.DurableTask.Core/3.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
-      "path": "microsoft.azure.durabletask.core/3.8.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
+      "sha512": "sha512-wnB/MYS/qlYM87O1JMbIdhQW5qtFx4VEpVQ95l7D5NZSku9upjelHJ3jlmuhdIwpInMqVaPGcCd8E3fmmmgV5w==",
+      "path": "microsoft.azure.durabletask.core/3.9.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4796,19 +4799,19 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMm6eVLGif1uxv5GBrnE2DvprsLc9Dxe9hd2rathPWYQH1Hdj0k6FogIgmniaVwHPgQa5iJuz8MoRUKODjlBBg==",
-      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.4-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.4-preview.nupkg.sha512"
+      "sha512": "sha512-CqQruJSaqpGjeCRjNxm44VbgnTvPvgOJ5pFjuRfhf0VX/g9WzuSU0N6fhiufet1NHZVtt7tV+XozUHWhR7+47g==",
+      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.5-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.5-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bN08fXiB33HnHNckexkhmMT98podFCj/MtMnmcplF6rhj898nfoxfmu4CFpxFc+QvOOwg8Ousrf0cUgD69Nk3w==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.0.nupkg.sha512"
+      "sha512": "sha512-KFh0HvMTqESPmCmZ7AilxIegw47WgXi8wnVXAwFmfhFCWynUZ9i3q72+Ije9XS6oL4gM/8zr16wOQzCroZ07/A==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4817,12 +4820,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
+      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4831,12 +4834,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4852,12 +4855,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kej0MnZNRtnMYzxchmP+12+Dfrl8CoOluNXRZkWSh2IfX9NYvtquE/zcMfRsqlA16I2VJARbp0rExWr1iVhvqA==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.70",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.70.nupkg.sha512"
+      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4929,12 +4932,12 @@
       "path": "microsoft.azure.webjobs.extensions.rabbitmq/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.rabbitmq.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vixrIn4FMZsIVezuQvw1RpTBkEkddxDFd1Pi50I2fycsOGbQId6fGE9e6kslznJcxTBUCCvEPwJqRi4bQp06Xg==",
-      "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
+      "sha512": "sha512-RZRFzOTOrb/NWIPYuih19tel4CdOkINHsS7r3/gNzDhXhvvi1XK5pcKNutBC12X0BIRDH+dyfn2U0CMBfX8olA==",
+      "path": "microsoft.azure.webjobs.extensions.redis/1.0.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.redis.1.0.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
@@ -5048,12 +5051,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
+      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5097,19 +5100,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
+      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
+      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5132,12 +5135,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -6658,12 +6661,12 @@
       "path": "system.threading.tasks.dataflow/4.8.0",
       "hashPath": "system.threading.tasks.dataflow.4.8.0.nupkg.sha512"
     },
-    "System.Threading.Tasks.Extensions/4.5.4": {
+    "System.Threading.Tasks.Extensions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-      "path": "system.threading.tasks.extensions/4.5.4",
-      "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
+      "sha512": "sha512-I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg==",
+      "path": "system.threading.tasks.extensions/4.6.0",
+      "hashPath": "system.threading.tasks.extensions.4.6.0.nupkg.sha512"
     },
     "System.Threading.Thread/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -9,18 +9,19 @@
     ".NETCoreApp,Version=v8.0/win-x64": {
       "extensions/1.0.0": {
         "dependencies": {
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
           "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.4-preview",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.0",
+          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
           "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
@@ -30,7 +31,7 @@
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.4.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.17.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
+          "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
@@ -78,7 +79,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -170,11 +171,11 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
@@ -513,23 +514,23 @@
           }
         }
       },
-      "MessagePack/2.5.192": {
+      "MessagePack/2.5.301": {
         "dependencies": {
-          "MessagePack.Annotations": "2.5.192",
+          "MessagePack.Annotations": "2.5.301",
           "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
           "lib/net6.0/MessagePack.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
-      "MessagePack.Annotations/2.5.192": {
+      "MessagePack.Annotations/2.5.301": {
         "runtime": {
           "lib/netstandard2.0/MessagePack.Annotations.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
@@ -653,30 +654,30 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0"
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Authorization/2.2.0": {
+      "Microsoft.AspNetCore.Authorization/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+      "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Authorization": "2.2.0"
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Authorization": "2.3.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
@@ -687,9 +688,9 @@
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "8.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.1",
@@ -702,14 +703,14 @@
           "System.Reflection.Metadata": "1.6.0"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.3.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
@@ -730,7 +731,7 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+      "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
@@ -743,78 +744,77 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+      "Microsoft.AspNetCore.JsonPatch/2.3.0": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.JsonPatch.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.18316"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Net.Http.Headers": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Core": "2.2.0",
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Core": "2.3.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.3.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.JsonPatch": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0"
+          "Microsoft.AspNetCore.JsonPatch": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.Mvc.WebApiCompatShim.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.0"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Routing/2.2.2": {
+      "Microsoft.AspNetCore.Routing/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.ObjectPool": "8.0.11",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0"
         }
@@ -829,7 +829,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0",
@@ -841,7 +841,7 @@
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.Cryptography.Cng": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Https/2.2.0": {
@@ -869,7 +869,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -903,7 +903,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -912,7 +912,7 @@
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
@@ -954,8 +954,8 @@
       "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -964,23 +964,23 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
             "assemblyVersion": "2.9.0.0",
-            "fileVersion": "2.9.0.12085"
+            "fileVersion": "2.9.1.24919"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.8.0": {
+      "Microsoft.Azure.DurableTask.Core/3.9.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -991,8 +991,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.8.0.0",
-            "fileVersion": "3.8.0.12085"
+            "assemblyVersion": "3.9.0.0",
+            "fileVersion": "3.9.0.19481"
           }
         }
       },
@@ -1003,8 +1003,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1018,9 +1018,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1071,7 +1071,7 @@
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1284,7 +1284,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1298,7 +1298,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.60.0",
@@ -1308,8 +1308,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.16.0.0",
-            "fileVersion": "4.16.0.26269"
+            "assemblyVersion": "4.16.1.0",
+            "fileVersion": "4.16.1.26276"
           }
         }
       },
@@ -1318,7 +1318,7 @@
           "CloudNative.CloudEvents": "2.6.0",
           "CloudNative.CloudEvents.SystemTextJson": "2.6.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1331,13 +1331,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1346,30 +1346,31 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.5.0"
+            "fileVersion": "3.13.1.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -1401,7 +1402,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1417,12 +1418,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           }
         }
       },
@@ -1430,9 +1431,9 @@
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45"
         },
         "runtime": {
@@ -1479,7 +1480,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1579,7 +1580,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1589,8 +1590,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Redis.dll": {
-            "assemblyVersion": "0.5.0.0",
-            "fileVersion": "0.5.0.0"
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
@@ -1635,7 +1636,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.1.0": {
         "dependencies": {
-          "MessagePack": "2.5.192",
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Azure.SignalR.Management": "1.29.0",
           "Microsoft.Azure.SignalR.Protocols": "1.29.0",
@@ -1756,7 +1757,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -1814,11 +1815,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.5",
-            "fileVersion": "10.0.526.15411"
+            "assemblyVersion": "10.0.0.8",
+            "fileVersion": "10.0.826.23019"
           }
         }
       },
@@ -1908,8 +1909,8 @@
       },
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -1922,36 +1923,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -2000,23 +2002,24 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -2036,7 +2039,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
@@ -2052,7 +2055,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -2807,7 +2810,7 @@
           "System.Security.Permissions": "8.0.0",
           "System.Text.Encoding.CodePages": "8.0.0",
           "System.Text.Json": "8.0.6",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "ZstdSharp.Port": "0.8.0"
         },
         "runtime": {
@@ -3491,7 +3494,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3635,7 +3638,7 @@
       "System.Reactive.Core/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Core.dll": {
@@ -3647,7 +3650,7 @@
       "System.Reactive.Interfaces/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Interfaces.dll": {
@@ -3659,7 +3662,7 @@
       "System.Reactive.Linq/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Linq.dll": {
@@ -3671,7 +3674,7 @@
       "System.Reactive.PlatformServices/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.PlatformServices.dll": {
@@ -3683,7 +3686,7 @@
       "System.Reactive.Providers/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Providers.dll": {
@@ -4006,7 +4009,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
-      "System.Threading.Tasks.Extensions/4.5.4": {},
+      "System.Threading.Tasks.Extensions/4.6.0": {},
       "System.Threading.Thread/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -4045,7 +4048,7 @@
           "System.Text.Encoding.Extensions": "4.3.0",
           "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "System.Xml.XDocument/4.3.0": {
@@ -4389,19 +4392,19 @@
       "path": "librdkafka.redist/2.4.0",
       "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/2.5.192": {
+    "MessagePack/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
-      "path": "messagepack/2.5.192",
-      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+      "sha512": "sha512-WUnJgmYc06ngIxZxLe9sa0P6rOTyOZIQn8SuDvJSjyMn7e8/AdlNAdt81WPUhWKeQ7hDkgxKU1vTrJqX/4L79A==",
+      "path": "messagepack/2.5.301",
+      "hashPath": "messagepack.2.5.301.nupkg.sha512"
     },
-    "MessagePack.Annotations/2.5.192": {
+    "MessagePack.Annotations/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
-      "path": "messagepack.annotations/2.5.192",
-      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
+      "sha512": "sha512-3PyBiSeKTfvtyzUv3+9eXGIw7vBBZ0GAc4k3+RVT0tz2vKv3l0pviiA2b6DrmHyDvj1Au8lSVDDw/wKPMxUQ4A==",
+      "path": "messagepack.annotations/2.5.301",
+      "hashPath": "messagepack.annotations.2.5.301.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
@@ -4466,33 +4469,33 @@
       "path": "microsoft.aspnet.webapi.client/5.2.9",
       "hashPath": "microsoft.aspnet.webapi.client.5.2.9.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-VloMLDJMf3n/9ic5lCBOa42IBYJgyB1JhzLsL68Zqg+2bEPWfGBj/xCJy/LrKTArN0coOcZp3wyVTZlx0y9pHQ==",
-      "path": "microsoft.aspnetcore.authentication.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ve6uvLwKNRkfnO/QeN9M8eUJ49lCnWv/6/9p6iTEuiI6Rtsz+myaBAjdMzLuTViQY032xbTF5AdZF5BJzJJyXQ==",
+      "path": "microsoft.aspnetcore.authentication.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XlVJzJ5wPOYW+Y0J6Q/LVTEyfS4ssLXmt60T0SPP+D8abVhBTl+cgw2gDHlyKYIkcJg7btMVh383NDkMVqD/fg==",
-      "path": "microsoft.aspnetcore.authentication.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-gnLnKGawBjqBnU9fEuel3VcYAARkjyONAliaGDfMc8o8HBtfh+HrOPEoR8Xx4b2RnMb7uxdBDOvEAC7sul79ig==",
+      "path": "microsoft.aspnetcore.authentication.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization/2.2.0": {
+    "Microsoft.AspNetCore.Authorization/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/L0W8H3jMYWyaeA9gBJqS/tSWBegP9aaTM0mjRhxTttBY9z4RVDRYJ2CwPAmAXIuPr3r1sOw+CS8jFVRGHRezQ==",
-      "path": "microsoft.aspnetcore.authorization/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.2.2.0.nupkg.sha512"
+      "sha512": "sha512-2/aBgLqBXva/+w8pzRNY8ET43Gi+dr1gv/7ySfbsh23lTK6IAgID5MGUEa1hreNIF+0XpW4tX7QwVe70+YvaPg==",
+      "path": "microsoft.aspnetcore.authorization/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+    "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aJCo6niDRKuNg2uS2WMEmhJTooQUGARhV2ENQ2tO5443zVHUo19MSgrgGo9FIrfD+4yKPF8Q+FF33WkWfPbyKw==",
-      "path": "microsoft.aspnetcore.authorization.policy/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.policy.2.2.0.nupkg.sha512"
+      "sha512": "sha512-vn31uQ1dA1MIV2WNNDOOOm88V5KgR9esfi0LyQ6eVaGq2h0Yw+R29f5A6qUNJt+RccS3qkYayylAy9tP1wV+7Q==",
+      "path": "microsoft.aspnetcore.authorization.policy/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.policy.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
       "type": "package",
@@ -4508,19 +4511,19 @@
       "path": "microsoft.aspnetcore.hosting/2.2.0",
       "hashPath": "microsoft.aspnetcore.hosting.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ubycklv+ZY7Kutdwuy1W4upWcZ6VFR8WUXU7l7B2+mvbDBBPAcfpi+E+Y5GFe+Q157YfA3C49D2GCjAZc7Mobw==",
-      "path": "microsoft.aspnetcore.hosting.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-4ivq53W2k6Nj4eez9wc81ytfGj6HR1NaZJCpOrvghJo9zHuQF57PLhPoQH5ItyCpHXnrN/y7yJDUm+TGYzrx0w==",
+      "path": "microsoft.aspnetcore.hosting.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1PMijw8RMtuQF60SsD/JlKtVfvh4NORAhF4wjysdABhlhTrYmtgssqyncR0Stq5vqtjplZcj6kbT4LRTglt9IQ==",
-      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-F5iHx7odAbFKBV1DNPDkFFcVmD5Tk7rk+tYm3LMQxHEFFdjlg5QcYb5XhHAefl5YaaPeG6ad+/ck8kSG3/D6kw==",
+      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http/2.3.0": {
       "type": "package",
@@ -4536,12 +4539,12 @@
       "path": "microsoft.aspnetcore.http.abstractions/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+    "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2DgZ9rWrJtuR7RYiew01nGRzuQBDaGHGmK56Rk54vsLLsCdzuFUPqbDTJCS1qJQWTbmbIQ9wGIOjpxA1t0l7/w==",
-      "path": "microsoft.aspnetcore.http.extensions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.http.extensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-EY2u/wFF5jsYwGXXswfQWrSsFPmiXsniAlUWo3rv/MGYf99ZFsENDnZcQP6W3c/+xQmQXq0NauzQ7jyy+o1LDQ==",
+      "path": "microsoft.aspnetcore.http.extensions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.http.extensions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Features/2.3.0": {
       "type": "package",
@@ -4550,61 +4553,61 @@
       "path": "microsoft.aspnetcore.http.features/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.features.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+    "Microsoft.AspNetCore.JsonPatch/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o9BB9hftnCsyJalz9IT0DUFxz8Xvgh3TOfGWolpuf19duxB4FySq7c25XDYBmBMS+sun5/PsEUAi58ra4iJAoA==",
-      "path": "microsoft.aspnetcore.jsonpatch/2.2.0",
-      "hashPath": "microsoft.aspnetcore.jsonpatch.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrcdmMlZxwZM0n65T8gq8/erN0aW8HyBXJYhBk3cyfboVQsE/S9h9R59wILMgA4wal3glih+6l06XGs8AnELWA==",
+      "path": "microsoft.aspnetcore.jsonpatch/2.3.0",
+      "hashPath": "microsoft.aspnetcore.jsonpatch.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ET6uZpfVbGR1NjCuLaLy197cQ3qZUjzl7EG5SL4GfJH/c9KRE89MMBrQegqWsh0w1iRUB/zQaK0anAjxa/pz4g==",
-      "path": "microsoft.aspnetcore.mvc.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrF8Fh10hEAS6Qp967IgPqNw2iz3/3Q8FQo+Jowbytaj1JJN86p0z851hSH4XP/sFnI5gFu7mGdkplirAJMWPw==",
+      "path": "microsoft.aspnetcore.mvc.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ALiY4a6BYsghw8PT5+VU593Kqp911U3w9f/dH9/ZoI3ezDsDAGiObqPu/HP1oXK80Ceu0XdQ3F0bx5AXBeuN/Q==",
-      "path": "microsoft.aspnetcore.mvc.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-WRXKrQ4wpzbo6Oo3+n6RegL83B/wXGo4/+Uo8yFFejMNCuNIyk/NL3Qe8MMRC3Mr9NqlOWwJr3qiWv/nKwg7dw==",
+      "path": "microsoft.aspnetcore.mvc.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ScWwXrkAvw6PekWUFkIr5qa9NKn4uZGRvxtt3DvtUrBYW5Iu2y4SS/vx79JN0XDHNYgAJ81nVs+4M7UE1Y/O+g==",
-      "path": "microsoft.aspnetcore.mvc.formatters.json/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.2.0.nupkg.sha512"
+      "sha512": "sha512-bh/nygMBuGoMNitOsstyoqWQj2L4SICecHhVdOVCsMXmkr0KQgzpTE5RwB34ZbxRTERG0p+eG5xnGGdgeoZ/eA==",
+      "path": "microsoft.aspnetcore.mvc.formatters.json/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YKovpp46Fgah0N8H4RGb+7x9vdjj50mS3NON910pYJFQmn20Cd1mYVkTunjy/DrZpvwmJ8o5Es0VnONSYVXEAQ==",
-      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OuJQe9manFUSsDRFCzIHsdLqxkc9N5xTYVTshsMv5DIwgGntSx7tCRFTCAZ5u9Wl7MUJBeQ9DTrlUWtG3v4s2g==",
+      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CIHWEKrHzZfFp7t57UXsueiSA/raku56TgRYauV/W1+KAQq6vevz60zjEKaazt3BI76zwMz3B4jGWnCwd8kwQw==",
-      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-VTqhxnUiawKS22fss5fr/NMJ4MVQHFUgqyWOIaJ9pUY+jmYGCAa+VYfB5DLJYmsD4AhdKnlO6I9lML5tUbDNNA==",
+      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing/2.2.2": {
+    "Microsoft.AspNetCore.Routing/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HcmJmmGYewdNZ6Vcrr5RkQbc/YWU4F79P3uPPBi6fCFOgUewXNM1P4kbPuoem7tN4f7x8mq7gTsm5QGohQ5g/w==",
-      "path": "microsoft.aspnetcore.routing/2.2.2",
-      "hashPath": "microsoft.aspnetcore.routing.2.2.2.nupkg.sha512"
+      "sha512": "sha512-no5/VC0CAQuT4PK4rp2K5fqwuSfzr2mdB6m1XNfWVhHnwzpRQzKAu9flChiT/JTLKwVI0Vq2MSmSW2OFMDCNXg==",
+      "path": "microsoft.aspnetcore.routing/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lRRaPN7jDlUCVCp9i0W+PB0trFaKB0bgMJD7hEJS9Uo4R9MXaMC8X2tJhPLmeVE3SGDdYI4QNKdVmhNvMJGgPQ==",
-      "path": "microsoft.aspnetcore.routing.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ZkFpUrSmp6TocxZLBEX3IBv5dPMbQuMs6L/BPl0WRfn32UVOtNYJQ0bLdh3cL9LMV0rmTW/5R0w8CBYxr0AOUw==",
+      "path": "microsoft.aspnetcore.routing.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Server.Kestrel/2.2.0": {
       "type": "package",
@@ -4676,19 +4679,19 @@
       "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
       "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
+      "sha512": "sha512-lfCjGsc6KRRnYC1NZNmdpDJyyNqO4VgnwpUG3qIIhZbAhdLdjwQiMGAIe2qdb6WTRgPlA6vMPfrT857YH83KiA==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.8.0": {
+    "Microsoft.Azure.DurableTask.Core/3.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
-      "path": "microsoft.azure.durabletask.core/3.8.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
+      "sha512": "sha512-wnB/MYS/qlYM87O1JMbIdhQW5qtFx4VEpVQ95l7D5NZSku9upjelHJ3jlmuhdIwpInMqVaPGcCd8E3fmmmgV5w==",
+      "path": "microsoft.azure.durabletask.core/3.9.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4830,19 +4833,19 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMm6eVLGif1uxv5GBrnE2DvprsLc9Dxe9hd2rathPWYQH1Hdj0k6FogIgmniaVwHPgQa5iJuz8MoRUKODjlBBg==",
-      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.4-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.4-preview.nupkg.sha512"
+      "sha512": "sha512-CqQruJSaqpGjeCRjNxm44VbgnTvPvgOJ5pFjuRfhf0VX/g9WzuSU0N6fhiufet1NHZVtt7tV+XozUHWhR7+47g==",
+      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.5-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.5-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bN08fXiB33HnHNckexkhmMT98podFCj/MtMnmcplF6rhj898nfoxfmu4CFpxFc+QvOOwg8Ousrf0cUgD69Nk3w==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.0.nupkg.sha512"
+      "sha512": "sha512-KFh0HvMTqESPmCmZ7AilxIegw47WgXi8wnVXAwFmfhFCWynUZ9i3q72+Ije9XS6oL4gM/8zr16wOQzCroZ07/A==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4851,12 +4854,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
+      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4865,12 +4868,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4886,12 +4889,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kej0MnZNRtnMYzxchmP+12+Dfrl8CoOluNXRZkWSh2IfX9NYvtquE/zcMfRsqlA16I2VJARbp0rExWr1iVhvqA==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.70",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.70.nupkg.sha512"
+      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4963,12 +4966,12 @@
       "path": "microsoft.azure.webjobs.extensions.rabbitmq/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.rabbitmq.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vixrIn4FMZsIVezuQvw1RpTBkEkddxDFd1Pi50I2fycsOGbQId6fGE9e6kslznJcxTBUCCvEPwJqRi4bQp06Xg==",
-      "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
+      "sha512": "sha512-RZRFzOTOrb/NWIPYuih19tel4CdOkINHsS7r3/gNzDhXhvvi1XK5pcKNutBC12X0BIRDH+dyfn2U0CMBfX8olA==",
+      "path": "microsoft.azure.webjobs.extensions.redis/1.0.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.redis.1.0.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
@@ -5082,12 +5085,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
+      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5131,19 +5134,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
+      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
+      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5166,12 +5169,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -6692,12 +6695,12 @@
       "path": "system.threading.tasks.dataflow/4.8.0",
       "hashPath": "system.threading.tasks.dataflow.4.8.0.nupkg.sha512"
     },
-    "System.Threading.Tasks.Extensions/4.5.4": {
+    "System.Threading.Tasks.Extensions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-      "path": "system.threading.tasks.extensions/4.5.4",
-      "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
+      "sha512": "sha512-I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg==",
+      "path": "system.threading.tasks.extensions/4.6.0",
+      "hashPath": "system.threading.tasks.extensions.4.6.0.nupkg.sha512"
     },
     "System.Threading.Thread/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -9,18 +9,19 @@
     ".NETCoreApp,Version=v8.0/win-x86": {
       "extensions/1.0.0": {
         "dependencies": {
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
           "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.4-preview",
-          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.0",
+          "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
+          "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.8.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.70",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
           "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
@@ -30,7 +31,7 @@
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.CosmosDBSearch": "0.4.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI.Kusto": "0.17.0-alpha",
           "Microsoft.Azure.WebJobs.Extensions.RabbitMQ": "2.1.0",
-          "Microsoft.Azure.WebJobs.Extensions.Redis": "0.5.0-preview",
+          "Microsoft.Azure.WebJobs.Extensions.Redis": "1.0.0",
           "Microsoft.Azure.WebJobs.Extensions.SendGrid": "3.1.1",
           "Microsoft.Azure.WebJobs.Extensions.ServiceBus": "5.17.0",
           "Microsoft.Azure.WebJobs.Extensions.SignalRService": "2.1.0",
@@ -78,7 +79,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -170,11 +171,11 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Messaging.EventHubs.Processor.dll": {
@@ -519,23 +520,23 @@
           }
         }
       },
-      "MessagePack/2.5.192": {
+      "MessagePack/2.5.301": {
         "dependencies": {
-          "MessagePack.Annotations": "2.5.192",
+          "MessagePack.Annotations": "2.5.301",
           "Microsoft.NET.StringTools": "17.6.3"
         },
         "runtime": {
           "lib/net6.0/MessagePack.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
-      "MessagePack.Annotations/2.5.192": {
+      "MessagePack.Annotations/2.5.301": {
         "runtime": {
           "lib/netstandard2.0/MessagePack.Annotations.dll": {
             "assemblyVersion": "2.5.0.0",
-            "fileVersion": "2.5.192.54228"
+            "fileVersion": "2.5.301.22103"
           }
         }
       },
@@ -659,30 +660,30 @@
           }
         }
       },
-      "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+      "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0"
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Authorization/2.2.0": {
+      "Microsoft.AspNetCore.Authorization/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+      "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Authorization": "2.2.0"
+          "Microsoft.AspNetCore.Authentication.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Authorization": "2.3.0"
         }
       },
       "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
@@ -693,9 +694,9 @@
       },
       "Microsoft.AspNetCore.Hosting/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "8.0.0",
           "Microsoft.Extensions.Configuration.FileExtensions": "8.0.1",
@@ -708,14 +709,14 @@
           "System.Reflection.Metadata": "1.6.0"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1"
         }
       },
-      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Features": "2.3.0",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
@@ -736,7 +737,7 @@
           "System.Text.Encodings.Web": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+      "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
@@ -749,78 +750,77 @@
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+      "Microsoft.AspNetCore.JsonPatch/2.3.0": {
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.JsonPatch.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.18316"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Net.Http.Headers": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Authentication.Core": "2.2.0",
-          "Microsoft.AspNetCore.Authorization.Policy": "2.2.0",
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Authentication.Core": "2.3.0",
+          "Microsoft.AspNetCore.Authorization.Policy": "2.3.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.ResponseCaching.Abstractions": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.DependencyModel": "2.1.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.JsonPatch": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0"
+          "Microsoft.AspNetCore.JsonPatch": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0"
         }
       },
-      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+      "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Mvc.Core": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.Core": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.AspNetCore.Mvc.WebApiCompatShim.dll": {
-            "assemblyVersion": "2.2.0.0",
-            "fileVersion": "2.2.0.0"
+            "assemblyVersion": "2.3.0.0",
+            "fileVersion": "2.3.0.25014"
           }
         }
       },
-      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
       },
-      "Microsoft.AspNetCore.Routing/2.2.2": {
+      "Microsoft.AspNetCore.Routing/2.3.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.AspNetCore.Routing.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
+          "Microsoft.AspNetCore.Routing.Abstractions": "2.3.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.ObjectPool": "8.0.11",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
-      "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+      "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
         "dependencies": {
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0"
         }
@@ -835,7 +835,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.WebUtilities": "2.3.0",
@@ -847,7 +847,7 @@
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Security.Cryptography.Cng": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "Microsoft.AspNetCore.Server.Kestrel.Https/2.2.0": {
@@ -875,7 +875,7 @@
       },
       "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/2.2.0": {
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting.Abstractions": "2.2.0",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "2.2.0",
           "Microsoft.Extensions.Options": "8.0.2"
         }
@@ -909,7 +909,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -918,7 +918,7 @@
           "System.Memory": "4.5.5",
           "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "System.ValueTuple": "4.5.0"
         },
         "runtime": {
@@ -943,8 +943,8 @@
       "Microsoft.Azure.DurableTask.ApplicationInsights/0.11.0": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -953,23 +953,23 @@
           }
         }
       },
-      "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+      "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
         "dependencies": {
           "Azure.Data.Tables": "12.11.0",
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.AzureStorage.dll": {
             "assemblyVersion": "2.9.0.0",
-            "fileVersion": "2.9.0.12085"
+            "fileVersion": "2.9.1.24919"
           }
         }
       },
-      "Microsoft.Azure.DurableTask.Core/3.8.0": {
+      "Microsoft.Azure.DurableTask.Core/3.9.0": {
         "dependencies": {
           "Castle.Core": "5.2.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -980,8 +980,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.Core.dll": {
-            "assemblyVersion": "3.8.0.0",
-            "fileVersion": "3.8.0.12085"
+            "assemblyVersion": "3.9.0.0",
+            "fileVersion": "3.9.0.19481"
           }
         }
       },
@@ -992,8 +992,8 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1007,9 +1007,9 @@
       },
       "Microsoft.Azure.DurableTask.Netherite.AzureFunctions/3.1.1": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1060,7 +1060,7 @@
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1273,7 +1273,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1287,7 +1287,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+      "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
         "dependencies": {
           "Microsoft.Azure.Core.NewtonsoftJson": "2.0.0",
           "Microsoft.Azure.Cosmos": "3.60.0",
@@ -1297,8 +1297,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll": {
-            "assemblyVersion": "4.16.0.0",
-            "fileVersion": "4.16.0.26269"
+            "assemblyVersion": "4.16.1.0",
+            "fileVersion": "4.16.1.26276"
           }
         }
       },
@@ -1307,7 +1307,7 @@
           "CloudNative.CloudEvents": "2.6.0",
           "CloudNative.CloudEvents.SystemTextJson": "2.6.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.AspNetCore.Server.Kestrel": "2.2.0",
           "Microsoft.Azure.Functions.Extensions.Dapr.Core": "0.17.0-preview01",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1320,13 +1320,13 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
           "Microsoft.Azure.DurableTask.ApplicationInsights": "0.11.0",
-          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.AzureStorage": "2.9.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers": "0.5.0",
           "Microsoft.Azure.WebJobs.Extensions.Rpc": "3.0.39",
@@ -1335,30 +1335,31 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.12.5.0"
+            "fileVersion": "3.13.1.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -1390,7 +1391,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1406,12 +1407,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.70.0",
-            "fileVersion": "1.0.70.0"
+            "assemblyVersion": "1.0.100.0",
+            "fileVersion": "1.0.100.0"
           }
         }
       },
@@ -1419,9 +1420,9 @@
         "dependencies": {
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.AspNetCore.Http": "2.3.0",
-          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
-          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.AspNetCore.Routing": "2.2.2",
+          "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.3.0",
+          "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
+          "Microsoft.AspNetCore.Routing": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45"
         },
         "runtime": {
@@ -1468,7 +1469,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1568,7 +1569,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+      "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
         "dependencies": {
           "Microsoft.Azure.StackExchangeRedis": "2.0.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
@@ -1578,8 +1579,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Redis.dll": {
-            "assemblyVersion": "0.5.0.0",
-            "fileVersion": "0.5.0.0"
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
           }
         }
       },
@@ -1624,7 +1625,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.SignalRService/2.1.0": {
         "dependencies": {
-          "MessagePack": "2.5.192",
+          "MessagePack": "2.5.301",
           "Microsoft.Azure.SignalR": "1.29.0",
           "Microsoft.Azure.SignalR.Management": "1.29.0",
           "Microsoft.Azure.SignalR.Protocols": "1.29.0",
@@ -1745,7 +1746,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.3.0",
-          "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
+          "Microsoft.AspNetCore.Http.Extensions": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -1803,11 +1804,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.5",
-            "fileVersion": "10.0.526.15411"
+            "assemblyVersion": "10.0.0.8",
+            "fileVersion": "10.0.826.23019"
           }
         }
       },
@@ -1897,8 +1898,8 @@
       },
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -1911,36 +1912,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.8.1",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -1989,23 +1991,24 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.8.1",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
+          "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.8.0.0",
-            "fileVersion": "1.8.1.58242"
+            "assemblyVersion": "1.9.0.0",
+            "fileVersion": "1.9.0.26961"
           }
         }
       },
@@ -2025,7 +2028,7 @@
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
-          "Microsoft.Azure.DurableTask.Core": "3.8.0",
+          "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
@@ -2041,7 +2044,7 @@
       },
       "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.12.5",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
           "Microsoft.DurableTask.SqlServer": "1.6.0"
         },
         "runtime": {
@@ -2796,7 +2799,7 @@
           "System.Security.Permissions": "8.0.0",
           "System.Text.Encoding.CodePages": "8.0.0",
           "System.Text.Json": "8.0.6",
-          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.6.0",
           "ZstdSharp.Port": "0.8.0"
         },
         "runtime": {
@@ -3463,7 +3466,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.5"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3607,7 +3610,7 @@
       "System.Reactive.Core/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Core.dll": {
@@ -3619,7 +3622,7 @@
       "System.Reactive.Interfaces/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Interfaces.dll": {
@@ -3631,7 +3634,7 @@
       "System.Reactive.Linq/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Linq.dll": {
@@ -3643,7 +3646,7 @@
       "System.Reactive.PlatformServices/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.PlatformServices.dll": {
@@ -3655,7 +3658,7 @@
       "System.Reactive.Providers/4.4.1": {
         "dependencies": {
           "System.Reactive": "4.4.1",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         },
         "runtime": {
           "lib/netstandard2.0/System.Reactive.Providers.dll": {
@@ -3978,7 +3981,7 @@
         }
       },
       "System.Threading.Tasks.Dataflow/4.8.0": {},
-      "System.Threading.Tasks.Extensions/4.5.4": {},
+      "System.Threading.Tasks.Extensions/4.6.0": {},
       "System.Threading.Thread/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -4017,7 +4020,7 @@
           "System.Text.Encoding.Extensions": "4.3.0",
           "System.Text.RegularExpressions": "4.3.1",
           "System.Threading.Tasks": "4.3.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Threading.Tasks.Extensions": "4.6.0"
         }
       },
       "System.Xml.XDocument/4.3.0": {
@@ -4361,19 +4364,19 @@
       "path": "librdkafka.redist/2.4.0",
       "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
     },
-    "MessagePack/2.5.192": {
+    "MessagePack/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Jtle5MaFeIFkdXtxQeL9Tu2Y3HsAQGoSntOzrn6Br/jrl6c8QmG22GEioT5HBtZJR0zw0s46OnKU8ei2M3QifA==",
-      "path": "messagepack/2.5.192",
-      "hashPath": "messagepack.2.5.192.nupkg.sha512"
+      "sha512": "sha512-WUnJgmYc06ngIxZxLe9sa0P6rOTyOZIQn8SuDvJSjyMn7e8/AdlNAdt81WPUhWKeQ7hDkgxKU1vTrJqX/4L79A==",
+      "path": "messagepack/2.5.301",
+      "hashPath": "messagepack.2.5.301.nupkg.sha512"
     },
-    "MessagePack.Annotations/2.5.192": {
+    "MessagePack.Annotations/2.5.301": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jaJuwcgovWIZ8Zysdyf3b7b34/BrADw4v82GaEZymUhDd3ScMPrYd/cttekeDteJJPXseJxp04yTIcxiVUjTWg==",
-      "path": "messagepack.annotations/2.5.192",
-      "hashPath": "messagepack.annotations.2.5.192.nupkg.sha512"
+      "sha512": "sha512-3PyBiSeKTfvtyzUv3+9eXGIw7vBBZ0GAc4k3+RVT0tz2vKv3l0pviiA2b6DrmHyDvj1Au8lSVDDw/wKPMxUQ4A==",
+      "path": "messagepack.annotations/2.5.301",
+      "hashPath": "messagepack.annotations.2.5.301.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights/2.23.0": {
       "type": "package",
@@ -4438,33 +4441,33 @@
       "path": "microsoft.aspnet.webapi.client/5.2.9",
       "hashPath": "microsoft.aspnet.webapi.client.5.2.9.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-VloMLDJMf3n/9ic5lCBOa42IBYJgyB1JhzLsL68Zqg+2bEPWfGBj/xCJy/LrKTArN0coOcZp3wyVTZlx0y9pHQ==",
-      "path": "microsoft.aspnetcore.authentication.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ve6uvLwKNRkfnO/QeN9M8eUJ49lCnWv/6/9p6iTEuiI6Rtsz+myaBAjdMzLuTViQY032xbTF5AdZF5BJzJJyXQ==",
+      "path": "microsoft.aspnetcore.authentication.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authentication.Core/2.2.0": {
+    "Microsoft.AspNetCore.Authentication.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XlVJzJ5wPOYW+Y0J6Q/LVTEyfS4ssLXmt60T0SPP+D8abVhBTl+cgw2gDHlyKYIkcJg7btMVh383NDkMVqD/fg==",
-      "path": "microsoft.aspnetcore.authentication.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authentication.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-gnLnKGawBjqBnU9fEuel3VcYAARkjyONAliaGDfMc8o8HBtfh+HrOPEoR8Xx4b2RnMb7uxdBDOvEAC7sul79ig==",
+      "path": "microsoft.aspnetcore.authentication.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authentication.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization/2.2.0": {
+    "Microsoft.AspNetCore.Authorization/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-/L0W8H3jMYWyaeA9gBJqS/tSWBegP9aaTM0mjRhxTttBY9z4RVDRYJ2CwPAmAXIuPr3r1sOw+CS8jFVRGHRezQ==",
-      "path": "microsoft.aspnetcore.authorization/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.2.2.0.nupkg.sha512"
+      "sha512": "sha512-2/aBgLqBXva/+w8pzRNY8ET43Gi+dr1gv/7ySfbsh23lTK6IAgID5MGUEa1hreNIF+0XpW4tX7QwVe70+YvaPg==",
+      "path": "microsoft.aspnetcore.authorization/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Authorization.Policy/2.2.0": {
+    "Microsoft.AspNetCore.Authorization.Policy/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aJCo6niDRKuNg2uS2WMEmhJTooQUGARhV2ENQ2tO5443zVHUo19MSgrgGo9FIrfD+4yKPF8Q+FF33WkWfPbyKw==",
-      "path": "microsoft.aspnetcore.authorization.policy/2.2.0",
-      "hashPath": "microsoft.aspnetcore.authorization.policy.2.2.0.nupkg.sha512"
+      "sha512": "sha512-vn31uQ1dA1MIV2WNNDOOOm88V5KgR9esfi0LyQ6eVaGq2h0Yw+R29f5A6qUNJt+RccS3qkYayylAy9tP1wV+7Q==",
+      "path": "microsoft.aspnetcore.authorization.policy/2.3.0",
+      "hashPath": "microsoft.aspnetcore.authorization.policy.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Connections.Abstractions/2.2.0": {
       "type": "package",
@@ -4480,19 +4483,19 @@
       "path": "microsoft.aspnetcore.hosting/2.2.0",
       "hashPath": "microsoft.aspnetcore.hosting.2.2.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ubycklv+ZY7Kutdwuy1W4upWcZ6VFR8WUXU7l7B2+mvbDBBPAcfpi+E+Y5GFe+Q157YfA3C49D2GCjAZc7Mobw==",
-      "path": "microsoft.aspnetcore.hosting.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-4ivq53W2k6Nj4eez9wc81ytfGj6HR1NaZJCpOrvghJo9zHuQF57PLhPoQH5ItyCpHXnrN/y7yJDUm+TGYzrx0w==",
+      "path": "microsoft.aspnetcore.hosting.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Hosting.Server.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-1PMijw8RMtuQF60SsD/JlKtVfvh4NORAhF4wjysdABhlhTrYmtgssqyncR0Stq5vqtjplZcj6kbT4LRTglt9IQ==",
-      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-F5iHx7odAbFKBV1DNPDkFFcVmD5Tk7rk+tYm3LMQxHEFFdjlg5QcYb5XhHAefl5YaaPeG6ad+/ck8kSG3/D6kw==",
+      "path": "microsoft.aspnetcore.hosting.server.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http/2.3.0": {
       "type": "package",
@@ -4508,12 +4511,12 @@
       "path": "microsoft.aspnetcore.http.abstractions/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Http.Extensions/2.2.0": {
+    "Microsoft.AspNetCore.Http.Extensions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2DgZ9rWrJtuR7RYiew01nGRzuQBDaGHGmK56Rk54vsLLsCdzuFUPqbDTJCS1qJQWTbmbIQ9wGIOjpxA1t0l7/w==",
-      "path": "microsoft.aspnetcore.http.extensions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.http.extensions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-EY2u/wFF5jsYwGXXswfQWrSsFPmiXsniAlUWo3rv/MGYf99ZFsENDnZcQP6W3c/+xQmQXq0NauzQ7jyy+o1LDQ==",
+      "path": "microsoft.aspnetcore.http.extensions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.http.extensions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Http.Features/2.3.0": {
       "type": "package",
@@ -4522,61 +4525,61 @@
       "path": "microsoft.aspnetcore.http.features/2.3.0",
       "hashPath": "microsoft.aspnetcore.http.features.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.JsonPatch/2.2.0": {
+    "Microsoft.AspNetCore.JsonPatch/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-o9BB9hftnCsyJalz9IT0DUFxz8Xvgh3TOfGWolpuf19duxB4FySq7c25XDYBmBMS+sun5/PsEUAi58ra4iJAoA==",
-      "path": "microsoft.aspnetcore.jsonpatch/2.2.0",
-      "hashPath": "microsoft.aspnetcore.jsonpatch.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrcdmMlZxwZM0n65T8gq8/erN0aW8HyBXJYhBk3cyfboVQsE/S9h9R59wILMgA4wal3glih+6l06XGs8AnELWA==",
+      "path": "microsoft.aspnetcore.jsonpatch/2.3.0",
+      "hashPath": "microsoft.aspnetcore.jsonpatch.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ET6uZpfVbGR1NjCuLaLy197cQ3qZUjzl7EG5SL4GfJH/c9KRE89MMBrQegqWsh0w1iRUB/zQaK0anAjxa/pz4g==",
-      "path": "microsoft.aspnetcore.mvc.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-xrF8Fh10hEAS6Qp967IgPqNw2iz3/3Q8FQo+Jowbytaj1JJN86p0z851hSH4XP/sFnI5gFu7mGdkplirAJMWPw==",
+      "path": "microsoft.aspnetcore.mvc.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Core/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Core/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ALiY4a6BYsghw8PT5+VU593Kqp911U3w9f/dH9/ZoI3ezDsDAGiObqPu/HP1oXK80Ceu0XdQ3F0bx5AXBeuN/Q==",
-      "path": "microsoft.aspnetcore.mvc.core/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.core.2.2.0.nupkg.sha512"
+      "sha512": "sha512-WRXKrQ4wpzbo6Oo3+n6RegL83B/wXGo4/+Uo8yFFejMNCuNIyk/NL3Qe8MMRC3Mr9NqlOWwJr3qiWv/nKwg7dw==",
+      "path": "microsoft.aspnetcore.mvc.core/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.core.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.Formatters.Json/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ScWwXrkAvw6PekWUFkIr5qa9NKn4uZGRvxtt3DvtUrBYW5Iu2y4SS/vx79JN0XDHNYgAJ81nVs+4M7UE1Y/O+g==",
-      "path": "microsoft.aspnetcore.mvc.formatters.json/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.2.0.nupkg.sha512"
+      "sha512": "sha512-bh/nygMBuGoMNitOsstyoqWQj2L4SICecHhVdOVCsMXmkr0KQgzpTE5RwB34ZbxRTERG0p+eG5xnGGdgeoZ/eA==",
+      "path": "microsoft.aspnetcore.mvc.formatters.json/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.formatters.json.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.2.0": {
+    "Microsoft.AspNetCore.Mvc.WebApiCompatShim/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-YKovpp46Fgah0N8H4RGb+7x9vdjj50mS3NON910pYJFQmn20Cd1mYVkTunjy/DrZpvwmJ8o5Es0VnONSYVXEAQ==",
-      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.2.0",
-      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.2.0.nupkg.sha512"
+      "sha512": "sha512-OuJQe9manFUSsDRFCzIHsdLqxkc9N5xTYVTshsMv5DIwgGntSx7tCRFTCAZ5u9Wl7MUJBeQ9DTrlUWtG3v4s2g==",
+      "path": "microsoft.aspnetcore.mvc.webapicompatshim/2.3.0",
+      "hashPath": "microsoft.aspnetcore.mvc.webapicompatshim.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.ResponseCaching.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-CIHWEKrHzZfFp7t57UXsueiSA/raku56TgRYauV/W1+KAQq6vevz60zjEKaazt3BI76zwMz3B4jGWnCwd8kwQw==",
-      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-VTqhxnUiawKS22fss5fr/NMJ4MVQHFUgqyWOIaJ9pUY+jmYGCAa+VYfB5DLJYmsD4AhdKnlO6I9lML5tUbDNNA==",
+      "path": "microsoft.aspnetcore.responsecaching.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.responsecaching.abstractions.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing/2.2.2": {
+    "Microsoft.AspNetCore.Routing/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-HcmJmmGYewdNZ6Vcrr5RkQbc/YWU4F79P3uPPBi6fCFOgUewXNM1P4kbPuoem7tN4f7x8mq7gTsm5QGohQ5g/w==",
-      "path": "microsoft.aspnetcore.routing/2.2.2",
-      "hashPath": "microsoft.aspnetcore.routing.2.2.2.nupkg.sha512"
+      "sha512": "sha512-no5/VC0CAQuT4PK4rp2K5fqwuSfzr2mdB6m1XNfWVhHnwzpRQzKAu9flChiT/JTLKwVI0Vq2MSmSW2OFMDCNXg==",
+      "path": "microsoft.aspnetcore.routing/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.2.3.0.nupkg.sha512"
     },
-    "Microsoft.AspNetCore.Routing.Abstractions/2.2.0": {
+    "Microsoft.AspNetCore.Routing.Abstractions/2.3.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lRRaPN7jDlUCVCp9i0W+PB0trFaKB0bgMJD7hEJS9Uo4R9MXaMC8X2tJhPLmeVE3SGDdYI4QNKdVmhNvMJGgPQ==",
-      "path": "microsoft.aspnetcore.routing.abstractions/2.2.0",
-      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.2.0.nupkg.sha512"
+      "sha512": "sha512-ZkFpUrSmp6TocxZLBEX3IBv5dPMbQuMs6L/BPl0WRfn32UVOtNYJQ0bLdh3cL9LMV0rmTW/5R0w8CBYxr0AOUw==",
+      "path": "microsoft.aspnetcore.routing.abstractions/2.3.0",
+      "hashPath": "microsoft.aspnetcore.routing.abstractions.2.3.0.nupkg.sha512"
     },
     "Microsoft.AspNetCore.Server.Kestrel/2.2.0": {
       "type": "package",
@@ -4648,19 +4651,19 @@
       "path": "microsoft.azure.durabletask.applicationinsights/0.11.0",
       "hashPath": "microsoft.azure.durabletask.applicationinsights.0.11.0.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.AzureStorage/2.9.0": {
+    "Microsoft.Azure.DurableTask.AzureStorage/2.9.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5nVmpNaCb+StVd/Yl++zXMcFLUkMKnuMm+OvjBmZeoeetEZK+CGqYmOXy5DaD+giBPT2ZymPa/2Ta/6eooUhFw==",
-      "path": "microsoft.azure.durabletask.azurestorage/2.9.0",
-      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.0.nupkg.sha512"
+      "sha512": "sha512-lfCjGsc6KRRnYC1NZNmdpDJyyNqO4VgnwpUG3qIIhZbAhdLdjwQiMGAIe2qdb6WTRgPlA6vMPfrT857YH83KiA==",
+      "path": "microsoft.azure.durabletask.azurestorage/2.9.1",
+      "hashPath": "microsoft.azure.durabletask.azurestorage.2.9.1.nupkg.sha512"
     },
-    "Microsoft.Azure.DurableTask.Core/3.8.0": {
+    "Microsoft.Azure.DurableTask.Core/3.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-59lnjA0e/X8yqwYGlHvzdmhU0+cB0SuNh0cMq/xgH0PRMP+XEwLZQQVKgHAzCmdsVgwzYg64KwqE1SJRRMkp0w==",
-      "path": "microsoft.azure.durabletask.core/3.8.0",
-      "hashPath": "microsoft.azure.durabletask.core.3.8.0.nupkg.sha512"
+      "sha512": "sha512-wnB/MYS/qlYM87O1JMbIdhQW5qtFx4VEpVQ95l7D5NZSku9upjelHJ3jlmuhdIwpInMqVaPGcCd8E3fmmmgV5w==",
+      "path": "microsoft.azure.durabletask.core/3.9.0",
+      "hashPath": "microsoft.azure.durabletask.core.3.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.DurableTask.Netherite/3.1.1": {
       "type": "package",
@@ -4802,19 +4805,19 @@
       "path": "microsoft.azure.webjobs.extensions.authenticationevents/1.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.authenticationevents.1.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.4-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo/1.2.5-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-UMm6eVLGif1uxv5GBrnE2DvprsLc9Dxe9hd2rathPWYQH1Hdj0k6FogIgmniaVwHPgQa5iJuz8MoRUKODjlBBg==",
-      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.4-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.4-preview.nupkg.sha512"
+      "sha512": "sha512-CqQruJSaqpGjeCRjNxm44VbgnTvPvgOJ5pFjuRfhf0VX/g9WzuSU0N6fhiufet1NHZVtt7tV+XozUHWhR7+47g==",
+      "path": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo/1.2.5-preview",
+      "hashPath": "microsoft.azure.webjobs.extensions.azurecosmosdb.mongo.1.2.5-preview.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.0": {
+    "Microsoft.Azure.WebJobs.Extensions.CosmosDB/4.16.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bN08fXiB33HnHNckexkhmMT98podFCj/MtMnmcplF6rhj898nfoxfmu4CFpxFc+QvOOwg8Ousrf0cUgD69Nk3w==",
-      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.0.nupkg.sha512"
+      "sha512": "sha512-KFh0HvMTqESPmCmZ7AilxIegw47WgXi8wnVXAwFmfhFCWynUZ9i3q72+Ije9XS6oL4gM/8zr16wOQzCroZ07/A==",
+      "path": "microsoft.azure.webjobs.extensions.cosmosdb/4.16.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.cosmosdb.4.16.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Dapr/0.17.0-preview01": {
       "type": "package",
@@ -4823,12 +4826,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.12.5": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-izhbSsIKZaomtG6bxju/8YXieyV2zfOCyG655n12JwySlxXfUcwyqTPTIvNXdKZ90HfMsIbbGSeUChwyRpHjPw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.12.5",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.12.5.nupkg.sha512"
+      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4837,12 +4840,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.8.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-jnzSOiw0AOg+7t94f4FbPdqSEg0l2E4lFGRtNOtWegPu0EmvGnN6M+fJE4xPwm4e7jyxRZfuegkCZ8QlxigNOw==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.8.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4858,12 +4861,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.70": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-kej0MnZNRtnMYzxchmP+12+Dfrl8CoOluNXRZkWSh2IfX9NYvtquE/zcMfRsqlA16I2VJARbp0rExWr1iVhvqA==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.70",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.70.nupkg.sha512"
+      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4935,12 +4938,12 @@
       "path": "microsoft.azure.webjobs.extensions.rabbitmq/2.1.0",
       "hashPath": "microsoft.azure.webjobs.extensions.rabbitmq.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Redis/0.5.0-preview": {
+    "Microsoft.Azure.WebJobs.Extensions.Redis/1.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vixrIn4FMZsIVezuQvw1RpTBkEkddxDFd1Pi50I2fycsOGbQId6fGE9e6kslznJcxTBUCCvEPwJqRi4bQp06Xg==",
-      "path": "microsoft.azure.webjobs.extensions.redis/0.5.0-preview",
-      "hashPath": "microsoft.azure.webjobs.extensions.redis.0.5.0-preview.nupkg.sha512"
+      "sha512": "sha512-RZRFzOTOrb/NWIPYuih19tel4CdOkINHsS7r3/gNzDhXhvvi1XK5pcKNutBC12X0BIRDH+dyfn2U0CMBfX8olA==",
+      "path": "microsoft.azure.webjobs.extensions.redis/1.0.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.redis.1.0.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Rpc/3.0.39": {
       "type": "package",
@@ -5054,12 +5057,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.5": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-hQB3Hq1LlF0NkGVNyZIvwIQIY3LM7Cw1oYjNiTvdNqmzzipVAWEK1c5sj2H5aFX0udnjgPLxSYKq2fupueS8ow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.5",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.5.nupkg.sha512"
+      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5103,19 +5106,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-rnt1cTeoMaevq4ZVxCsaz/9m2pvJXYnbge/X1CopEbVHjjlFL7JxJ4mwQ/4oKxEPPNarJ9bTANUdWoX2+kTmBA==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.8.1.nupkg.sha512"
+      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.8.1": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-+X3X+hBDyVigmzWYJAxGNsicXTwmeQLAwruVQeKDc4g3BTavvb6L1N/2yAm8OaIn6LzmsRP/juoiZOIAGYYZsw==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.8.1",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.8.1.nupkg.sha512"
+      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5138,12 +5141,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.8.1": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-wOVTe9itvTft+4g+Mupz+1IEh2PWYaGfnL/dmkDkhRTGO+B3gFdomZTp5v9DK8ZJ+/e5DhL7FGxHxXoi+41swQ==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.8.1",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.8.1.nupkg.sha512"
+      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -6664,12 +6667,12 @@
       "path": "system.threading.tasks.dataflow/4.8.0",
       "hashPath": "system.threading.tasks.dataflow.4.8.0.nupkg.sha512"
     },
-    "System.Threading.Tasks.Extensions/4.5.4": {
+    "System.Threading.Tasks.Extensions/4.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-      "path": "system.threading.tasks.extensions/4.5.4",
-      "hashPath": "system.threading.tasks.extensions.4.5.4.nupkg.sha512"
+      "sha512": "sha512-I5G6Y8jb0xRtGUC9Lahy7FUvlYlnGMMkbuKAQBy8Jb7Y6Yn8OlBEiUOY0PqZ0hy6Ua8poVA1ui1tAIiXNxGdsg==",
+      "path": "system.threading.tasks.extensions/4.6.0",
+      "hashPath": "system.threading.tasks.extensions.4.6.0.nupkg.sha512"
     },
     "System.Threading.Thread/4.3.0": {
       "type": "package",


### PR DESCRIPTION
# Pull Request

## Description

Update preview bundle Redis extension major version and bindings to match main bundle as #393

- Bump `Redis` from `majorVersion: 0` (`0.5.0-preview`) to `majorVersion: 1` (`1.0.0`) and update bindings (`redisPubSubTrigger`, `redisStreamTrigger`, `redisListTrigger`, `redis`) to match `main`.
- Verified no breaking changes between `0.5.0-preview` and `1.0.0` (identical target framework and dependency tree), also reviewed [release notes](https://github.com/Azure/azure-functions-redis-extension/releases) for any functional breaking changes
- Regenerate `ExtensionBundle.Tests` dependency baselines for all four RIDs (`any_any`, `win_x64`, `win_x86`, `linux_x64`); the only dependency delta is `Redis.dll: 0.5.0.0 -> 1.0.0.0`.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [x] main - #393
- [x] main-preview
- [x] main-experimental - #729
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

Dependency baselines regenerated locally (Windows RIDs) and linux_x64 sourced from the build agent.
