### PR TITLE
main: Update dotnet host emulator tests for net10 host versions and pin storage

### DIFF
--- a/eng/ci/scripts/get-latest-host-tags.ps1
+++ b/eng/ci/scripts/get-latest-host-tags.ps1
@@ -90,19 +90,19 @@ $parsedTags = $tags | ForEach-Object {
     }
 } | Where-Object { $_ -ne $null }
 
-# Exclude host versions >= 4.1049 which require dotnet 10.
-# TODO: Remove this filter once core tools complete migration to dotnet 10.
+# Only include host versions >= 4.1049 which require dotnet 10.
+# This branch tests dotnet 10 based host versions using a core-tools workaround branch.
 $parsedTags = $parsedTags | Where-Object {
     $versionParts = $_.VersionNoPrefix -split '\.'
-    [int]$versionParts[1] -lt 1049
+    [int]$versionParts[1] -ge 1049
 }
 
 if (-not $parsedTags) {
-    Write-Error "No tags found after filtering for versions < 4.1049"
+    Write-Error "No tags found after filtering for versions >= 4.1049"
     exit 1
 }
 
-Write-Host "Tags after filtering (< 4.1049): $($parsedTags.Count)" -ForegroundColor Green
+Write-Host "Tags after filtering (>= 4.1049): $($parsedTags.Count)" -ForegroundColor Green
 
 # Group by middle version and get the highest patch from each group
 $groupedTags = $parsedTags | 

--- a/eng/ci/scripts/get-latest-host-tags.ps1
+++ b/eng/ci/scripts/get-latest-host-tags.ps1
@@ -91,7 +91,6 @@ $parsedTags = $tags | ForEach-Object {
 } | Where-Object { $_ -ne $null }
 
 # Only include host versions >= 4.1049 which require dotnet 10.
-# This branch tests dotnet 10 based host versions using a core-tools workaround branch.
 $parsedTags = $parsedTags | Where-Object {
     $versionParts = $_.VersionNoPrefix -split '\.'
     [int]$versionParts[1] -ge 1049

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage",
-    "majorVersion": "5",
+    "version": "5.3.7",
     "name": "AzureStorage",
     "bindings": [
       "blobtrigger",
@@ -12,7 +12,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Queues",
-    "majorVersion": "5",
+    "version": "5.3.7",
     "name": "AzureStorageQueues",
     "bindings": [
       "queue",
@@ -29,7 +29,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.Storage.Blobs",
-    "majorVersion": "5",
+    "version": "5.3.7",
     "name": "AzureStorageBlobs",
     "bindings": [
       "blobtrigger",

--- a/tests/emulator_tests/blob_functions/function_app.py
+++ b/tests/emulator_tests/blob_functions/function_app.py
@@ -8,7 +8,7 @@ import string
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 @app.function_name(name="blob_trigger")

--- a/tests/emulator_tests/cosmosdb_functions/function_app.py
+++ b/tests/emulator_tests/cosmosdb_functions/function_app.py
@@ -16,7 +16,7 @@ import json
 import logging
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 # Store triggered documents for verification (in-memory for tests)
 _triggered_docs = []

--- a/tests/emulator_tests/eventgrid_functions/function_app.py
+++ b/tests/emulator_tests/eventgrid_functions/function_app.py
@@ -21,7 +21,7 @@ import logging
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 # =============================================================================

--- a/tests/emulator_tests/eventhub_batch_functions/function_app.py
+++ b/tests/emulator_tests/eventhub_batch_functions/function_app.py
@@ -7,7 +7,7 @@ import typing
 import azure.functions as func
 from azure.eventhub import EventData, EventHubProducerClient
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 # This is an actual EventHub trigger which handles Eventhub events in batches.

--- a/tests/emulator_tests/eventhub_functions/function_app.py
+++ b/tests/emulator_tests/eventhub_functions/function_app.py
@@ -6,7 +6,7 @@ import azure.functions as func
 from azure.eventhub import EventData
 from azure.eventhub.aio import EventHubProducerClient
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 # An HttpTrigger to generating EventHub event from EventHub Output Binding

--- a/tests/emulator_tests/kafka_functions/function_app.py
+++ b/tests/emulator_tests/kafka_functions/function_app.py
@@ -2,7 +2,7 @@ import json
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 # Global storage for metadata trigger results (shared in-process)
 _kafka_metadata_result = {}

--- a/tests/emulator_tests/queue_functions/function_app.py
+++ b/tests/emulator_tests/queue_functions/function_app.py
@@ -4,7 +4,7 @@ import typing
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 @app.function_name(name="get_queue_blob")

--- a/tests/emulator_tests/rabbitmq_functions/function_app.py
+++ b/tests/emulator_tests/rabbitmq_functions/function_app.py
@@ -10,7 +10,7 @@ import logging
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 # A RabbitMQ trigger which stores the message value into a storage blob.

--- a/tests/emulator_tests/servicebus_functions/function_app.py
+++ b/tests/emulator_tests/servicebus_functions/function_app.py
@@ -2,7 +2,7 @@ import json
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 @app.route(route="put_message")

--- a/tests/emulator_tests/signalr_functions/function_app.py
+++ b/tests/emulator_tests/signalr_functions/function_app.py
@@ -9,7 +9,7 @@ import logging
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 # Hub name used across all SignalR functions
 HUB_NAME = "testhub"

--- a/tests/emulator_tests/sql_functions/function_app.py
+++ b/tests/emulator_tests/sql_functions/function_app.py
@@ -6,7 +6,7 @@ import azure.functions as func
 import pyodbc
 import connection_utils
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 # ============================================================================

--- a/tests/emulator_tests/table_functions/function_app.py
+++ b/tests/emulator_tests/table_functions/function_app.py
@@ -5,7 +5,7 @@ import uuid
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 
 @app.function_name(name="table_in_binding")

--- a/tests/emulator_tests/webpubsub_functions_custom_only/function_app.py
+++ b/tests/emulator_tests/webpubsub_functions_custom_only/function_app.py
@@ -12,7 +12,7 @@ import logging
 
 import azure.functions as func
 
-app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+app = func.FunctionApp()
 
 HUB_NAME = "customhub"
 


### PR DESCRIPTION
# Pull Request

## Description

Update the dotnet host emulator tests for net10 host versions (`>= 4.1049`) and pin storage extensions.

- Update `get-latest-host-tags.ps1` to select host versions `>= 4.1049` (dotnet 10) as core tools is updated to dotnet 10
- Pin storage extensions (`Storage`, `Storage.Queues`, `Storage.Blobs`) to `5.3.7` in `extensions.json` until the bundle can accept their updated dependencies.
- Use the default HTTP auth level in emulator test function apps (remove explicit `AuthLevel.ANONYMOUS`).

## Issue Link

Resolves #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Testing

## Branch Propagation

- [x] main
- [x] main-preview (#728)
- [x] main-experimental (#729)
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

N/A

## Additional Information
