### PR TITLE
Route dependency restores through Azure Functions CFS (#740)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,20 +52,11 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: Restore
+      run: dotnet restore ExtensionBundle.Tests.sln --configfile NuGet.config
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+    - name: Build
+      run: dotnet build ExtensionBundle.Tests.sln --configuration Release --no-restore
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include:
         - language: csharp
-          build-mode: autobuild
+          build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -77,14 +77,11 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+    - name: Restore
+      run: dotnet restore ExtensionBundle.Tests.sln --configfile NuGet.config
+
+    - name: Build
+      run: dotnet build ExtensionBundle.Tests.sln --configuration Release --no-restore
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -47,11 +47,9 @@ ExtensionBundle.v4.Templates.1.0.5130.zip
 
 - Download the files from the [templates.public](https://dev.azure.com/azfunc/public/_build/results?buildId=221883) Pipeline
 
-#### (Optional) Using Custom NuGet feed for local testing
+#### NuGet feed configuration
 
-- Set up a NuGet feed with `NuGet Gallery (https://api.nuget.org/v3/index.json)` as upstream sources.
-- Update [NuGet.Config](src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config) and [Helper.cs](build/Helper.cs#L14) with the custom NuGet feed.
-- Publish extension packages to new feed and build the project using below instructions.
+The repository restores packages through the root [NuGet.config](NuGet.config), which uses the Azure Functions CFS feed. To test unpublished extension packages, use an Azure Artifacts feed and update both the root configuration and the metadata source in [Settings.cs](build/Settings.cs) for the local test.
 
 ### Building on Windows
 
@@ -62,7 +60,8 @@ $env:TEMPLATES_ARTIFACTS_DIRECTORY = "templatesArtifacts"
 
 # Navigate to build directory and run
 cd build
-dotnet run skip:GenerateVulnerabilityReport,PackageLinuxBundle,CreateCDNStoragePackageLinux,BuildLinuxBinaries
+dotnet restore .\Build.csproj --configfile ..\NuGet.config
+dotnet run --no-restore -- skip:GenerateVulnerabilityReport,PackageLinuxBundle,CreateCDNStoragePackageLinux,BuildLinuxBinaries
 ```
 
 ### Building on Linux
@@ -74,7 +73,8 @@ export TEMPLATES_ARTIFACTS_DIRECTORY="templatesArtifacts"
 
 # Navigate to build directory and run
 cd build
-dotnet run skip:GenerateVulnerabilityReport,PackageWindowsBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildWindowsBinaries,BuildFilteredPortableBinaries
+dotnet restore ./Build.csproj --configfile ../NuGet.config
+dotnet run --no-restore -- skip:GenerateVulnerabilityReport,PackageWindowsBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildWindowsBinaries,BuildFilteredPortableBinaries
 ```
 
 **Note:** Replace `<ExtensionBundleRepoPath>` with the actual path to your extension bundle repository.
@@ -122,7 +122,7 @@ dotnet run skip:GenerateVulnerabilityReport,PackageWindowsBundle,CreateRUPackage
 
 1. Open the `build/Build.sln` file in Visual Studio
 1. Create a debug profile for the project (right-click on the project, "Properties", "Debug", "Open debug launch profiles UI")
-1. Set the Command Line arguments using the instructions above (everything after `dotnet run`, i.e. `"skip:XXX,YYY,..."`)
+1. Set the application arguments to the value after the `--` separator in the commands above (for example, `"skip:XXX,YYY,..."`)
 1. Set the working directory to be the `build` directory
 1. F5
 

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -9,6 +9,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NuGet.Versioning" Version="6.13.2" />
 		<PackageReference Include="NuGet.Protocol" Version="6.13.2" />
+		<PackageReference Include="NuGet.Credentials" Version="6.13.2" />
 		<PackageReference Include="System.IO.Abstractions" Version="22.0.12" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -146,16 +146,13 @@ namespace Build
 
         private static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig, string configPrefix = null, IList<Extension> extensionList = null)
         {
-            var sourceNugetConfig = Path.Combine(Settings.SourcePath, Settings.NugetConfigFileName);
             var sourceProjectFilePath = Path.Combine(Settings.SourcePath, buildConfig.SourceProjectFileName);
             string configDirName = configPrefix != null ? $"{configPrefix}_{buildConfig.ConfigId}" : buildConfig.ConfigId.ToString();
             string projectDirectory = Path.Combine(Settings.RootBuildDirectory, configDirName);
             string targetProjectFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, "extensions.csproj");
-            string targetNugetConfigFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, Settings.NugetConfigFileName);
 
             FileUtility.EnsureDirectoryExists(projectDirectory);
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
-            FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
             await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle, extensionList);
             return targetProjectFilePath;
@@ -168,7 +165,7 @@ namespace Build
             foreach (var extension in extensions)
             {
                 string version = string.IsNullOrEmpty(extension.Version) ? await Helper.GetLatestPackageVersion(extension.Id, extension.MajorVersion, addPrereleasePackages) : extension.Version;
-                Shell.Run("dotnet", $"add {projectFilePath} package {extension.Id} -v {version} -n");
+                Shell.Run("dotnet", new[] { "add", projectFilePath, "package", extension.Id, "--version", version, "--no-restore" });
             }
         }
 
@@ -184,18 +181,37 @@ namespace Build
                 ? Path.Combine(publishPath, buildConfig.PublishBinDirectorySubPath)
                 : buildConfig.PublishBinDirectoryPath;
 
-            var publishCommandArguments = $"publish {projectFilePath} -c Release -o {publishPath}";
+            var restoreCommandArguments = new List<string>
+            {
+                "restore",
+                projectFilePath,
+                "--configfile",
+                Settings.NuGetConfigFilePath
+            };
+            var publishCommandArguments = new List<string>
+            {
+                "publish",
+                projectFilePath,
+                "--configuration",
+                "Release",
+                "--output",
+                publishPath,
+                "--no-restore"
+            };
 
             if (!buildConfig.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase))
             {
-                publishCommandArguments += $" -r {buildConfig.RuntimeIdentifier}";
+                restoreCommandArguments.AddRange(new[] { "--runtime", buildConfig.RuntimeIdentifier });
+                publishCommandArguments.AddRange(new[] { "--runtime", buildConfig.RuntimeIdentifier });
             }
 
             if (buildConfig.PublishReadyToRun)
             {
-                publishCommandArguments += $" /p:PublishReadyToRun=true";
+                restoreCommandArguments.Add("/p:PublishReadyToRun=true");
+                publishCommandArguments.Add("/p:PublishReadyToRun=true");
             }
 
+            Shell.Run("dotnet", restoreCommandArguments);
             Shell.Run("dotnet", publishCommandArguments);
 
             if (Path.Combine(publishPath, "bin") != publishBinPath)
@@ -222,9 +238,17 @@ namespace Build
                 Directory.SetCurrentDirectory(Settings.RootBuildDirectory);
 
                 Console.WriteLine(Directory.GetCurrentDirectory());
-                Console.WriteLine($"dotnet list \"{projectFilePath}\" package --include-transitive --vulnerable");
-
-                string output = Shell.GetOutput("dotnet", $"list \"{projectFilePath}\" package --include-transitive --vulnerable");
+                var arguments = new[]
+                {
+                    "list",
+                    projectFilePath,
+                    "package",
+                    "--include-transitive",
+                    "--vulnerable",
+                    "--configfile",
+                    Settings.NuGetConfigFilePath
+                };
+                string output = Shell.GetOutput("dotnet", arguments);
 
                 if (!output.Contains("has no vulnerable packages given the current sources."))
                 {

--- a/build/Helper.cs
+++ b/build/Helper.cs
@@ -1,4 +1,5 @@
 ﻿using NuGet.Common;
+using NuGet.Credentials;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using System.Linq;
@@ -11,7 +12,8 @@ namespace Build
     {
         public static async Task<string> GetLatestPackageVersion(string packageId, int majorVersion, bool isPrerelease = false)
         {
-            var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+            var repository = Repository.Factory.GetCoreV3(Settings.UpstreamPublicNuGetFeedUrl);
             var resource = await repository.GetResourceAsync<PackageMetadataResource>();
 
             var packages = await resource.GetMetadataAsync(packageId, includePrerelease: isPrerelease, includeUnlisted: false,

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -8,6 +8,8 @@ namespace Build
 {
     public static class Settings
     {
+        public const string UpstreamPublicNuGetFeedUrl = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
+
         public static string basePath = path;
 
         public static readonly string WindowsExclusionsFilePath = Path.Combine(Path.GetFullPath(basePath), "src", "Microsoft.Azure.Functions.ExtensionBundle", "windowsExclusions.json");
@@ -38,6 +40,7 @@ namespace Build
 
         public static readonly string SourcePath = Path.GetFullPath(basePath + "/src/Microsoft.Azure.Functions.ExtensionBundle/");
         public static readonly string BuildPath = Path.Combine(Path.GetFullPath(basePath), "build");
+        public static readonly string NuGetConfigFilePath = Path.Combine(Path.GetFullPath(basePath), NuGetConfigFileName);
 
         public static string ExtensionsJsonFilePath => Path.Combine(SourcePath, ExtensionsJsonFileName);
 
@@ -77,7 +80,7 @@ namespace Build
 
         public static readonly string BundleConfigJsonFileName = "bundleConfig.json";
 
-        public static readonly string NugetConfigFileName = "NuGet.Config";
+        public const string NuGetConfigFileName = "NuGet.config";
 
         public static readonly string IndexFileName = "index.json";
 

--- a/build/Shell.cs
+++ b/build/Shell.cs
@@ -1,22 +1,24 @@
 using Colors.Net;
 using Colors.Net.StringColorExtensions;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Build
 {
     public static class Shell
     {
-        public static void Run(string program, string arguments, bool streamOutput = true, bool silent = false)
+        public static void Run(string program, IReadOnlyList<string> arguments, bool streamOutput = true, bool silent = false)
         {
             var exe = new InternalExe(program, arguments, streamOutput);
 
             if (!silent)
             {
-                ColoredConsole.WriteLine($"> {program} {arguments}".Green());
+                ColoredConsole.WriteLine($"> {program} {FormatArguments(arguments)}".Green());
             }
 
             var exitcode = silent
@@ -29,7 +31,7 @@ namespace Build
             }
         }
 
-        public static string GetOutput(string program, string arguments, bool ignoreExitCode = false)
+        public static string GetOutput(string program, IReadOnlyList<string> arguments, bool ignoreExitCode = false)
         {
             var exe = new InternalExe(program, arguments);
             var sb = new StringBuilder();
@@ -43,18 +45,24 @@ namespace Build
             return sb.ToString().Trim(new[] { ' ', '\r', '\n' });
         }
 
+        private static string FormatArguments(IEnumerable<string> arguments)
+        {
+            return string.Join(" ", arguments.Select(argument =>
+                argument.Any(char.IsWhiteSpace) ? $"\"{argument.Replace("\"", "\\\"")}\"" : argument));
+        }
+
         class InternalExe
         {
-            private string _arguments;
-            private string _exeName;
-            private bool _shareConsole;
-            private bool _streamOutput;
+            private readonly IReadOnlyList<string> _arguments;
+            private readonly string _exeName;
+            private readonly bool _shareConsole;
+            private readonly bool _streamOutput;
             private readonly bool _visibleProcess;
 
-            public InternalExe(string exeName, string arguments = null, bool streamOutput = true, bool shareConsole = false, bool visibleProcess = false)
+            public InternalExe(string exeName, IReadOnlyList<string> arguments, bool streamOutput = true, bool shareConsole = false, bool visibleProcess = false)
             {
                 _exeName = exeName;
-                _arguments = arguments;
+                _arguments = arguments ?? Array.Empty<string>();
                 _streamOutput = streamOutput;
                 _shareConsole = shareConsole;
                 _visibleProcess = visibleProcess;
@@ -65,7 +73,6 @@ namespace Build
                 var processInfo = new ProcessStartInfo
                 {
                     FileName = _exeName,
-                    Arguments = _arguments,
                     CreateNoWindow = !_visibleProcess,
                     UseShellExecute = _shareConsole,
                     RedirectStandardError = _streamOutput,
@@ -73,6 +80,11 @@ namespace Build
                     RedirectStandardOutput = _streamOutput,
                     WorkingDirectory = Directory.GetCurrentDirectory()
                 };
+
+                foreach (var argument in _arguments)
+                {
+                    processInfo.ArgumentList.Add(argument);
+                }
 
                 Process process = null;
 

--- a/eng/ci/config/core-tools.NuGet.config
+++ b/eng/ci/config/core-tools.NuGet.config
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+    <!-- Core Tools packages not yet available through CFS are isolated by the exact mappings below. -->
+    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" protocolVersion="3" />
+    <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" protocolVersion="3" />
+    <add key="PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" protocolVersion="3" />
+    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" protocolVersion="3" />
+    <add key="Infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="AzureFunctions">
+      <package pattern="Microsoft.Azure.AppService.Middleware.Functions" />
+      <package pattern="Microsoft.Azure.AppService.Middleware" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Modules" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.NetCore" />
+    </packageSource>
+    <packageSource key="AzureFunctionsRelease">
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost" />
+      <package pattern="Microsoft.Azure.WebJobs.Script" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.Grpc" />
+      <package pattern="Microsoft.Azure.Functions.JavaWorker" />
+      <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
+      <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+    </packageSource>
+    <packageSource key="PowerShellWorker">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" />
+    </packageSource>
+    <packageSource key="AzureFunctionsTempStaging">
+      <package pattern="Microsoft.Azure.DurableTask.AzureStorage.Internal" />
+      <package pattern="Microsoft.Azure.DurableTask.Core.Internal" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Client" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Common" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Runtime" />
+      <package pattern="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" />
+      <package pattern="Microsoft.Azure.WebSites.DataProtection" />
+    </packageSource>
+    <packageSource key="Infra">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" />
+      <package pattern="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/eng/ci/scripts/build-core-tools.ps1
+++ b/eng/ci/scripts/build-core-tools.ps1
@@ -24,12 +24,24 @@ param(
     [string]$Configuration = "Release",
     [Parameter(Mandatory=$true)]
     [string]$CoreToolsDir,
+    [string]$NuGetConfigPath = "",
     [string]$ZipOutputDir = "artifacts-coretools-zip"
     
 )
 
 $ErrorActionPreference = "Stop"
 
+$RepoRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
+if ([string]::IsNullOrEmpty($NuGetConfigPath)) {
+    $NuGetConfigPath = Join-Path $RepoRoot "eng\ci\config\core-tools.NuGet.config"
+}
+
+if (-not (Test-Path -LiteralPath $NuGetConfigPath)) {
+    Write-Error "NuGet configuration not found at $NuGetConfigPath"
+    exit 1
+}
+
+$NuGetConfigPath = (Resolve-Path -LiteralPath $NuGetConfigPath).Path
 
 if ($IsWindows -or $env:OS -eq "Windows_NT") {
     $osName = "win"
@@ -97,7 +109,9 @@ try {
     $restoreArgs = @(
         "restore",
         $ProjectPath,
-        "/p:TargetFramework=$targetFramework"
+        "--configfile", $NuGetConfigPath,
+        "/p:TargetFramework=$targetFramework",
+        "/p:SelfContained=true"
     )
     
     if (-not [string]::IsNullOrEmpty($Runtime)) {

--- a/eng/ci/scripts/build-multi-version-core-tools.ps1
+++ b/eng/ci/scripts/build-multi-version-core-tools.ps1
@@ -43,7 +43,8 @@ param(
     [int]$Count = 2,
     [string]$Pattern = "v4.10",
     [string]$Configuration = "Release",
-    [string]$CloneDir = ""
+    [string]$CloneDir = "",
+    [string]$NuGetConfigPath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -58,6 +59,17 @@ Write-Host "===========================================================" -Foregr
 # Get the script directory
 $ScriptDir = $PSScriptRoot
 $RepoRoot = Split-Path (Split-Path (Split-Path $ScriptDir -Parent) -Parent) -Parent
+
+if ([string]::IsNullOrEmpty($NuGetConfigPath)) {
+    $NuGetConfigPath = Join-Path $RepoRoot "eng\ci\config\core-tools.NuGet.config"
+}
+
+if (-not (Test-Path -LiteralPath $NuGetConfigPath)) {
+    Write-Error "NuGet configuration not found at $NuGetConfigPath"
+    exit 1
+}
+
+$NuGetConfigPath = (Resolve-Path -LiteralPath $NuGetConfigPath).Path
 
 # Set default CloneDir if not provided
 if ([string]::IsNullOrEmpty($CloneDir)) {
@@ -273,7 +285,7 @@ try {
         
         # Use a temp zip dir inside the repo (will be cleaned by git clean next iteration)
         $versionZipDir = "artifacts-coretools-zip-$hostVersion"
-        $buildOutput = & $BuildScript -Configuration $Configuration -CoreToolsDir $CloneDir -ZipOutputDir $versionZipDir
+        $buildOutput = & $BuildScript -Configuration $Configuration -CoreToolsDir $CloneDir -NuGetConfigPath $NuGetConfigPath -ZipOutputDir $versionZipDir
         
         if ($LASTEXITCODE -ne 0) {
             throw "Core Tools build failed with exit code $LASTEXITCODE"

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -19,6 +19,14 @@ jobs:
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - task: DownloadBuildArtifacts@1
     inputs:
       buildType: 'specific'
@@ -37,7 +45,9 @@ jobs:
       command: 'run'
       workingDirectory: '.\build'
       ${{ if eq(parameters.official, false) }}:
-        arguments: 'skip:DownloadTemplates,PackageBundle,PackagePortableBundle,PackageWindowsBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageLinuxBundle'
+        arguments: '--no-restore -- skip:DownloadTemplates,PackageBundle,PackagePortableBundle,PackageWindowsBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageLinuxBundle'
+      ${{ else }}:
+        arguments: '--no-restore'
 
   - ${{ if eq(parameters.official, true) }}:
     - pwsh: |

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -31,7 +31,6 @@ jobs:
   - checkout: self
     path: bundle
     fetchDepth: 1
-    sparseCheckoutDirectories: eng
     
   - checkout: coretools
     path: core-tools
@@ -49,7 +48,7 @@ jobs:
     displayName: 'Build Azure Functions Core Tools'
     inputs:
       filePath: '$(Agent.BuildDirectory)/bundle/eng/ci/scripts/build-multi-version-core-tools.ps1'
-      arguments: '-Count $(hostTagsCount) -Pattern "$(hostTagPattern)" -Configuration Release -CloneDir "$(Agent.BuildDirectory)/core-tools"'
+      arguments: '-Count $(hostTagsCount) -Pattern "$(hostTagPattern)" -Configuration Release -CloneDir "$(Agent.BuildDirectory)/core-tools" -NuGetConfigPath "$(Agent.BuildDirectory)/bundle/eng/ci/config/core-tools.NuGet.config"'
       pwsh: true
       workingDirectory: '$(Agent.BuildDirectory)/core-tools'
   
@@ -119,13 +118,21 @@ jobs:
 
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
-    
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - task: DotNetCoreCLI@2
     displayName: 'Build Linux Bundle (once)'
     inputs:
       command: 'run'
       workingDirectory: './build'
-      arguments: 'skip:DownloadTemplates,BuildWindowsBinaries,BuildFilteredPortableBinaries,BuildLinuxBinaries,GenerateVulnerabilityReport,PackageBundle,PackageWindowsBundle,PackageLinuxBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
+      arguments: '--no-restore -- skip:DownloadTemplates,BuildWindowsBinaries,BuildFilteredPortableBinaries,BuildLinuxBinaries,GenerateVulnerabilityReport,PackageBundle,PackageWindowsBundle,PackageLinuxBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
     env:
       BUILD_REPOSITORY_LOCALPATH: '$(Build.Repository.LocalPath)'
       TEMPLATES_ARTIFACTS_DIRECTORY: '$(Build.Repository.LocalPath)/templatesArtifacts'
@@ -292,6 +299,15 @@ jobs:
       fi
     displayName: 'Verify Core Tools Artifact'
 
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Authenticate'
+
+  - task: PipAuthenticate@1
+    displayName: 'PyPI Authenticate'
+    inputs:
+      artifactFeeds: 'public/upstream-public'
+      onlyAddExtraIndex: false
+
   # Set up Python 3.12 and create virtual environment
   - task: UsePythonVersion@0
     inputs:
@@ -300,17 +316,12 @@ jobs:
       architecture: 'x64'
     displayName: 'Set up Python 3.12'
 
-  - task: PipAuthenticate@1
-    displayName: 'PyPI Authenticate'
-    inputs:
-      artifactFeeds: 'public/azure-functions-extension-bundles-feed'
-
   - script: |
       cd tests
       python -m venv venv
       source venv/bin/activate
-      pip install --upgrade pip
-      pip install --cache-dir ~/.cache/pip -r requirements.txt
+      python -m pip install --upgrade pip
+      python -m pip install --cache-dir ~/.cache/pip -r requirements.txt
     displayName: 'Install Python Dependencies (cached)'
     env:
       PIP_INDEX_URL: $(PIP_INDEX_URL)
@@ -433,7 +444,8 @@ jobs:
         echo "Starting SignalR Emulator for $(DISPLAY_NAME)..."
         
         # Install SignalR emulator .NET tool
-        dotnet tool install -g Microsoft.Azure.SignalR.Emulator || dotnet tool update -g Microsoft.Azure.SignalR.Emulator
+        tool_args=(--global Microsoft.Azure.SignalR.Emulator --configfile "$NUGET_CONFIG_PATH")
+        dotnet tool install "${tool_args[@]}" || dotnet tool update "${tool_args[@]}"
         export PATH="$PATH:$HOME/.dotnet/tools"
         
         # Start emulator in background with settings file
@@ -457,6 +469,7 @@ jobs:
     displayName: 'Start Additional Emulators'
     env:
       AzureWebJobsSQLPassword: $(AzureWebJobsSQLPassword)
+      NUGET_CONFIG_PATH: '$(Build.Repository.LocalPath)/NuGet.config'
 
   # Start mock extension site in background
   - script: |

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -11,10 +11,19 @@ jobs:
       packageType: 'sdk'
       version: '8.x'
       performMultiLevelLookup: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore tests'
+    inputs:
+      command: 'restore'
+      projects: 'ExtensionBundle.Tests.sln'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - task: DotNetCoreCLI@2
     displayName: 'Run tests'
     inputs:
       command: 'test'
-      arguments: '-c Release'
+      arguments: '--configuration Release --no-restore'
       projects: |
         **/*Tests.csproj

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="azure-functions-extension-bundles" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/azure-functions-extension-bundles-feed/nuget/v3/index.json" protocolVersion="3" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>
-

--- a/tests/emulator_tests/README.md
+++ b/tests/emulator_tests/README.md
@@ -127,7 +127,8 @@ Build the extension bundle locally. For detailed build instructions, see the "Lo
 ```powershell
 # From the repository root
 cd build
-dotnet run skip:DownloadTemplates,BuildWindowsBinaries,BuildFilteredPortableBinaries,BuildLinuxBinaries,GenerateVulnerabilityReport,PackageBundle,PackageWindowsBundle,PackageLinuxBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux
+dotnet restore .\Build.csproj --configfile ..\NuGet.config
+dotnet run --no-restore -- skip:DownloadTemplates,BuildWindowsBinaries,BuildFilteredPortableBinaries,BuildLinuxBinaries,GenerateVulnerabilityReport,PackageBundle,PackageWindowsBundle,PackageLinuxBundle,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux
 ```
 
 This will generate extension bundle packages in the `artifacts/` directory.
@@ -198,7 +199,8 @@ Install the project with dev dependencies from `pyproject.toml`:
 ```powershell
 # Install with dev dependencies
 cd tests
-pip install -r requirements.txt
+$env:PIP_INDEX_URL = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+python -m pip install -r requirements.txt
 
 # This installs all required packages including:
 # - pytest, requests, psutil
@@ -566,7 +568,7 @@ You can create additional debug configurations for different test files:
 7. **Import Errors**: If you see import errors during debugging, verify that:
    - The virtual environment is activated
    - VS Code is using the correct Python interpreter
-   - All dependencies are installed with `cd tests && pip install -r requirements.txt`
+   - All dependencies are installed with `PIP_INDEX_URL` set as shown above and `cd tests && python -m pip install -r requirements.txt`
 
 ```text
 
@@ -626,7 +628,8 @@ You can create additional debug configurations for different test files:
    which python  # Should point to venv/Scripts/python.exe
    
    # Reinstall dependencies if needed
-   pip install -r requirements.txt --force-reinstall
+   $env:PIP_INDEX_URL = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+   python -m pip install -r requirements.txt --force-reinstall
    ```
 
 5. **Port Conflicts**:

--- a/tests/emulator_tests/pip.conf
+++ b/tests/emulator_tests/pip.conf
@@ -1,2 +1,0 @@
-[global]
-index-url = https://pkgs.dev.azure.com/azfunc/public/_packaging/azure-functions-extension-bundles-feed/pypi/simple/

--- a/validate-ci.ps1
+++ b/validate-ci.ps1
@@ -19,6 +19,7 @@ $requiredFiles = @(
     "tests\test_setup.py",
     "tests\utils\testutils.py",
     "tests\emulator_tests\utils\eventhub\docker-compose.yml",
+    "eng\ci\config\core-tools.NuGet.config",
     "eng\ci\templates\jobs\emulator-tests.yml"
 )
 
@@ -122,9 +123,10 @@ Write-Host ""
 Write-Host "🎉 All validations passed!" -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Cyan
-Write-Host "1. Build locally: 'cd build && dotnet run'" -ForegroundColor White
-Write-Host "2. Test emulator setup: 'cd tests && python test_setup.py'" -ForegroundColor White
-Write-Host "3. Run emulator tests with mock site:" -ForegroundColor White
+Write-Host "1. Restore locally: 'dotnet restore build/Build.csproj --configfile NuGet.config'" -ForegroundColor White
+Write-Host "2. Build locally: 'cd build && dotnet run --no-restore'" -ForegroundColor White
+Write-Host "3. Test emulator setup: 'cd tests && python test_setup.py'" -ForegroundColor White
+Write-Host "4. Run emulator tests with mock site:" -ForegroundColor White
 Write-Host "   cd tests" -ForegroundColor Gray
 Write-Host "   invoke mock-extension-site --port 8000 --keep-alive &" -ForegroundColor Gray
 Write-Host "   `$env:FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI='http://localhost:8000'" -ForegroundColor Gray


### PR DESCRIPTION
# Pull Request

## Description

Routes every applicable repository-owned dependency path through the Azure Functions CFS `upstream-public` feed.

- Adds a root CFS-only `NuGet.config` with `<clear />` and wildcard package-source mapping.
- Makes generated bundle, vulnerability, detached Core Tools, global tool, build, test, and CodeQL restores explicit; downstream publish/run/test operations use `--no-restore`.
- Enables Azure Artifacts credential-provider support for direct `NuGet.Protocol` metadata queries and preserves structured process arguments for paths containing spaces.
- Adds Azure Pipelines NuGet/Python authentication, places `PipAuthenticate@1` before Python setup, and routes Python installs through `PIP_INDEX_URL` without a fallback index.
- Removes the nested public NuGet fallback and committed pip configuration.
- Updates root and emulator-development documentation with explicit CFS restore/install commands.
- No repository-owned npm, uv, or dependency-building Docker surface exists, so those ecosystems are intentionally unchanged.
- Customer samples, templates, scaffolding, and generated manifests remain unchanged.

Base/head: `Azure:main` <- `fabiocav:cfs-update`
Head commit: `f1b8e25287e41ac7701591fe584ad2dda1949b6f`

## Issue Link

N/A - inventory-driven CFS onboarding (EM owner: vameru).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [x] Refactoring
- [x] Testing

## Branch Propagation

- [x] main - this PR
- [ ] main-preview - not included in this main-branch onboarding PR
- [ ] main-experimental - not included in this main-branch onboarding PR
- [ ] main-v2 - not included in this main-branch onboarding PR
- [ ] main-v3 - not included in this main-branch onboarding PR

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works (N/A: feed routing only; the existing emulator pipeline was updated)
- [x] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [x] I have added appropriate comments to complex code

## Documentation Updates

Updated the root README build/feed instructions, emulator-development setup and troubleshooting commands, and local CI guidance.

## Additional Information

### Validation

- Restored 83 solution packages from empty NuGet global-packages, HTTP, plugin, and CLI-home caches; the current independent restore log contains 189 CFS references and zero direct-public references.
- Captured package metadata/traffic showed only `pkgs.dev.azure.com` and Azure Artifacts blob hosts, with no direct nuget.org traffic.
- Built portable, filtered portable, Windows x86/x64, and Linux x64 ReadyToRun bundle graphs through CFS; the final solution build completed with 0 warnings and 0 errors and all 4 unit tests passed.
- Installed Python 3.12 requirements through CFS in the recovered run. A second authenticated empty-cache Python 3.13 run installed 56 distributions; `pip check` passed across 163 HTTP requests (111 CFS, 52 Azure Artifacts blob) with zero unexpected/public hosts, authentication failures, or credential leaks.
- Installed `Microsoft.Azure.SignalR.Emulator` 1.6.1 through the explicit CFS NuGet config.
- Exercised the detached Core Tools restore/publish script from empty caches with spaces in project, config, and output paths; its self-contained restore and `--no-restore` publish succeeded with CFS-only assets.
- Verified `ProcessStartInfo.ArgumentList` preserved a space-containing file path exactly.
- Generated the vulnerability report and portable package successfully.
- The recovered run audited 8 release archives / 1,682 entries. The current run independently audited a 221,109,216-byte / 238-entry bundle archive. Neither audit found feed configs, credentials, lockfiles, `node_modules`, feed URLs, or unintended staged/published files.
- Parsed all changed PowerShell files and NuGet XML successfully; final committed-tree checks confirmed 5 NuGet authentication contexts, Python authentication before setup, no npm/uv manifests, no pip config, no public registry references, and no embedded URL credentials.

### Post-PR repair 1

- Azure Pipelines build `294918` failed only in `EmulatorTests` -> `Build Core Tools`; all bundle builds, unit tests, SDL tasks, and CLA passed.
- Root cause: the detached Azure Functions Core Tools graph includes internal host and worker packages not replicated to CFS, but the onboarding made that restore use the root CFS-only config.
- Added `eng/ci/config/core-tools.NuGet.config`, retaining CFS as the wildcard fallback while exactly mapping only the cold-cache-proven internal package families. Mappings cover Azure Functions/App Service packages, Script host and language workers, PowerShell workers, Durable Task internal packages, platform metrics/data-protection packages, and the isolated native host across the `AzureFunctions`, `AzureFunctionsRelease`, PowerShell worker, `AzureFunctionsTempStaging`, and public `infra` feeds.
- The Azure Pipelines job and both independently runnable Core Tools scripts now explicitly select the dedicated config; `NuGetAuthenticate@1` remains before restore.
- A genuinely empty synthetic `net10.0/linux-x64` restore completed for 383 packages, followed by the actual patched Core Tools `Azure.Functions.Cli.csproj` restore for 422 packages. Both used only the six configured Azure Artifacts feeds with no nuget.org/MyGet source.
- Repository `validate-ci.ps1`, NuGet XML parsing, PowerShell syntax parsing, mapping/source audit, and focused .NET review passed. Mainline build `294451` also shows the same Core Tools task succeeding, confirming the pipeline identity can authenticate to the required internal feeds.

### Caveats

- An unauthenticated Windows Python 3.13 cold install hit the documented CFS upstream-ingestion 401 for the new `mysql-connector-python 26.7` wheel. The authenticated run ingested that wheel and completed without a fallback index.
- Publishing the full generated bundle from a very long package-cache path containing spaces reaches `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator`, but that dependency constructs an invalid working directory. The same cold build/tests pass with a short cache, and the independent structured-argument and detached spaced-path checks pass.
- The existing Twilio `NU1603` resolution warning remains unchanged and is not suppressed.

Post-PR CFS repair attempts: **1 of 3**.