### PR TITLE
Disable the Cosmos DB emulator’s bundled Data Explorer during emulato…

### DIFF
--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -359,7 +359,7 @@ jobs:
       if [ "$(ADDITIONAL_EMULATORS)" = "cosmosdb" ]; then
         echo "Starting CosmosDB Emulator for $(DISPLAY_NAME)..."
         docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
-        docker run --detach --publish 8081:8081 --publish 1234:1234 --name cosmosdb-emulator mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+        docker run --detach --env ENABLE_EXPLORER=false --publish 8081:8081 --name cosmosdb-emulator mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
         echo "Waiting for CosmosDB Emulator to start..."
         sleep 60
         docker ps


### PR DESCRIPTION

# Pull Request

## Description

<!-- Please provide a clear and concise description of your changes -->
Disable the Cosmos DB emulator’s bundled Data Explorer during emulator tests.

The Data Explorer entrypoint runs npm start inside the container, causing CFSClean violations from registry.npmjs.org. The tests do not use Data Explorer, so this change sets ENABLE_EXPLORER=false and removes the unused port 1234 mapping.

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->