### PR TITLE
main-preview: ci- route package restores through CFS feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ ExtensionBundle.v4.Templates.1.0.5130.zip
 
 - Download the files from the [templates.public](https://dev.azure.com/azfunc/public/_build/results?buildId=221883) Pipeline
 
-#### (Optional) Using Custom NuGet feed for local testing
+#### NuGet feed configuration
 
-- Set up a NuGet feed with `NuGet Gallery (https://api.nuget.org/v3/index.json)` as upstream sources.
-- Update [NuGet.Config](src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config) and [Helper.cs](build/Helper.cs#L14) with the custom NuGet feed.
-- Publish extension packages to new feed and build the project using below instructions.
+The repository restores packages through the root [NuGet.config](NuGet.config), which uses the Azure Functions CFS feed. To test unpublished extension packages, use an Azure Artifacts feed and update both the root configuration and the metadata source in [Settings.cs](build/Settings.cs) for the local test.
 
 ### Building on Windows
 
@@ -60,7 +58,8 @@ $env:TEMPLATES_ARTIFACTS_DIRECTORY = "templatesArtifacts"
 
 # Navigate to build directory and run
 cd build
-dotnet run skip:PackageBundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux
+dotnet restore .\Build.csproj --configfile ..\NuGet.config
+dotnet run --no-restore -- skip:PackageBundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux
 ```
 
 ### Building on Linux
@@ -72,7 +71,8 @@ export TEMPLATES_ARTIFACTS_DIRECTORY="templatesArtifacts"
 
 # Navigate to build directory and run
 cd build
-dotnet run skip:PackageBundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows
+dotnet restore ./Build.csproj --configfile ../NuGet.config
+dotnet run --no-restore -- skip:PackageBundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows
 ```
 
 **Note:** Replace `<ExtensionBundleRepoPath>` with the actual path to your extension bundle repository.
@@ -125,7 +125,7 @@ dotnet run skip:PackageBundlesWindows,CreateRUPackage,CreateCDNStoragePackage,Cr
 
 1. Open the `build/Build.sln` file in Visual Studio
 1. Create a debug profile for the project (right-click on the project, "Properties", "Debug", "Open debug launch profiles UI")
-1. Set the Command Line arguments using the instructions above (everything after `dotnet run`, i.e. `"skip:XXX,YYY,..."`)
+1. Set the application arguments to the value after the `--` separator in the commands above (for example, `"skip:XXX,YYY,..."`)
 1. Set the working directory to be the `build` directory
 1. F5
 

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -9,6 +9,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NuGet.Versioning" Version="6.13.2" />
 		<PackageReference Include="NuGet.Protocol" Version="6.13.2" />
+		<PackageReference Include="NuGet.Credentials" Version="6.13.2" />
 		<PackageReference Include="System.IO.Abstractions" Version="22.0.12" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -114,15 +114,12 @@ namespace Build
 
         public static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig)
         {
-            var sourceNugetConfig = Path.Combine(Settings.SourcePath, Settings.NugetConfigFileName);
             var sourceProjectFilePath = Path.Combine(Settings.SourcePath, buildConfig.SourceProjectFileName);
             string projectDirectory = Path.Combine(Settings.RootBuildDirectory, buildConfig.ConfigId.ToString());
             string targetProjectFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, "extensions.csproj");
-            string targetNugetConfigFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, Settings.NugetConfigFileName);
 
             FileUtility.EnsureDirectoryExists(projectDirectory);
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
-            FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
             await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle);
             return targetProjectFilePath;
@@ -134,7 +131,7 @@ namespace Build
             foreach (var extension in extensions)
             {
                 string version = string.IsNullOrEmpty(extension.Version) ? await Helper.GetLatestPackageVersion(extension.Id, extension.MajorVersion, addPrereleasePackages) : extension.Version;
-                Shell.Run("dotnet", $"add {projectFilePath} package {extension.Id} -v {version} -n");
+                Shell.Run("dotnet", new[] { "add", projectFilePath, "package", extension.Id, "--version", version, "--no-restore" });
             }
         }
 
@@ -142,18 +139,37 @@ namespace Build
         {
             var projectFilePath = await GenerateBundleProjectFile(buildConfig);
 
-            var publishCommandArguments = $"publish {projectFilePath} -c Release -o {buildConfig.PublishDirectoryPath}";
+            var restoreCommandArguments = new List<string>
+            {
+                "restore",
+                projectFilePath,
+                "--configfile",
+                Settings.NuGetConfigFilePath
+            };
+            var publishCommandArguments = new List<string>
+            {
+                "publish",
+                projectFilePath,
+                "--configuration",
+                "Release",
+                "--output",
+                buildConfig.PublishDirectoryPath,
+                "--no-restore"
+            };
 
             if (!buildConfig.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase))
             {
-                publishCommandArguments += $" -r {buildConfig.RuntimeIdentifier}";
+                restoreCommandArguments.AddRange(new[] { "--runtime", buildConfig.RuntimeIdentifier });
+                publishCommandArguments.AddRange(new[] { "--runtime", buildConfig.RuntimeIdentifier });
             }
 
             if (buildConfig.PublishReadyToRun)
             {
-                publishCommandArguments += $" /p:PublishReadyToRun=true";
+                restoreCommandArguments.Add("/p:PublishReadyToRun=true");
+                publishCommandArguments.Add("/p:PublishReadyToRun=true");
             }
 
+            Shell.Run("dotnet", restoreCommandArguments);
             Shell.Run("dotnet", publishCommandArguments);
 
             if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)

--- a/build/Helper.cs
+++ b/build/Helper.cs
@@ -1,4 +1,5 @@
 ﻿using NuGet.Common;
+using NuGet.Credentials;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using System.Linq;
@@ -11,7 +12,8 @@ namespace Build
     {
         public static async Task<string> GetLatestPackageVersion(string packageId, int majorVersion, bool isPrerelease = false)
         {
-            var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+            var repository = Repository.Factory.GetCoreV3(Settings.UpstreamPublicNuGetFeedUrl);
             var resource = await repository.GetResourceAsync<PackageMetadataResource>();
 
             var packages = await resource.GetMetadataAsync(packageId, includePrerelease: isPrerelease, includeUnlisted: false,

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -6,10 +6,13 @@ namespace Build
 {
     public static class Settings
     {
+        public const string UpstreamPublicNuGetFeedUrl = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
+
         public static string basePath = path;
 
         public static readonly string SourcePath = Path.GetFullPath(basePath + "/src/Microsoft.Azure.Functions.ExtensionBundle/");
         public static readonly string BuildPath = Path.Combine(Path.GetFullPath(basePath), "build");
+        public static readonly string NuGetConfigFilePath = Path.Combine(Path.GetFullPath(basePath), NuGetConfigFileName);
 
         public static string ExtensionsJsonFilePath => Path.Combine(SourcePath, ExtensionsJsonFileName);
 
@@ -49,7 +52,7 @@ namespace Build
 
         public static readonly string BundleConfigJsonFileName = "bundleConfig.json";
 
-        public static readonly string NugetConfigFileName = "NuGet.Config";
+        public const string NuGetConfigFileName = "NuGet.config";
 
         public static readonly string RUPackagePath = Path.Combine(RootBinDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package", BundleConfiguration.Instance.ExtensionBundleVersion);
 

--- a/build/Shell.cs
+++ b/build/Shell.cs
@@ -1,22 +1,24 @@
 using Colors.Net;
 using Colors.Net.StringColorExtensions;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Build
 {
     public static class Shell
     {
-        public static void Run(string program, string arguments, bool streamOutput = true, bool silent = false)
+        public static void Run(string program, IReadOnlyList<string> arguments, bool streamOutput = true, bool silent = false)
         {
             var exe = new InternalExe(program, arguments, streamOutput);
 
             if (!silent)
             {
-                ColoredConsole.WriteLine($"> {program} {arguments}".Green());
+                ColoredConsole.WriteLine($"> {program} {FormatArguments(arguments)}".Green());
             }
 
             var exitcode = silent
@@ -29,7 +31,7 @@ namespace Build
             }
         }
 
-        public static string GetOutput(string program, string arguments, bool ignoreExitCode = false)
+        public static string GetOutput(string program, IReadOnlyList<string> arguments, bool ignoreExitCode = false)
         {
             var exe = new InternalExe(program, arguments);
             var sb = new StringBuilder();
@@ -43,18 +45,24 @@ namespace Build
             return sb.ToString().Trim(new[] { ' ', '\r', '\n' });
         }
 
+        private static string FormatArguments(IEnumerable<string> arguments)
+        {
+            return string.Join(" ", arguments.Select(argument =>
+                argument.Any(char.IsWhiteSpace) ? $"\"{argument.Replace("\"", "\\\"")}\"" : argument));
+        }
+
         class InternalExe
         {
-            private string _arguments;
-            private string _exeName;
-            private bool _shareConsole;
-            private bool _streamOutput;
+            private readonly IReadOnlyList<string> _arguments;
+            private readonly string _exeName;
+            private readonly bool _shareConsole;
+            private readonly bool _streamOutput;
             private readonly bool _visibleProcess;
 
-            public InternalExe(string exeName, string arguments = null, bool streamOutput = true, bool shareConsole = false, bool visibleProcess = false)
+            public InternalExe(string exeName, IReadOnlyList<string> arguments, bool streamOutput = true, bool shareConsole = false, bool visibleProcess = false)
             {
                 _exeName = exeName;
-                _arguments = arguments;
+                _arguments = arguments ?? Array.Empty<string>();
                 _streamOutput = streamOutput;
                 _shareConsole = shareConsole;
                 _visibleProcess = visibleProcess;
@@ -65,7 +73,6 @@ namespace Build
                 var processInfo = new ProcessStartInfo
                 {
                     FileName = _exeName,
-                    Arguments = _arguments,
                     CreateNoWindow = !_visibleProcess,
                     UseShellExecute = _shareConsole,
                     RedirectStandardError = _streamOutput,
@@ -73,6 +80,11 @@ namespace Build
                     RedirectStandardOutput = _streamOutput,
                     WorkingDirectory = Directory.GetCurrentDirectory()
                 };
+
+                foreach (var argument in _arguments)
+                {
+                    processInfo.ArgumentList.Add(argument);
+                }
 
                 Process process = null;
 

--- a/eng/ci/config/core-tools.NuGet.config
+++ b/eng/ci/config/core-tools.NuGet.config
@@ -27,6 +27,7 @@
       <package pattern="Microsoft.Azure.Functions.JavaWorker" />
       <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
       <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+      <package pattern="Azure.Functions.*" />
     </packageSource>
     <packageSource key="PowerShellWorker">
       <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />

--- a/eng/ci/config/core-tools.NuGet.config
+++ b/eng/ci/config/core-tools.NuGet.config
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+    <!-- Core Tools packages not yet available through CFS are isolated by the exact mappings below. -->
+    <add key="AzureFunctions" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions/nuget/v3/index.json" protocolVersion="3" />
+    <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" protocolVersion="3" />
+    <add key="PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" protocolVersion="3" />
+    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" protocolVersion="3" />
+    <add key="Infra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="AzureFunctions">
+      <package pattern="Microsoft.Azure.AppService.Middleware.Functions" />
+      <package pattern="Microsoft.Azure.AppService.Middleware" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Modules" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.NetCore" />
+    </packageSource>
+    <packageSource key="AzureFunctionsRelease">
+      <package pattern="Microsoft.Azure.WebJobs.Script.WebHost" />
+      <package pattern="Microsoft.Azure.WebJobs.Script" />
+      <package pattern="Microsoft.Azure.WebJobs.Script.Grpc" />
+      <package pattern="Microsoft.Azure.Functions.JavaWorker" />
+      <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
+      <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+    </packageSource>
+    <packageSource key="PowerShellWorker">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" />
+    </packageSource>
+    <packageSource key="AzureFunctionsTempStaging">
+      <package pattern="Microsoft.Azure.DurableTask.AzureStorage.Internal" />
+      <package pattern="Microsoft.Azure.DurableTask.Core.Internal" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Client" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Common" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Runtime" />
+      <package pattern="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" />
+      <package pattern="Microsoft.Azure.WebSites.DataProtection" />
+    </packageSource>
+    <packageSource key="Infra">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" />
+      <package pattern="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/eng/ci/scripts/build-core-tools.ps1
+++ b/eng/ci/scripts/build-core-tools.ps1
@@ -24,13 +24,24 @@ param(
     [string]$Configuration = "Release",
     [Parameter(Mandatory=$true)]
     [string]$CoreToolsDir,
+    [string]$NuGetConfigPath = "",
     [string]$ZipOutputDir = "artifacts-coretools-zip"
     
 )
 
 $ErrorActionPreference = "Stop"
 
+$RepoRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
+if ([string]::IsNullOrEmpty($NuGetConfigPath)) {
+    $NuGetConfigPath = Join-Path $RepoRoot "eng\ci\config\core-tools.NuGet.config"
+}
 
+if (-not (Test-Path -LiteralPath $NuGetConfigPath)) {
+    Write-Error "NuGet configuration not found at $NuGetConfigPath"
+    exit 1
+}
+
+$NuGetConfigPath = (Resolve-Path -LiteralPath $NuGetConfigPath).Path
 if ($IsWindows -or $env:OS -eq "Windows_NT") {
     $osName = "win"
 } elseif ($IsMacOS) {
@@ -97,7 +108,9 @@ try {
     $restoreArgs = @(
         "restore",
         $ProjectPath,
-        "/p:TargetFramework=$targetFramework"
+        "--configfile", $NuGetConfigPath,
+        "/p:TargetFramework=$targetFramework",
+        "/p:SelfContained=true"
     )
     
     if (-not [string]::IsNullOrEmpty($Runtime)) {

--- a/eng/ci/scripts/build-multi-version-core-tools.ps1
+++ b/eng/ci/scripts/build-multi-version-core-tools.ps1
@@ -43,7 +43,8 @@ param(
     [int]$Count = 2,
     [string]$Pattern = "v4.10",
     [string]$Configuration = "Release",
-    [string]$CloneDir = ""
+    [string]$CloneDir = "",
+    [string]$NuGetConfigPath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -58,6 +59,17 @@ Write-Host "===========================================================" -Foregr
 # Get the script directory
 $ScriptDir = $PSScriptRoot
 $RepoRoot = Split-Path (Split-Path (Split-Path $ScriptDir -Parent) -Parent) -Parent
+
+if ([string]::IsNullOrEmpty($NuGetConfigPath)) {
+    $NuGetConfigPath = Join-Path $RepoRoot "eng\ci\config\core-tools.NuGet.config"
+}
+
+if (-not (Test-Path -LiteralPath $NuGetConfigPath)) {
+    Write-Error "NuGet configuration not found at $NuGetConfigPath"
+    exit 1
+}
+
+$NuGetConfigPath = (Resolve-Path -LiteralPath $NuGetConfigPath).Path
 
 # Set default CloneDir if not provided
 if ([string]::IsNullOrEmpty($CloneDir)) {
@@ -273,7 +285,7 @@ try {
         
         # Use a temp zip dir inside the repo (will be cleaned by git clean next iteration)
         $versionZipDir = "artifacts-coretools-zip-$hostVersion"
-        $buildOutput = & $BuildScript -Configuration $Configuration -CoreToolsDir $CloneDir -ZipOutputDir $versionZipDir
+        $buildOutput = & $BuildScript -Configuration $Configuration -CoreToolsDir $CloneDir -NuGetConfigPath $NuGetConfigPath -ZipOutputDir $versionZipDir
         
         if ($LASTEXITCODE -ne 0) {
             throw "Core Tools build failed with exit code $LASTEXITCODE"

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -38,12 +38,22 @@ jobs:
       useGlobalJson: true
 
   - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
+  - task: DotNetCoreCLI@2
     displayName: 'Build'
     inputs:
       command: 'run'
       workingDirectory: '.\build'
       ${{ if eq(parameters.official, false) }}:
-        arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux,PackageBundle,PackageBundlesWindows,PackageBundlesLinux'
+        arguments: '--no-restore -- skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux,PackageBundle,PackageBundlesWindows,PackageBundlesLinux'
+      ${{ else }}:
+        arguments: '--no-restore'
 
   - ${{ if eq(parameters.official, true) }}:
     - task: CopyFiles@2

--- a/eng/ci/templates/jobs/emulator-tests.yml
+++ b/eng/ci/templates/jobs/emulator-tests.yml
@@ -49,7 +49,7 @@ jobs:
         displayName: 'Build Azure Functions Core Tools'
         inputs:
           filePath: '$(Agent.BuildDirectory)/bundle/eng/ci/scripts/build-multi-version-core-tools.ps1'
-          arguments: '-Count $(hostTagsCount) -Pattern "$(hostTagPattern)" -Configuration Release -CloneDir "$(Agent.BuildDirectory)/core-tools"'
+          arguments: '-Count $(hostTagsCount) -Pattern "$(hostTagPattern)" -Configuration Release -CloneDir "$(Agent.BuildDirectory)/core-tools" -NuGetConfigPath "$(Agent.BuildDirectory)/bundle/eng/ci/config/core-tools.NuGet.config"'
           pwsh: true
           workingDirectory: '$(Agent.BuildDirectory)/core-tools'
 
@@ -100,13 +100,21 @@ jobs:
           packageType: 'sdk'
           useGlobalJson: true
 
+      - task: DotNetCoreCLI@2
+        displayName: 'Restore build tooling'
+        inputs:
+          command: 'restore'
+          projects: 'build/Build.csproj'
+          feedsToUse: 'config'
+          nugetConfigPath: 'NuGet.config'
+
       # Build the any-any bundle
       - task: DotNetCoreCLI@2
         displayName: 'Build any-any Bundle (once)'
         inputs:
           command: 'run'
           workingDirectory: './build'
-          arguments: 'skip:DownloadTemplates,BuildBundleBinariesForLinux,PackageBundle,PackageBundlesLinux,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
+          arguments: '--no-restore -- skip:DownloadTemplates,BuildBundleBinariesForLinux,PackageBundle,PackageBundlesLinux,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux'
         env:
           BUILD_REPOSITORY_LOCALPATH: '$(Build.Repository.LocalPath)'
 
@@ -272,6 +280,15 @@ jobs:
           fi
         displayName: 'Verify Core Tools Artifact'
 
+      - task: NuGetAuthenticate@1
+        displayName: 'NuGet Authenticate'
+
+      - task: PipAuthenticate@1
+        displayName: 'PyPI Authenticate'
+        inputs:
+          artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
+
       # Set up Python 3.12 and create virtual environment
       - task: UsePythonVersion@0
         inputs:
@@ -280,17 +297,12 @@ jobs:
           architecture: 'x64'
         displayName: 'Set up Python 3.12'
 
-      - task: PipAuthenticate@1
-        displayName: 'PyPI Authenticate'
-        inputs:
-          artifactFeeds: 'public/azure-functions-extension-bundles-feed'
-
       - script: |
           cd tests
           python -m venv venv
           source venv/bin/activate
-          pip install --upgrade pip
-          pip install --cache-dir ~/.cache/pip -r requirements.txt
+          python -m pip install --upgrade pip
+          python -m pip install --cache-dir ~/.cache/pip -r requirements.txt
         displayName: 'Install Python Dependencies (cached)'
         env:
           PIP_INDEX_URL: $(PIP_INDEX_URL)
@@ -328,7 +340,7 @@ jobs:
           if [ "$(ADDITIONAL_EMULATORS)" = "cosmosdb" ]; then
             echo "Starting CosmosDB Emulator for $(DISPLAY_NAME)..."
             docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
-            docker run --detach --publish 8081:8081 --publish 1234:1234 --name cosmosdb-emulator mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+            docker run --detach --env ENABLE_EXPLORER=false --publish 8081:8081 --name cosmosdb-emulator mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
             echo "Waiting for CosmosDB Emulator to start..."
             sleep 60
             docker ps
@@ -413,7 +425,8 @@ jobs:
             echo "Starting SignalR Emulator for $(DISPLAY_NAME)..."
             
             # Install SignalR emulator .NET tool
-            dotnet tool install -g Microsoft.Azure.SignalR.Emulator || dotnet tool update -g Microsoft.Azure.SignalR.Emulator
+            tool_args=(--global Microsoft.Azure.SignalR.Emulator --configfile "$NUGET_CONFIG_PATH")
+            dotnet tool install "${tool_args[@]}" || dotnet tool update "${tool_args[@]}"
             export PATH="$PATH:$HOME/.dotnet/tools"
             
             # Start emulator in background with settings file
@@ -437,6 +450,7 @@ jobs:
         displayName: 'Start Additional Emulators'
         env:
           AzureWebJobsSQLPassword: $(AzureWebJobsSQLPassword)
+          NUGET_CONFIG_PATH: '$(Build.Repository.LocalPath)/NuGet.config'
 
       # Start mock extension site in background
       - script: |

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -13,9 +13,17 @@ jobs:
     displayName: 'NuGet Authenticate'
 
   - task: DotNetCoreCLI@2
+    displayName: 'Restore tests'
+    inputs:
+      command: 'restore'
+      projects: 'ExtensionBundle.Tests.sln'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
+  - task: DotNetCoreCLI@2
     displayName: 'Run tests'
     inputs:
       command: 'test'
-      arguments: '-c Release'
+      arguments: '--configuration Release --no-restore'
       projects: |
         **/*Tests.csproj

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="azure-functions-extension-bundles" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/azure-functions-extension-bundles-feed/nuget/v3/index.json" protocolVersion="3" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>
-

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json
@@ -139,7 +139,7 @@
   },
   {
     "id": "Microsoft.Azure.WebJobs.Extensions.SignalRService",
-    "majorVersion": "2",
+    "version": "2.1.0",
     "name": "SignalR",
     "bindings": [
       "signalr",

--- a/tests/emulator_tests/README.md
+++ b/tests/emulator_tests/README.md
@@ -198,7 +198,8 @@ Install the project with dev dependencies from `pyproject.toml`:
 ```powershell
 # Install with dev dependencies
 cd tests
-pip install -r requirements.txt
+$env:PIP_INDEX_URL = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+python -m pip install -r requirements.txt
 
 # This installs all required packages including:
 # - pytest, requests, psutil

--- a/tests/emulator_tests/eventgrid_functions/function_app.py
+++ b/tests/emulator_tests/eventgrid_functions/function_app.py
@@ -7,14 +7,11 @@ using mock HTTP POST events (no Azure Event Grid connection required).
 
 Test scenarios covered (based on .NET SDK samples):
 1. EventGridEvent single trigger
-2. CloudEvent single trigger (CloudEvents mapped to func.EventGridEvent)
+2. CloudEvent single trigger
 3. EventGrid event construction verification (mock - not actual output binding)
 4. CloudEvent construction verification (mock - not actual output binding)
 5. Data shape variations - String, array, primitive, nested payloads
 6. Edge cases - Missing/null/empty data, special characters, large payloads
-
-Note: Python Event Grid triggers only support func.EventGridEvent type annotation.
-CloudEvents format is automatically mapped to EventGridEvent by the runtime.
 """
 import json
 import logging
@@ -60,28 +57,22 @@ def get_eventgrid_triggered(req: func.HttpRequest,
 
 # =============================================================================
 # CloudEvent Trigger - Single Event
-# Note: Python Event Grid triggers only support func.EventGridEvent type.
-# CloudEvents format is mapped to EventGridEvent by the extension runtime.
 # =============================================================================
 @app.function_name(name="cloudevent_trigger")
 @app.event_grid_trigger(arg_name="event")
 @app.blob_output(arg_name="$return",
                  path="bundle-tests/test-cloudevent-triggered.txt",
                  connection="AzureWebJobsStorage")
-def cloudevent_trigger(event: func.EventGridEvent) -> str:
-    """Process a single CloudEvent and write result to blob storage.
-    
-    Note: Python SDK only supports func.EventGridEvent type annotation.
-    CloudEvents are mapped to EventGridEvent by the extension runtime.
-    """
+def cloudevent_trigger(event: func.CloudEvent) -> str:
+    """Process a single CloudEvent and write result to blob storage."""
     logging.info(f"CloudEvent trigger received event: {event.id}")
     result = {
         'id': event.id,
-        'event_type': event.event_type,  # CloudEvent 'type' is mapped here
+        'event_type': event.type,
         'subject': event.subject,
-        'event_time': str(event.event_time) if event.event_time else None,
+        'event_time': str(event.time) if event.time else None,
         'data': event.get_json(),
-        'source': event.topic  # CloudEvent 'source' is mapped to topic
+        'source': event.source
     }
     return json.dumps(result)
 
@@ -218,10 +209,8 @@ def get_cloudevent_construction(req: func.HttpRequest,
 
 
 # =============================================================================
-# NOTE: Python Event Grid triggers only support func.EventGridEvent type annotation.
 # Unlike C#, Python does not support str, bytes, or dict type annotations for
-# eventGridTrigger bindings. The C# equivalents (String, BinaryData, JObject)
-# are not available in Python SDK.
+# eventGridTrigger bindings. Use func.EventGridEvent or func.CloudEvent.
 # =============================================================================
 
 
@@ -353,42 +342,6 @@ def eventgrid_trigger_nested_data(event: func.EventGridEvent) -> str:
 def get_eventgrid_nesteddata_triggered(req: func.HttpRequest,
                                        file: func.InputStream) -> str:
     """Retrieve the nested data trigger result from blob storage."""
-    return file.read().decode('utf-8')
-
-
-# =============================================================================
-# Edge Case: CloudEvent Backward Compatibility (legacy format)
-# Tests handling of older CloudEvent format with 'eventType' instead of 'type'
-# =============================================================================
-@app.function_name(name="cloudevent_backcompat_trigger")
-@app.event_grid_trigger(arg_name="event")
-@app.blob_output(arg_name="$return",
-                 path="bundle-tests/test-cloudevent-backcompat-triggered.txt",
-                 connection="AzureWebJobsStorage")
-def cloudevent_backcompat_trigger(event: func.EventGridEvent) -> str:
-    """Process CloudEvent in backward compatible mode.
-    
-    Handles both legacy 'eventType' and modern 'type' field formats.
-    """
-    logging.info("CloudEvent backcompat trigger received event")
-    result = {
-        'id': event.id,
-        'event_type': event.event_type,
-        'subject': event.subject,
-        'data': event.get_json(),
-        'format': 'backcompat'
-    }
-    return json.dumps(result)
-
-
-@app.function_name(name="get_cloudevent_backcompat_triggered")
-@app.route(route="get_cloudevent_backcompat_triggered")
-@app.blob_input(arg_name="file",
-                path="bundle-tests/test-cloudevent-backcompat-triggered.txt",
-                connection="AzureWebJobsStorage")
-def get_cloudevent_backcompat_triggered(req: func.HttpRequest,
-                                        file: func.InputStream) -> str:
-    """Retrieve the CloudEvent backcompat trigger result."""
     return file.read().decode('utf-8')
 
 

--- a/tests/emulator_tests/pip.conf
+++ b/tests/emulator_tests/pip.conf
@@ -1,2 +1,0 @@
-[global]
-index-url = https://pkgs.dev.azure.com/azfunc/public/_packaging/azure-functions-extension-bundles-feed/pypi/simple/

--- a/tests/emulator_tests/test_eventgrid_functions.py
+++ b/tests/emulator_tests/test_eventgrid_functions.py
@@ -10,7 +10,7 @@ https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/eventgrid/Microsoft.Azu
 
 Scenarios covered:
 1. EventGridEventTriggerFunction - Single EventGridEvent trigger
-2. CloudEventTriggerFunction - Single CloudEvent trigger (azure.core.messaging.CloudEvent)
+2. CloudEventTriggerFunction - Single CloudEvent trigger
 3. EventGrid event construction - Validates event structure (mock, not actual output binding)
 4. CloudEvent construction - Validates event structure (mock, not actual output binding)
 5. Data shape variations - String, array, primitive, nested payloads
@@ -119,33 +119,19 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
 
     # =========================================================================
     # CloudEvent Trigger Tests
-    # Note: Python SDK only supports func.EventGridEvent type annotation.
-    # CloudEvents are mapped to EventGridEvent by the runtime.
     # =========================================================================
     def test_cloudevent_trigger(self):
         """Test EventGridTrigger with a single CloudEvent.
         
         Equivalent to C# sample: CloudEventTriggerFunction
-        Note: Python only supports func.EventGridEvent - CloudEvents format
-        is mapped to EventGridEvent fields by the extension runtime.
-        
-        IMPORTANT: The local Event Grid webhook endpoint expects EventGrid-style
-        field names (eventType) even when using CloudEvents content-type header.
-        This is a known limitation of the local emulator - in production Azure,
-        proper CloudEvents 1.0 field mapping (type -> event_type) may work.
         """
-        # Generate unique CloudEvent data
         event_id = f"cloud-event-{uuid.uuid4()}"
         test_data = {'message': f'cloud-test-{int(time.time())}'}
         
-        # Create CloudEvent payload - use EventGrid field names for local emulator
-        # The local webhook doesn't map pure CloudEvents field names correctly:
-        #   - 'type' must be 'eventType'
-        #   - 'source' must be 'topic'
         event = {
             'specversion': '1.0',
-            'eventType': 'com.example.test',  # Use eventType (not 'type')
-            'topic': '/test/cloudevents',     # Use topic (not 'source')
+            'type': 'com.example.test',
+            'source': '/test/cloudevents',
             'id': event_id,
             'time': '2026-03-06T07:00:00Z',
             'subject': 'test/subject',
@@ -165,8 +151,6 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
 
         result = json.loads(r.text)
 
-        # Verify the CloudEvent was processed correctly
-        # Local emulator uses EventGrid field names: eventType->event_type, topic->source
         self.assertEqual(result['id'], event_id)
         self.assertEqual(result['event_type'], 'com.example.test')
         self.assertEqual(result['source'], '/test/cloudevents')
@@ -397,40 +381,6 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
     # =========================================================================
     # Edge Case Tests - These catch production issues!
     # =========================================================================
-    def test_cloudevent_backcompat_legacy_format(self):
-        """Test CloudEvent backward compatibility with EventGrid field names.
-        
-        Equivalent to C# CloudEventParamsBackCompat tests.
-        The local emulator requires EventGrid-style field names (eventType, topic)
-        even when using CloudEvents content-type header.
-        """
-        event_id = f"backcompat-{uuid.uuid4()}"
-        # CloudEvent with EventGrid field names for local emulator compatibility
-        legacy_event = {
-            'specversion': '1.0',
-            'eventType': 'com.legacy.format',  # EventGrid field name
-            'topic': '/test/backcompat',       # EventGrid field name (not 'source')
-            'id': event_id,
-            'time': '2026-03-06T07:00:00Z',
-            'subject': 'backcompat/test',
-            'data': {'legacy': True}
-        }
-
-        logger.info(f"Testing CloudEvent backcompat: {event_id}")
-        self._send_eventgrid_event('cloudevent_backcompat_trigger', legacy_event, 
-                                   is_cloudevent=True)
-
-        r = self.webhost.wait_and_request('GET', 'get_cloudevent_backcompat_triggered',
-                                          wait_time=2,
-                                          max_retries=10,
-                                          expected_status=200)
-
-        result = json.loads(r.text)
-        self.assertEqual(result['id'], event_id)
-        self.assertEqual(result['event_type'], 'com.legacy.format')  # Verify eventType works
-        self.assertEqual(result['subject'], 'backcompat/test')
-        self.assertEqual(result['format'], 'backcompat')
-
     def test_eventgrid_trigger_missing_data_field(self):
         """Test EventGridTrigger handles missing 'data' field gracefully.
         

--- a/tests/validate-ci.ps1
+++ b/tests/validate-ci.ps1
@@ -19,6 +19,7 @@ $requiredFiles = @(
     "test_setup.py",
     "utils\testutils.py",
     "emulator_tests\utils\eventhub\docker-compose.yml",
+    "..\eng\ci\config\core-tools.NuGet.config",
     "..\eng\ci\templates\jobs\emulator-tests.yml"
 )
 
@@ -122,9 +123,10 @@ Write-Host ""
 Write-Host "🎉 All validations passed!" -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Cyan
-Write-Host "1. Build locally: 'cd ..\build && dotnet run'" -ForegroundColor White
-Write-Host "2. Test emulator setup: 'python test_setup.py'" -ForegroundColor White
-Write-Host "3. Run emulator tests with mock site:" -ForegroundColor White
+Write-Host "1. Restore locally: 'dotnet restore ..\build\Build.csproj --configfile ..\NuGet.config'" -ForegroundColor White
+Write-Host "2. Build locally: 'cd ..\build && dotnet run --no-restore'" -ForegroundColor White
+Write-Host "3. Test emulator setup: 'python test_setup.py'" -ForegroundColor White
+Write-Host "4. Run emulator tests with mock site:" -ForegroundColor White
 Write-Host "   invoke mock-extension-site --port 8000 --keep-alive &" -ForegroundColor Gray
 Write-Host "   `$env:FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI='http://localhost:8000'" -ForegroundColor Gray
 Write-Host "   pytest emulator_tests/" -ForegroundColor Gray


### PR DESCRIPTION
## Summary

Back-ports the CFS network-isolation fixes from `main` (`98d6382` and `4ce4a8b`) to `main-preview`.

- adds a root `NuGet.config` with `<clear />`, the `upstream-public` CFS feed, and wildcard package-source mapping
- adds the dedicated Core Tools CFS configuration and passes it to Core Tools restores
- authenticates restores across build, unit-test, and emulator jobs
- moves PyPI authentication to `public/upstream-public`
- removes nested configurations that reintroduced old package sources
- disables the Cosmos emulator's bundled Data Explorer

`4ce4a8b` is not required for `PermissiveCFSClean` because it changes no restore or authentication path. It is included for parity with `main` and may be relevant to the broader `DefaultDeny` enforcement later.

## Back-port adaptation

This is an adaptation rather than a cherry-pick because `main-preview` has different build target names, a simpler `BuildSteps` implementation, `tests/validate-ci.ps1` instead of a root validation script, no `.github` workflows, and a sparse Core Tools checkout.

## Validation

- both NuGet configurations contain `<clear />`
- no tracked configuration references NuGet.org or the old extension-bundles feed
- authentication coverage is build=1, unit=1, emulator=3
- changed YAML and PowerShell files parse successfully
- CFS-only restores for the build and test projects succeed
- the build project compiles successfully

## Known limitations

- Pipeline execution and the `PermissiveCFSClean` telemetry verdict cannot be verified until this runs in Azure DevOps.
- The test suite encounters a pre-existing MessagePack conflict unrelated to this change: `extensions.json` pins 2.5.301 while SignalRService 2.2.0 requires >=2.5.302. The `upstream-public` feed carries both versions, so the feed is not the constraint; the pin can be bumped independently.

## Out of scope

`raw.githubusercontent.com` traffic from `resolve-core-tools-tags.ps1` is intentionally unchanged. It is not gated by `PermissiveCFSClean`, and replacing the per-tag scan requires a separate design and performance review.