### PR TITLE
main-v2: ci - route NuGet restores through CFS feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -8,6 +8,7 @@
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="NuGet.Versioning" Version="6.12.1" />
 	<PackageReference Include="NuGet.Protocol" Version="6.12.1" />
+	<PackageReference Include="NuGet.Credentials" Version="6.12.1" />
 	<PackageReference Include="System.IO.Abstractions" Version="2.1.0.227" />
 	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -98,15 +98,12 @@ namespace Build
 
         public static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig)
         {
-            var sourceNugetConfig = Path.Combine(Settings.SourcePath, Settings.NugetConfigFileName);
             var sourceProjectFilePath = Path.Combine(Settings.SourcePath, buildConfig.SourceProjectFileName);
             string projectDirectory = Path.Combine(Settings.RootBuildDirectory, buildConfig.ConfigId.ToString());
             string targetProjectFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, "extensions.csproj");
-            string targetNugetConfigFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, Settings.NugetConfigFileName);
 
             FileUtility.EnsureDirectoryExists(projectDirectory);
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
-            FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
             await AddExtensionPackages(targetProjectFilePath);
             return targetProjectFilePath;
@@ -118,7 +115,7 @@ namespace Build
             foreach (var extension in extensions)
             {
                 string version = string.IsNullOrEmpty(extension.Version) ? await Helper.GetLatestPackageVersion(extension.Id, extension.MajorVersion) : extension.Version;
-                Shell.Run("dotnet", $"add {projectFilePath} package {extension.Id} -v {version} -n");
+                Shell.Run("dotnet", $"add \"{projectFilePath}\" package {extension.Id} --version {version} --no-restore");
             }
         }
 
@@ -126,23 +123,28 @@ namespace Build
         {
             var projectFilePath = await GenerateBundleProjectFile(buildConfig);
 
-            var publishCommandArguments = $"publish {projectFilePath} -c Release -o {buildConfig.PublishDirectoryPath}";
+            var restoreCommandArguments = $"restore \"{projectFilePath}\" --configfile \"{Settings.NuGetConfigFilePath}\"";
+            var publishCommandArguments = $"publish \"{projectFilePath}\" -c Release -o \"{buildConfig.PublishDirectoryPath}\" --no-restore";
 
             if (!buildConfig.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase))
             {
+                restoreCommandArguments += $" -r {buildConfig.RuntimeIdentifier}";
                 publishCommandArguments += $" -r {buildConfig.RuntimeIdentifier}";
             }
 
             if (buildConfig.PublishReadyToRun)
             {
+                restoreCommandArguments += $" /p:PublishReadyToRun=true";
                 publishCommandArguments += $" /p:PublishReadyToRun=true";
             }
 
             if (buildConfig.SuppressTfmSupportBuildWarnings)
             {
+                restoreCommandArguments += " /p:SuppressTfmSupportBuildWarnings=true";
                 publishCommandArguments += " /p:SuppressTfmSupportBuildWarnings=true";
             }
 
+            Shell.Run("dotnet", restoreCommandArguments);
             Shell.Run("dotnet", publishCommandArguments);
 
             if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)
@@ -174,9 +176,7 @@ namespace Build
                 Directory.SetCurrentDirectory(Settings.RootBuildDirectory);
 
                 Console.WriteLine(Directory.GetCurrentDirectory());
-                Console.WriteLine($"dotnet list \"{projectFilePath}\" package --include-transitive --vulnerable");
-
-                string output = Shell.GetOutput("dotnet", $"list \"{projectFilePath}\" package --include-transitive --vulnerable");
+                string output = Shell.GetOutput("dotnet", $"list \"{projectFilePath}\" package --include-transitive --vulnerable --configfile \"{Settings.NuGetConfigFilePath}\"");
 
                 if (!output.Contains("has no vulnerable packages given the current sources."))
                 {

--- a/build/Helper.cs
+++ b/build/Helper.cs
@@ -1,4 +1,5 @@
 ﻿using NuGet.Common;
+using NuGet.Credentials;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using System.Linq;
@@ -11,7 +12,8 @@ namespace Build
     {
         public static async Task<string> GetLatestPackageVersion(string packageId, int majorVersion, bool isPrerelease = false)
         {
-            var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+            var repository = Repository.Factory.GetCoreV3(Settings.UpstreamPublicNuGetFeedUrl);
             var resource = await repository.GetResourceAsync<PackageMetadataResource>();
 
             var packages = await resource.GetMetadataAsync(packageId, includePrerelease: isPrerelease, includeUnlisted: false,

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -8,7 +8,11 @@ namespace Build
 {
     public static class Settings
     {
+        public const string UpstreamPublicNuGetFeedUrl = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
+
         public static readonly string SourcePath = Path.GetFullPath("../src/Microsoft.Azure.Functions.ExtensionBundle/");
+
+        public static readonly string NuGetConfigFilePath = Path.GetFullPath("../NuGet.config");
 
         public static string ExtensionsJsonFilePath => Path.Combine(SourcePath, ExtensionsJsonFileName);
 
@@ -39,7 +43,6 @@ namespace Build
         public static readonly string ExtensionsJsonFileName = "extensions.json";
 
         public static readonly string BundleConfigJsonFileName = "bundleConfig.json";
-        public static readonly string NugetConfigFileName = "NuGet.Config";
 
         public static readonly string RUPackagePath = Path.Combine(RootBinDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package", BundleConfiguration.Instance.ExtensionBundleVersion);
 

--- a/build/global.json
+++ b/build/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "3.1.100",
-    "rollForward": "latestMinor"
-  }
-}

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -35,6 +35,17 @@ jobs:
       version: '3.1.x'
       performMultiLevelLookup: true
 
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Authenticate'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - ${{ if eq(parameters.official, true) }}:
     - task: DownloadBuildArtifacts@1
       inputs:
@@ -52,9 +63,9 @@ jobs:
       command: 'run'
       workingDirectory: '.\build'
       ${{ if eq(parameters.official, true) }}:
-        arguments: 'skip:GenerateVulnerabilityReport,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux'
+        arguments: '--no-restore -- skip:GenerateVulnerabilityReport,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux'
       ${{ else }}:
-        arguments: 'skip:DownloadTemplates,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux,BuildBundleBinariesForLinux,GenerateVulnerabilityReport,PackageNetCoreV2Bundle'
+        arguments: '--no-restore -- skip:DownloadTemplates,GenerateVulnerabilityReport,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux,BuildBundleBinariesForLinux,GenerateVulnerabilityReport,PackageNetCoreV2Bundle'
         
   - ${{ if eq(parameters.official, true) }}:
     - task: CopyFiles@2
@@ -92,6 +103,17 @@ jobs:
       version: '3.1.x'
       performMultiLevelLookup: true
 
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Authenticate'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - ${{ if eq(parameters.official, true) }}:
     - task: DownloadBuildArtifacts@1
       inputs:
@@ -111,7 +133,7 @@ jobs:
         script: |
           PATH=".dotnet:"$PATH && dotnet --info
           cd build
-          dotnet run skip:DownloadTemplates,GenerateVulnerabilityReport,PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux
+          dotnet run --no-restore -- skip:DownloadTemplates,GenerateVulnerabilityReport,PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux
 
   - ${{ if eq(parameters.official, true) }}:      
     - task: Bash@3
@@ -120,7 +142,7 @@ jobs:
         script: |
           PATH=".dotnet:"$PATH && dotnet --info
           cd build
-          dotnet run skip:GenerateVulnerabilityReport,PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport
+          dotnet run --no-restore -- skip:GenerateVulnerabilityReport,PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport
 
 
   - ${{ if eq(parameters.official, true) }}:      

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -35,6 +35,13 @@ jobs:
       version: '3.1.x'
       performMultiLevelLookup: true
 
+  - task: UseDotNet@2
+    displayName: 'Install current .NET SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '8.x'
+      performMultiLevelLookup: true
+
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
@@ -101,6 +108,13 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '3.1.x'
+      performMultiLevelLookup: true
+
+  - task: UseDotNet@2
+    displayName: 'Install current .NET SDK'
+    inputs:
+      packageType: 'sdk'
+      version: '8.x'
       performMultiLevelLookup: true
 
   - task: NuGetAuthenticate@1

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -17,10 +17,23 @@ jobs:
       packageType: 'sdk'
       version: '3.1.x'
       performMultiLevelLookup: true
+
+  - task: NuGetAuthenticate@1
+    displayName: 'NuGet Authenticate'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore tests'
+    inputs:
+      command: 'restore'
+      projects: |
+        **/*Tests.csproj
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - task: DotNetCoreCLI@2
     displayName: 'Run tests'
     inputs:
       command: 'test'
-      arguments: '-c Release'
+      arguments: '--configuration Release --no-restore'
       projects: |
         **/*Tests.csproj

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -17,23 +17,10 @@ jobs:
       packageType: 'sdk'
       version: '3.1.x'
       performMultiLevelLookup: true
-
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Authenticate'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Restore tests'
-    inputs:
-      command: 'restore'
-      projects: |
-        **/*Tests.csproj
-      feedsToUse: 'config'
-      nugetConfigPath: 'NuGet.config'
-
   - task: DotNetCoreCLI@2
     displayName: 'Run tests'
     inputs:
       command: 'test'
-      arguments: '--configuration Release --no-restore'
+      arguments: '-c Release'
       projects: |
         **/*Tests.csproj

--- a/eng/official-build.yml
+++ b/eng/official-build.yml
@@ -6,15 +6,6 @@ trigger:
     include:
     - 'v*'
 
-schedules:
-# Ensure we build nightly to catch any new CVEs and report SDL often.
-- cron: "0 3 * * *"
-  displayName: Nightly Build
-  branches:
-    include:
-    - main-v2
-  always: true
-
 # CI only, does not trigger on PRs.
 pr: none
 
@@ -60,4 +51,3 @@ extends:
         parameters:
           official: true
           poolName: 1es-pool-azfunc
-

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.416",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>  
-</configuration>


### PR DESCRIPTION
## Summary

Back-ports the CFS network-isolation fix from `main` commit `98d6382` to `main-v2`.

- Adds the root `NuGet.config` with `<clear />`, the Azure Functions `upstream-public` CFS feed, and wildcard package source mapping.
- Deletes `src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config`, which re-added `api.nuget.org`.
- Adds `NuGetAuthenticate@1` and explicit config-based restores to both real restoring jobs, with `--no-restore` on subsequent operations.
- Adds a root `global.json` pinned to .NET SDK `8.0.416` with `latestFeature` roll-forward and removes the nested .NET 3.1 SDK pin.
- Routes `Helper.cs` package metadata resolution through CFS with NuGet credential-provider support.
- Removes the `main-v2` nightly schedule.

## Branch adaptation

`main-v2` has separate Windows and Linux jobs inside `eng/ci/templates/jobs/build.yml`, so each job receives its own authentication and restore pair. `eng/ci/templates/jobs/emulator-tests.yml` does not exist on this branch, so there is no emulator restore path to patch.

`eng/ci/templates/jobs/run-unit-test.yml` references `**/*Tests.csproj`, but this branch contains no matching projects. Its existing test task is therefore a warning-only no-op. Adding an explicit restore for that unmatched glob caused PR validation to fail, so the template remains unchanged from `main-v2` and performs no package restore.

## Validation

- Exactly one NuGet config and one configured source.
- No `nuget.org` or `api.nuget.org` references remain in restore-relevant files.
- Authentication covers both real restoring jobs: Windows and Linux builds.
- A no-cache restore using the root config succeeded under .NET SDK 8.
- `build/Build.csproj` compiled successfully in Release under .NET SDK 8.
- SDK selection resolves to .NET `8.0.424` from both the repository root and `build/`.
- The generated Windows bundle path completed successfully, including generated-project restores through the root CFS config, with no SDK 3.1, credential-provider, HTTP 401, or restore errors.
- `NuGet.config` is byte-identical to `origin/main` blob `1f635d7c7491b45b2d4ca4f138b65f0012a48c08`, including wildcard package source mapping.

## Build-break investigation

PR build 299612 exposed two deterministic issues:

- Generated bundle restores ran under .NET 3.1, but `NuGetAuthenticate@1` installs a credential provider requiring .NET 6 or newer. The initial task-managed restore succeeded, while subsequent generated-project restores received 401 responses for uncached upstream packages.
- The explicit unit-test restore failed with `No files matched the search pattern`; the prior test task only warned for the same empty glob. Reverting that template to its branch baseline restores its no-op behavior.

Follow-up build 300028 passed Linux and unit tests but still failed Windows. Although the pipeline installed SDK 8, `build/global.json` was the nearest SDK policy file and pinned `3.1.100` with `latestMinor`, causing generated restores to run under `3.1.426`. This revision replaces that nested pin with a repository-wide .NET 8 pin using `latestFeature`, allowing hosted agents to select the latest installed .NET 8 feature band while remaining compatible with the credential provider.

## Known limitation

Pipeline execution and `PermissiveCFSClean` telemetry for the latest revision cannot be verified until it runs in Azure DevOps.

`raw.githubusercontent.com` traffic was traced in build 298909's expanded YAML and logs to 1ES-injected SDL/template tooling rather than repository build logic. It is deliberately out of scope because it is not gated by `PermissiveCFSClean`.