### PR TITLE
main-v3: ci - route NuGet restores through CFS feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -9,6 +9,7 @@
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="NuGet.Versioning" Version="6.12.1" />
 	<PackageReference Include="NuGet.Protocol" Version="6.12.1" />
+	<PackageReference Include="NuGet.Credentials" Version="6.12.1" />
 	<PackageReference Include="System.IO.Abstractions" Version="2.1.0.227" />
 	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/build/BuildSteps.cs
+++ b/build/BuildSteps.cs
@@ -119,15 +119,12 @@ namespace Build
 
         public static async Task<string> GenerateBundleProjectFile(BuildConfiguration buildConfig)
         {
-            var sourceNugetConfig = Path.Combine(Settings.SourcePath, Settings.NugetConfigFileName);
             var sourceProjectFilePath = Path.Combine(Settings.SourcePath, buildConfig.SourceProjectFileName);
             string projectDirectory = Path.Combine(Settings.RootBuildDirectory, buildConfig.ConfigId.ToString());
             string targetProjectFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, "extensions.csproj");
-            string targetNugetConfigFilePath = Path.Combine(Settings.RootBuildDirectory, projectDirectory, Settings.NugetConfigFileName);
 
             FileUtility.EnsureDirectoryExists(projectDirectory);
             FileUtility.CopyFile(sourceProjectFilePath, targetProjectFilePath);
-            FileUtility.CopyFile(sourceNugetConfig, targetNugetConfigFilePath);
 
             await AddExtensionPackages(targetProjectFilePath, BundleConfiguration.Instance.IsPreviewBundle);
             return targetProjectFilePath;
@@ -147,15 +144,18 @@ namespace Build
         {
             var projectFilePath = await GenerateBundleProjectFile(buildConfig);
 
-            var publishCommandArguments = $"publish {projectFilePath} -c Release -o {buildConfig.PublishDirectoryPath}";
+            var restoreCommandArguments = $"restore \"{projectFilePath}\" --configfile \"{Settings.NuGetConfigFilePath}\"";
+            var publishCommandArguments = $"publish \"{projectFilePath}\" -c Release -o \"{buildConfig.PublishDirectoryPath}\" --no-restore";
 
             if (!buildConfig.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase))
             {
+                restoreCommandArguments += $" -r {buildConfig.RuntimeIdentifier}";
                 publishCommandArguments += $" -r {buildConfig.RuntimeIdentifier}";
             }
 
             if (buildConfig.PublishReadyToRun)
             {
+                restoreCommandArguments += " /p:PublishReadyToRun=true";
                 publishCommandArguments += $" /p:PublishReadyToRun=true";
             }
 
@@ -164,6 +164,7 @@ namespace Build
                 publishCommandArguments += " /p:SuppressTfmSupportBuildWarnings=true";
             }
 
+            Shell.Run("dotnet", restoreCommandArguments);
             Shell.Run("dotnet", publishCommandArguments);
 
             if (Path.Combine(buildConfig.PublishDirectoryPath, "bin") != buildConfig.PublishBinDirectoryPath)
@@ -195,9 +196,9 @@ namespace Build
                 Directory.SetCurrentDirectory(Settings.RootBuildDirectory);
 
                 Console.WriteLine(Directory.GetCurrentDirectory());
-                Console.WriteLine($"dotnet list \"{projectFilePath}\" package --include-transitive --vulnerable");
+                Console.WriteLine($"dotnet list \"{projectFilePath}\" package --include-transitive --vulnerable --configfile \"{Settings.NuGetConfigFilePath}\"");
 
-                string output = Shell.GetOutput("dotnet", $"list \"{projectFilePath}\" package --include-transitive --vulnerable");
+                string output = Shell.GetOutput("dotnet", $"list \"{projectFilePath}\" package --include-transitive --vulnerable --configfile \"{Settings.NuGetConfigFilePath}\"");
 
                 if (!output.Contains("has no vulnerable packages given the current sources."))
                 {

--- a/build/Helper.cs
+++ b/build/Helper.cs
@@ -1,4 +1,5 @@
 ﻿using NuGet.Common;
+using NuGet.Credentials;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using System.Linq;
@@ -11,7 +12,8 @@ namespace Build
     {
         public static async Task<string> GetLatestPackageVersion(string packageId, int majorVersion, bool isPrerelease = false)
         {
-            var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+            var repository = Repository.Factory.GetCoreV3(Settings.UpstreamPublicNuGetFeedUrl);
             var resource = await repository.GetResourceAsync<PackageMetadataResource>();
 
             var packages = await resource.GetMetadataAsync(packageId, includePrerelease: isPrerelease, includeUnlisted: false,

--- a/build/Settings.cs
+++ b/build/Settings.cs
@@ -9,10 +9,13 @@ namespace Build
 {
     public static class Settings
     {
+        public const string UpstreamPublicNuGetFeedUrl = "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json";
+
         public static string basePath = path;
 
         public static readonly string SourcePath = Path.GetFullPath(basePath + "/src/Microsoft.Azure.Functions.ExtensionBundle/");
         public static readonly string BuildPath = Path.Combine(Path.GetFullPath(basePath), "build");
+        public static readonly string NuGetConfigFilePath = Path.Combine(Path.GetFullPath(basePath), NuGetConfigFileName);
 
         public static string ExtensionsJsonFilePath => Path.Combine(SourcePath, ExtensionsJsonFileName);
 
@@ -49,7 +52,7 @@ namespace Build
 
         public static readonly string BundleConfigJsonFileName = "bundleConfig.json";
 
-        public static readonly string NugetConfigFileName = "NuGet.Config";
+        public const string NuGetConfigFileName = "NuGet.config";
 
         public static readonly string RUPackagePath = Path.Combine(RootBinDirectory, $"{BundleConfiguration.Instance.ExtensionBundleId}.{BundleConfiguration.Instance.ExtensionBundleVersion}_RU_package", BundleConfiguration.Instance.ExtensionBundleVersion);
 

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -36,10 +36,10 @@ jobs:
       performMultiLevelLookup: true
 
   - task: UseDotNet@2
-    displayName: 'Install credential provider runtime'
+    displayName: 'Install authentication SDK'
     inputs:
-      packageType: 'runtime'
-      version: '6.x'
+      packageType: 'sdk'
+      version: '8.x'
 
   - ${{ if eq(parameters.official, true) }}:
     - task: DownloadBuildArtifacts@1
@@ -110,10 +110,10 @@ jobs:
       performMultiLevelLookup: true
 
   - task: UseDotNet@2
-    displayName: 'Install credential provider runtime'
+    displayName: 'Install authentication SDK'
     inputs:
-      packageType: 'runtime'
-      version: '6.x'
+      packageType: 'sdk'
+      version: '8.x'
 
   - ${{ if eq(parameters.official, true) }}:
     - task: DownloadBuildArtifacts@1

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -47,17 +47,25 @@ jobs:
         artifactName: 'drop'
         downloadPath: '$(Build.Repository.LocalPath)\templatesArtifacts'
         
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'    
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
 
   - task: DotNetCoreCLI@2
     inputs:
       command: 'run'
       workingDirectory: '.\build'
       ${{ if eq(parameters.official, true) }}:
-        arguments: 'skip:PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux'
+        arguments: '--no-restore -- skip:PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux,BuildBundleBinariesForLinux'
       ${{ else }}:
-        arguments: 'skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux,BuildBundleBinariesForLinux,PackageNetCoreV2Bundle'
+        arguments: '--no-restore -- skip:DownloadTemplates,PackageNetCoreV3Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,CreateCDNStoragePackageLinux,PackageNetCoreV3BundlesLinux,BuildBundleBinariesForLinux,PackageNetCoreV2Bundle'
         
   - ${{ if eq(parameters.official, true) }}:
     - task: CopyFiles@2
@@ -107,8 +115,16 @@ jobs:
         artifactName: 'drop'
         downloadPath: '$(Build.Repository.LocalPath)/templatesArtifacts'
 
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore build tooling'
+    inputs:
+      command: 'restore'
+      projects: 'build/Build.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
     
   - ${{ if eq(parameters.official, false) }}:      
     - task: Bash@3
@@ -117,7 +133,7 @@ jobs:
         script: |
           PATH=".dotnet:"$PATH && dotnet --info
           cd build
-          dotnet run skip:DownloadTemplates,PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux
+          dotnet run --no-restore -- skip:DownloadTemplates,PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport,PackageNetCoreV3BundlesLinux,CreateCDNStoragePackageLinux
 
   - ${{ if eq(parameters.official, true) }}:      
     - task: Bash@3
@@ -126,7 +142,7 @@ jobs:
         script: |
           PATH=".dotnet:"$PATH && dotnet --info
           cd build
-          dotnet run skip:PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport
+          dotnet run --no-restore -- skip:PackageNetCoreV2Bundle,PackageNetCoreV3BundlesWindows,CreateRUPackage,CreateCDNStoragePackage,CreateCDNStoragePackageWindows,BuildBundleBinariesForWindows,GenerateVulnerabilityReport
 
 
   - ${{ if eq(parameters.official, true) }}:      
@@ -137,4 +153,3 @@ jobs:
         TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
         CleanTargetFolder: false
-

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -35,6 +35,12 @@ jobs:
       version: '3.1.x'
       performMultiLevelLookup: true
 
+  - task: UseDotNet@2
+    displayName: 'Install credential provider runtime'
+    inputs:
+      packageType: 'runtime'
+      version: '6.x'
+
   - ${{ if eq(parameters.official, true) }}:
     - task: DownloadBuildArtifacts@1
       inputs:
@@ -102,6 +108,12 @@ jobs:
       packageType: 'sdk'
       version: '3.1.x'
       performMultiLevelLookup: true
+
+  - task: UseDotNet@2
+    displayName: 'Install credential provider runtime'
+    inputs:
+      packageType: 'runtime'
+      version: '6.x'
 
   - ${{ if eq(parameters.official, true) }}:
     - task: DownloadBuildArtifacts@1

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -23,6 +23,12 @@ jobs:
       packageType: 'sdk'
       version: '3.1.x'
       performMultiLevelLookup: true
+
+  - task: UseDotNet@2
+    displayName: 'Install credential provider runtime'
+    inputs:
+      packageType: 'runtime'
+      version: '6.x'
       
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -25,10 +25,10 @@ jobs:
       performMultiLevelLookup: true
 
   - task: UseDotNet@2
-    displayName: 'Install credential provider runtime'
+    displayName: 'Install authentication SDK'
     inputs:
-      packageType: 'runtime'
-      version: '6.x'
+      packageType: 'sdk'
+      version: '8.x'
       
   - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'

--- a/eng/ci/templates/jobs/run-unit-test.yml
+++ b/eng/ci/templates/jobs/run-unit-test.yml
@@ -24,16 +24,22 @@ jobs:
       version: '3.1.x'
       performMultiLevelLookup: true
       
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
-    
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Restore tests'
+    inputs:
+      command: 'restore'
+      projects: 'ExtensionBundle.Tests/ExtensionBundle.Tests.csproj'
+      feedsToUse: 'config'
+      nugetConfigPath: 'NuGet.config'
+
   - task: DotNetCoreCLI@2
     displayName: 'Run tests'
     inputs:
       command: 'test'
-      arguments: '-c Release'
+      arguments: '--configuration Release --no-restore'
       projects: |
 
         **/*Tests.csproj
-
-

--- a/eng/official-build.yml
+++ b/eng/official-build.yml
@@ -7,15 +7,6 @@ trigger:
     include:
     - 'v*'
 
-schedules:
-# Ensure we build nightly to catch any new CVEs and report SDL often.
-- cron: "0 2 * * *"
-  displayName: Nightly Build
-  branches:
-    include:
-    - main-v3
-  always: true
-
 # CI only, does not trigger on PRs.
 pr: none
 
@@ -61,5 +52,4 @@ extends:
         parameters:
           official: true
           poolName: 1es-pool-azfunc
-
 

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="azure-functions-extension-bundles" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/azure-functions-extension-bundles-feed/nuget/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
## Summary

Back-ports the CFS network-isolation fix from `main` commit `98d6382` to `main-v3`.

- adds a root `NuGet.config` with `<clear />`, the `upstream-public` CFS feed, and wildcard package-source mapping
- removes the legacy nested `src/Microsoft.Azure.Functions.ExtensionBundle/NuGet.Config`
- authenticates and explicitly restores through that config in both build jobs and the unit-test job
- disables subsequent implicit restores with `--no-restore`
- routes generated extension-project restores, vulnerability checks, and package metadata queries through CFS with NuGet credential support
- installs the in-support .NET 8 SDK required by the current NuGet authentication task
- removes the `main-v3` nightly official-build schedule

## Branch mapping

`main-v3` differs structurally from `main`: it has `build.yml` with separate Windows and Linux jobs plus `run-unit-test.yml`, but no emulator-test template. Both build jobs and the unit-test job are covered independently. Tests restore `ExtensionBundle.Tests/ExtensionBundle.Tests.csproj` because the newer test solution is absent on this branch. The legacy nested NuGet config is removed rather than copied into generated projects.

Test coverage is unchanged: the test task still uses its original `**/*Tests.csproj` glob. That glob resolves to exactly one project on `main-v3`, and only the newly added explicit restore names that same project directly.

## CI follow-up

The first PR build exposed a legacy-SDK compatibility issue: `NuGetAuthenticate@1` requires a .NET SDK 6 or later, while these jobs installed only .NET Core 2.1 and 3.1. The credential provider could not start, and authenticated CFS downloads subsequently returned 401 responses. Installing the in-support .NET 8 SDK before authentication satisfies that requirement while retaining the legacy SDKs needed by the bundle build.

## Validation

- exactly one repository NuGet config and one configured package feed
- no remaining `nuget.org` references
- authentication precedes every pipeline restore
- build tooling and test dependencies restore through CFS with .NET SDK 8.0.424
- build tooling compiles with .NET SDK 8.0.424
- root `NuGet.config` is byte-identical to `origin/main` (`1f635d7c7491b45b2d4ca4f138b65f0012a48c08`)

## Known limitations

- Full local tests could not complete because bundle publishing requires the .NET Core 2.1 runtime. The pipeline installs it, but the local machine does not have it.
- `PermissiveCFSClean` telemetry cannot be verified until the updated branch runs in ADO.

`raw.githubusercontent.com` traffic is out of scope. It comes from `main`-only emulator/Core Tools scripts that are absent on this branch, and it is not gated by `PermissiveCFSClean`.