### PR TITLE
Fixing EG tests

### DIFF
--- a/tests/emulator_tests/eventgrid_functions/function_app.py
+++ b/tests/emulator_tests/eventgrid_functions/function_app.py
@@ -7,14 +7,11 @@ using mock HTTP POST events (no Azure Event Grid connection required).
 
 Test scenarios covered (based on .NET SDK samples):
 1. EventGridEvent single trigger
-2. CloudEvent single trigger (CloudEvents mapped to func.EventGridEvent)
+2. CloudEvent single trigger
 3. EventGrid event construction verification (mock - not actual output binding)
 4. CloudEvent construction verification (mock - not actual output binding)
 5. Data shape variations - String, array, primitive, nested payloads
 6. Edge cases - Missing/null/empty data, special characters, large payloads
-
-Note: Python Event Grid triggers only support func.EventGridEvent type annotation.
-CloudEvents format is automatically mapped to EventGridEvent by the runtime.
 """
 import json
 import logging
@@ -60,28 +57,22 @@ def get_eventgrid_triggered(req: func.HttpRequest,
 
 # =============================================================================
 # CloudEvent Trigger - Single Event
-# Note: Python Event Grid triggers only support func.EventGridEvent type.
-# CloudEvents format is mapped to EventGridEvent by the extension runtime.
 # =============================================================================
 @app.function_name(name="cloudevent_trigger")
 @app.event_grid_trigger(arg_name="event")
 @app.blob_output(arg_name="$return",
                  path="bundle-tests/test-cloudevent-triggered.txt",
                  connection="AzureWebJobsStorage")
-def cloudevent_trigger(event: func.EventGridEvent) -> str:
-    """Process a single CloudEvent and write result to blob storage.
-    
-    Note: Python SDK only supports func.EventGridEvent type annotation.
-    CloudEvents are mapped to EventGridEvent by the extension runtime.
-    """
+def cloudevent_trigger(event: func.CloudEvent) -> str:
+    """Process a single CloudEvent and write result to blob storage."""
     logging.info(f"CloudEvent trigger received event: {event.id}")
     result = {
         'id': event.id,
-        'event_type': event.event_type,  # CloudEvent 'type' is mapped here
+        'event_type': event.type,
         'subject': event.subject,
-        'event_time': str(event.event_time) if event.event_time else None,
+        'event_time': str(event.time) if event.time else None,
         'data': event.get_json(),
-        'source': event.topic  # CloudEvent 'source' is mapped to topic
+        'source': event.source
     }
     return json.dumps(result)
 
@@ -218,10 +209,8 @@ def get_cloudevent_construction(req: func.HttpRequest,
 
 
 # =============================================================================
-# NOTE: Python Event Grid triggers only support func.EventGridEvent type annotation.
 # Unlike C#, Python does not support str, bytes, or dict type annotations for
-# eventGridTrigger bindings. The C# equivalents (String, BinaryData, JObject)
-# are not available in Python SDK.
+# eventGridTrigger bindings. Use func.EventGridEvent or func.CloudEvent.
 # =============================================================================
 
 
@@ -353,42 +342,6 @@ def eventgrid_trigger_nested_data(event: func.EventGridEvent) -> str:
 def get_eventgrid_nesteddata_triggered(req: func.HttpRequest,
                                        file: func.InputStream) -> str:
     """Retrieve the nested data trigger result from blob storage."""
-    return file.read().decode('utf-8')
-
-
-# =============================================================================
-# Edge Case: CloudEvent Backward Compatibility (legacy format)
-# Tests handling of older CloudEvent format with 'eventType' instead of 'type'
-# =============================================================================
-@app.function_name(name="cloudevent_backcompat_trigger")
-@app.event_grid_trigger(arg_name="event")
-@app.blob_output(arg_name="$return",
-                 path="bundle-tests/test-cloudevent-backcompat-triggered.txt",
-                 connection="AzureWebJobsStorage")
-def cloudevent_backcompat_trigger(event: func.EventGridEvent) -> str:
-    """Process CloudEvent in backward compatible mode.
-    
-    Handles both legacy 'eventType' and modern 'type' field formats.
-    """
-    logging.info("CloudEvent backcompat trigger received event")
-    result = {
-        'id': event.id,
-        'event_type': event.event_type,
-        'subject': event.subject,
-        'data': event.get_json(),
-        'format': 'backcompat'
-    }
-    return json.dumps(result)
-
-
-@app.function_name(name="get_cloudevent_backcompat_triggered")
-@app.route(route="get_cloudevent_backcompat_triggered")
-@app.blob_input(arg_name="file",
-                path="bundle-tests/test-cloudevent-backcompat-triggered.txt",
-                connection="AzureWebJobsStorage")
-def get_cloudevent_backcompat_triggered(req: func.HttpRequest,
-                                        file: func.InputStream) -> str:
-    """Retrieve the CloudEvent backcompat trigger result."""
     return file.read().decode('utf-8')
 
 

--- a/tests/emulator_tests/test_eventgrid_functions.py
+++ b/tests/emulator_tests/test_eventgrid_functions.py
@@ -10,7 +10,7 @@ https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/eventgrid/Microsoft.Azu
 
 Scenarios covered:
 1. EventGridEventTriggerFunction - Single EventGridEvent trigger
-2. CloudEventTriggerFunction - Single CloudEvent trigger (azure.core.messaging.CloudEvent)
+2. CloudEventTriggerFunction - Single CloudEvent trigger
 3. EventGrid event construction - Validates event structure (mock, not actual output binding)
 4. CloudEvent construction - Validates event structure (mock, not actual output binding)
 5. Data shape variations - String, array, primitive, nested payloads
@@ -119,33 +119,19 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
 
     # =========================================================================
     # CloudEvent Trigger Tests
-    # Note: Python SDK only supports func.EventGridEvent type annotation.
-    # CloudEvents are mapped to EventGridEvent by the runtime.
     # =========================================================================
     def test_cloudevent_trigger(self):
         """Test EventGridTrigger with a single CloudEvent.
         
         Equivalent to C# sample: CloudEventTriggerFunction
-        Note: Python only supports func.EventGridEvent - CloudEvents format
-        is mapped to EventGridEvent fields by the extension runtime.
-        
-        IMPORTANT: The local Event Grid webhook endpoint expects EventGrid-style
-        field names (eventType) even when using CloudEvents content-type header.
-        This is a known limitation of the local emulator - in production Azure,
-        proper CloudEvents 1.0 field mapping (type -> event_type) may work.
         """
-        # Generate unique CloudEvent data
         event_id = f"cloud-event-{uuid.uuid4()}"
         test_data = {'message': f'cloud-test-{int(time.time())}'}
         
-        # Create CloudEvent payload - use EventGrid field names for local emulator
-        # The local webhook doesn't map pure CloudEvents field names correctly:
-        #   - 'type' must be 'eventType'
-        #   - 'source' must be 'topic'
         event = {
             'specversion': '1.0',
-            'eventType': 'com.example.test',  # Use eventType (not 'type')
-            'topic': '/test/cloudevents',     # Use topic (not 'source')
+            'type': 'com.example.test',
+            'source': '/test/cloudevents',
             'id': event_id,
             'time': '2026-03-06T07:00:00Z',
             'subject': 'test/subject',
@@ -165,8 +151,6 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
 
         result = json.loads(r.text)
 
-        # Verify the CloudEvent was processed correctly
-        # Local emulator uses EventGrid field names: eventType->event_type, topic->source
         self.assertEqual(result['id'], event_id)
         self.assertEqual(result['event_type'], 'com.example.test')
         self.assertEqual(result['source'], '/test/cloudevents')
@@ -397,40 +381,6 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
     # =========================================================================
     # Edge Case Tests - These catch production issues!
     # =========================================================================
-    def test_cloudevent_backcompat_legacy_format(self):
-        """Test CloudEvent backward compatibility with EventGrid field names.
-        
-        Equivalent to C# CloudEventParamsBackCompat tests.
-        The local emulator requires EventGrid-style field names (eventType, topic)
-        even when using CloudEvents content-type header.
-        """
-        event_id = f"backcompat-{uuid.uuid4()}"
-        # CloudEvent with EventGrid field names for local emulator compatibility
-        legacy_event = {
-            'specversion': '1.0',
-            'eventType': 'com.legacy.format',  # EventGrid field name
-            'topic': '/test/backcompat',       # EventGrid field name (not 'source')
-            'id': event_id,
-            'time': '2026-03-06T07:00:00Z',
-            'subject': 'backcompat/test',
-            'data': {'legacy': True}
-        }
-
-        logger.info(f"Testing CloudEvent backcompat: {event_id}")
-        self._send_eventgrid_event('cloudevent_backcompat_trigger', legacy_event, 
-                                   is_cloudevent=True)
-
-        r = self.webhost.wait_and_request('GET', 'get_cloudevent_backcompat_triggered',
-                                          wait_time=2,
-                                          max_retries=10,
-                                          expected_status=200)
-
-        result = json.loads(r.text)
-        self.assertEqual(result['id'], event_id)
-        self.assertEqual(result['event_type'], 'com.legacy.format')  # Verify eventType works
-        self.assertEqual(result['subject'], 'backcompat/test')
-        self.assertEqual(result['format'], 'backcompat')
-
     def test_eventgrid_trigger_missing_data_field(self):
         """Test EventGridTrigger handles missing 'data' field gracefully.
         


### PR DESCRIPTION
# Pull Request

## Description

Fix the Event Grid emulator tests to use the native  func.CloudEvent  contract introduced in recent  azure-functions  releases.

• Update the CloudEvent trigger annotation from  func.EventGridEvent  to  func.CloudEvent .
• Read CloudEvent fields through  type ,  source , and  time .
• Send a valid CloudEvents 1.0 payload using  type  and  source .
• Remove the unsupported hybrid CloudEvent/Event Grid back-compat test.
• Keep  azure-functions  unpinned so CI uses the latest compatible version.

Root cause

The test payload included  specversion  but used Event Grid fields such as  eventType  and  topic . Newer  azure-functions  versions correctly deserialize payloads containing  specversion  as  CloudEvent , which does not expose  event_type ,  event_time , or  topic . This caused  cloudevent_trigger  to fail with an  AttributeError .

## Issue Link

<!-- Link to the issue this PR addresses -->
Resolves #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Testing

## Branch Propagation

<!-- For each branch, check if the change should be ported and link PRs, or explain why not -->
- [ ] main
- [ ] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [ ] I have updated relevant documentation
- [ ] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

<!-- If applicable, provide links to updated documentation -->

## Additional Information

<!-- Any other information that would be helpful for reviewers -->