### PR TITLE
main-preview: release prep Update bundle version to 4.47.0

### DIFF
--- a/.github/skills/extension-bundle-dependency-review/SKILL.md
+++ b/.github/skills/extension-bundle-dependency-review/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: extension-bundle-dependency-review
+description: Run extension-bundle unit tests, investigate dependency baseline failures against adjacent Azure DevOps scheduled builds, assess shared and host runtime risks, and update approved dependency baselines. Use when bundle dependency validation tests fail, an assembly major version changes, or someone asks to review or accept a deps bump.
+---
+
+# Extension bundle dependency review
+
+Use this skill only in the `Azure/azure-functions-extension-bundles` repository.
+
+## Inputs
+
+- Use the branch supplied by the user.
+- If no branch is supplied, use the current Git branch when it has an upstream Azure DevOps build history. Otherwise, ask which branch to inspect.
+- The public Azure DevOps pipeline is definition `939`:
+  `https://dev.azure.com/azfunc/public/_build?definitionId=939`
+- The internal Azure DevOps pipeline used for Linux release artifacts is definition `922`:
+  `https://dev.azure.com/azfunc/internal/_build?definitionId=922`
+- If the user supplies build IDs, use them after verifying that they are scheduled builds for the selected branch.
+
+## Safety rules
+
+- Do not update dependency baselines merely to make tests pass.
+- Establish the extension responsible for the bump, all extension consumers of the assembly, and Azure Functions host resolution behavior first.
+- A single-extension dependency that is not shared with the host can normally be accepted when the responsible extension has already validated the upgrade.
+- If multiple extensions consume the dependency and the major upgrade can break compatibility, stop before editing. Report the affected extensions and the coordination/testing required.
+- If the host carries or overrides the assembly at another major version, stop before editing unless compatibility with the host resolution policy is established.
+- Preserve unrelated worktree changes. Do not commit unless explicitly requested.
+- Do not claim a transitive dependency path without evidence from a deps file, assets file, NuGet metadata, or package contents.
+
+## Workflow
+
+### 0. Prepare a working branch
+
+Create a dedicated working branch from the branch being investigated before editing baselines. Fetch the remote
+first. If the requested working branch already exists remotely, switch to its tracking branch and pull it with
+fast-forward only instead of recreating it. Preserve unrelated worktree changes and do not include them in the
+dependency-review commit.
+
+### 1. Run the same unit tests as CI
+
+Resolve every `**/*Tests.csproj` under the repository. Run each with:
+
+```powershell
+dotnet test <project> --configuration Release --no-restore
+```
+
+If the failure is caused by missing restored assets, run the repository's existing restore command from
+`eng/ci/templates/jobs/run-unit-test.yml`, then rerun the test. Do not restore automatically for other failures.
+
+Capture every dependency-validation change, including:
+
+- baseline and generated deps file paths
+- assembly name
+- old and new assembly versions
+- old and new file versions
+- affected runtime configurations
+
+If tests pass, report that no dependency review or baseline update is needed and stop.
+If failures are unrelated to dependency validation, report them and stop this workflow.
+
+### 2. Select the build transition
+
+Query Azure DevOps for scheduled builds of definition `939` on the exact branch ref
+(`refs/heads/<branch>`). The public REST API is:
+
+```text
+https://dev.azure.com/azfunc/public/_apis/build/builds
+  ?definitions=939
+  &branchName=refs/heads/<branch>
+  &reasonFilter=schedule
+  &queryOrder=queueTimeDescending
+  &api-version=7.1
+```
+
+Follow continuation tokens if the first page does not contain the transition. Sort the returned runs
+chronologically and select the most recent adjacent transition where:
+
+1. the earlier scheduled build completed successfully, and
+2. the immediately following scheduled build failed.
+
+Do not compare a non-adjacent success and failure, because that can combine several extension updates.
+Record both build IDs, timestamps, source commits, results, and links. If no adjacent transition exists,
+stop and report that the build pair could not be established.
+
+### 3. Download and compare `any_any` artifacts
+
+For both builds, enumerate artifacts with:
+
+```text
+https://dev.azure.com/azfunc/public/_apis/build/builds/<buildId>/artifacts?api-version=7.1
+```
+
+Download `bundle_artifact`. If that exact name is absent, inspect the artifact list and select the artifact
+that actually contains the `any_any` bundle; report the observed artifact name rather than silently assuming
+one. Extract both builds into a temporary directory outside the repository and remove it when finished.
+
+Within each artifact:
+
+1. locate the `any_any` bundle content;
+2. locate and compare its generated `.csproj` files;
+3. compare `PackageReference` IDs and resolved versions structurally, not only as raw text;
+4. identify which extension NuGet changed between the builds; and
+5. verify that the new extension package was published between the two build timestamps using package metadata.
+
+Read `NuGet.config` and use its configured package source for registration and package metadata. Do not call
+`api.nuget.org` directly; it may be blocked in the development environment. Resolve the feed's
+`RegistrationsBaseUrl/3.6.0` resource from its NuGet v3 service index, then query the lower-cased package ID's
+registration document for the version and `published` timestamp.
+
+If multiple extension packages changed, use the failing assembly's dependency graph to identify the responsible
+package rather than guessing from timestamps.
+
+### 4. Trace the failing library to extension consumers
+
+Open the failing build artifact's `functions.deps.json`. If the artifact uses a differently named generated
+deps file, use the equivalent file containing the full bundle dependency graph and report its actual path.
+
+Use the `targets` and `libraries` sections to:
+
+1. find packages whose runtime assets contain the failing assembly;
+2. walk dependency edges backward through transitive packages; and
+3. identify every top-level extension package that reaches that assembly.
+
+Report each complete evidence-backed chain using this shape:
+
+```text
+top-level extension
+  -> transitive package
+  -> package containing or depending on the assembly
+  -> failing assembly
+```
+
+Treat two extensions as consumers even if they reach the assembly through different transitive paths.
+
+### 5. Assess cross-extension breaking-change risk
+
+If more than one extension consumes the assembly:
+
+1. read official release notes, changelogs, and migration guidance for the library versions spanning the major bump;
+2. identify binary, API, serialization, or behavioral breaking changes relevant to the discovered paths;
+3. determine whether all consuming extensions support the same loaded major version; and
+4. require coordinated validation when compatibility is not clearly established.
+
+Prefer first-party project and NuGet sources. Include links and distinguish documented facts from inference.
+
+### 6. Check Azure Functions host resolution
+
+Inspect the current `dev` version of:
+
+```text
+https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/runtimeassemblies.json
+```
+
+Search case-insensitively for the failing assembly. When present:
+
+1. record the host assembly version and `resolutionPolicy`;
+2. find the implementation/specification for that policy in `Azure/azure-functions-host`;
+3. explain whether the host unifies, overrides, rejects, or otherwise constrains the extension assembly; and
+4. compare the policy's accepted version range with the extension's new major version.
+
+Also inspect directly related host runtime-assembly manifests when the referenced policy requires them.
+Absence from `runtimeassemblies.json` must be reported explicitly; do not infer host sharing solely from absence.
+
+### 7. Decide and update baselines
+
+The bump is acceptable only when the evidence supports all applicable conditions:
+
+- the responsible extension/package is identified;
+- the extension release timing matches the successful-to-failing build transition;
+- every extension consumer is identified;
+- shared consumers are compatible or have coordinated testing;
+- host resolution does not create a conflicting major-version load; and
+- the responsible extension has validated the dependency change.
+
+For an acceptable bump, copy each locally generated `extensions.deps.json` over only its corresponding baseline:
+
+| Runtime configuration | Baseline |
+| --- | --- |
+| `any_any` | `tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json` |
+| `win_x64` | `tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json` |
+| `win_x86` | `tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json` |
+| `linux_x64` | `tests/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json` |
+
+Update only configurations reported by the test unless the generated files prove the same reviewed change applies
+to another tracked configuration.
+
+On Windows, obtain the Linux baseline from internal pipeline definition `922`:
+
+1. filter runs to the exact concerned branch;
+2. select the latest failed run whose `Build` stage succeeded;
+3. enumerate that run's artifacts and use the `zip` artifact;
+4. download only `/Microsoft.Azure.Functions.ExtensionBundle.<version>_linux-x64.zip` from the artifact rather
+   than downloading the complete multi-gigabyte artifact;
+5. extract `bin_v3/linux-x64/function.deps.json`;
+6. confirm it contains the same reviewed dependency bump; and
+7. copy it to `tests/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json`.
+
+The pipeline artifact single-file REST request uses its `resource.downloadUrl` with `format=file` and a
+URL-encoded, leading-slash `subPath`. Authenticate internal Azure DevOps requests without printing access tokens.
+
+Rerun the CI-equivalent test command after editing.
+
+### 8. Commit and open the pull request
+
+When the user requests a commit and pull request:
+
+1. stage only the reviewed dependency baselines and this skill when it changed;
+2. commit on the dedicated working branch;
+3. include the repository-required commit trailers;
+4. push the branch without force;
+5. read and preserve `.github/pull_request_template.md`;
+6. open the PR against the investigated base branch; and
+7. fill the template with brief evidence-based justification from this review: the build transition, responsible
+   extension release, dependency chain and consumer count, host resolution result, updated configurations, and
+   final test result.
+
+Do not leave template placeholders or claim unrelated test coverage.
+
+## Required result
+
+Lead with one decision: `safe to update`, `coordination required`, `host conflict risk`, or `inconclusive`.
+Then provide:
+
+- local test summary and exact assembly bump
+- selected successful/failing build pair
+- changed extension NuGet and publication evidence
+- complete dependency chain(s) and all consumers
+- breaking-change assessment when shared
+- host manifest/policy result
+- baseline files changed, if any
+- final test result
+
+Include source URLs and file paths. State missing evidence plainly and never convert an inconclusive review into an
+automatic baseline update.

--- a/.github/skills/extension-bundle-dependency-review/SKILL.md
+++ b/.github/skills/extension-bundle-dependency-review/SKILL.md
@@ -102,10 +102,22 @@ Within each artifact:
 4. identify which extension NuGet changed between the builds; and
 5. verify that the new extension package was published between the two build timestamps using package metadata.
 
-Read `NuGet.config` and use its configured package source for registration and package metadata. Do not call
-`api.nuget.org` directly; it may be blocked in the development environment. Resolve the feed's
-`RegistrationsBaseUrl/3.6.0` resource from its NuGet v3 service index, then query the lower-cased package ID's
-registration document for the version and `published` timestamp.
+Read `NuGet.config` and honor both `<packageSources>` and `<packageSourceMapping>` when selecting the source for
+the package. Do not call `api.nuget.org` directly; it may be blocked in the development environment.
+
+From the selected source's NuGet v3 service index:
+
+1. resolve its `RegistrationsBaseUrl/3.6.0` resource;
+2. query `<registration-base>/<lower-case-package-id>/index.json`;
+3. select the exact version's catalog entry and record its `published`, dependency groups, and `packageContent`;
+4. use the catalog entry's `packageContent` URL to download the `.nupkg` when package inspection is needed; or
+5. resolve `PackageBaseAddress/3.0.0` and download
+   `<package-base>/<lower-case-id>/<lower-case-version>/<lower-case-id>.<lower-case-version>.nupkg`.
+
+Use `dotnet restore --configfile NuGet.config` when restoring a project so package source mapping and configured
+credentials are applied consistently. Public feeds require no added credentials. For authenticated feeds, use
+the environment's existing Azure Artifacts credential provider or access token without printing or persisting
+the credential. Never add a source, token, or credential to the repository.
 
 If multiple extension packages changed, use the failing assembly's dependency graph to identify the responsible
 package rather than guessing from timestamps.

--- a/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
+++ b/src/Microsoft.Azure.Functions.ExtensionBundle/bundleConfig.json
@@ -1,5 +1,5 @@
 {
   "bundleId": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
-  "bundleVersion": "4.46.0",
+  "bundleVersion": "4.47.0",
   "isPreviewBundle": true
 }

--- a/tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/any_any_extensions.deps.json
@@ -11,17 +11,17 @@
           "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.6.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.10.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.110",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.19.0-alpha",
@@ -40,7 +40,7 @@
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.8.1",
           "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
@@ -49,18 +49,15 @@
           "extensions.dll": {}
         }
       },
-      "Apache.Avro/1.11.0": {
+      "Apache.Avro/1.12.0": {
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
-          "System.CodeDom": "4.4.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0"
+          "System.CodeDom": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/Avro.dll": {
-            "assemblyVersion": "1.11.0.0",
-            "fileVersion": "1.11.0.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         }
       },
@@ -78,7 +75,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -170,7 +167,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -311,58 +308,54 @@
           }
         }
       },
-      "Confluent.Kafka/2.4.0": {
+      "Confluent.Kafka/2.11.1": {
         "dependencies": {
-          "System.Memory": "4.5.5",
-          "librdkafka.redist": "2.4.0"
+          "librdkafka.redist": "2.11.1"
         },
         "runtime": {
-          "lib/net6.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/2.4.0": {
+      "Confluent.SchemaRegistry/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.Http": "4.3.4"
+          "Confluent.Kafka": "2.11.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
         "dependencies": {
-          "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "Apache.Avro": "1.12.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
           "Google.Protobuf": "3.34.1",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "protobuf-net.Reflection": "3.2.12"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
@@ -488,7 +481,7 @@
           }
         }
       },
-      "librdkafka.redist/2.4.0": {
+      "librdkafka.redist/2.11.1": {
         "runtimeTargets": {
           "runtimes/linux-arm64/native/librdkafka.so": {
             "rid": "linux-arm64",
@@ -500,12 +493,7 @@
             "assetType": "native",
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/linux-x64/native/centos6-librdkafka.so": {
-            "rid": "linux-x64",
-            "assetType": "native",
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/linux-x64/native/centos7-librdkafka.so": {
+          "runtimes/linux-x64/native/centos8-librdkafka.so": {
             "rid": "linux-x64",
             "assetType": "native",
             "fileVersion": "0.0.0.0"
@@ -528,12 +516,12 @@
           "runtimes/win-x64/native/libcrypto-3-x64.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x64/native/libcurl.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "7.86.0.0"
+            "fileVersion": "8.10.1.0"
           },
           "runtimes/win-x64/native/librdkafka.dll": {
             "rid": "win-x64",
@@ -548,27 +536,27 @@
           "runtimes/win-x64/native/libssl-3-x64.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x64/native/zlib1.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.2.13.0"
+            "fileVersion": "1.3.1.0"
           },
           "runtimes/win-x64/native/zstd.dll": {
             "rid": "win-x64",
             "assetType": "native",
-            "fileVersion": "1.5.2.0"
+            "fileVersion": "1.5.6.0"
           },
           "runtimes/win-x86/native/libcrypto-3.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x86/native/libcurl.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "7.86.0.0"
+            "fileVersion": "8.10.1.0"
           },
           "runtimes/win-x86/native/librdkafka.dll": {
             "rid": "win-x86",
@@ -583,27 +571,27 @@
           "runtimes/win-x86/native/libssl-3.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x86/native/msvcp140.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "14.29.30040.0"
+            "fileVersion": "14.40.33816.0"
           },
           "runtimes/win-x86/native/vcruntime140.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "14.29.30040.0"
+            "fileVersion": "14.40.33816.0"
           },
           "runtimes/win-x86/native/zlib1.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.2.13.0"
+            "fileVersion": "1.3.1.0"
           },
           "runtimes/win-x86/native/zstd.dll": {
             "rid": "win-x86",
             "assetType": "native",
-            "fileVersion": "1.5.2.0"
+            "fileVersion": "1.5.6.0"
           }
         }
       },
@@ -996,7 +984,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -1058,7 +1046,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -1073,7 +1061,7 @@
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -1107,7 +1095,7 @@
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1123,7 +1111,7 @@
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1168,13 +1156,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1184,8 +1172,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.26227"
+            "assemblyVersion": "1.6.0.0",
+            "fileVersion": "1.6.0.26380"
           }
         }
       },
@@ -1434,7 +1422,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
@@ -1449,12 +1437,12 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.13.1.0"
+            "fileVersion": "3.15.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1462,9 +1450,9 @@
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -1472,8 +1460,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -1505,7 +1493,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1521,12 +1509,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           }
         }
       },
@@ -1546,20 +1534,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.11.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.3.2.0"
+            "assemblyVersion": "4.3.3.0",
+            "fileVersion": "4.3.3.0"
           }
         }
       },
@@ -1583,7 +1571,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1918,11 +1906,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.8",
-            "fileVersion": "10.0.826.23019"
+            "assemblyVersion": "10.0.0.9",
+            "fileVersion": "10.0.926.27113"
           }
         }
       },
@@ -2044,7 +2032,7 @@
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -2057,37 +2045,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.10.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -2136,15 +2124,15 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -2152,8 +2140,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -2169,7 +2157,7 @@
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.6.0": {
+      "Microsoft.DurableTask.SqlServer/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -2177,25 +2165,25 @@
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Text.Json": "8.0.6"
+          "System.Drawing.Common": "4.7.3",
+          "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.DurableTask.SqlServer": "1.6.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.DurableTask.SqlServer": "1.8.1"
         },
         "runtime": {
-          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
@@ -3122,6 +3110,28 @@
           }
         }
       },
+      "protobuf-net.Core/3.2.12": {
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        },
+        "runtime": {
+          "lib/net6.0/protobuf-net.Core.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
+      "protobuf-net.Reflection/3.2.12": {
+        "dependencies": {
+          "protobuf-net.Core": "3.2.12"
+        },
+        "runtime": {
+          "lib/netstandard2.0/protobuf-net.Reflection.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
       "RabbitMQ.Client/6.8.1": {
         "dependencies": {
           "System.Memory": "4.5.5",
@@ -3256,11 +3266,11 @@
           }
         }
       },
-      "System.CodeDom/4.4.0": {
+      "System.CodeDom/8.0.0": {
         "runtime": {
-          "lib/netstandard2.0/System.CodeDom.dll": {
-            "assemblyVersion": "4.0.0.0",
-            "fileVersion": "4.6.25519.3"
+          "lib/net8.0/System.CodeDom.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -3588,7 +3598,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -3655,24 +3665,6 @@
           "runtime.native.System": "4.3.0",
           "runtime.native.System.Net.Http": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
-        }
-      },
-      "System.Net.NameResolution/4.3.0": {
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "3.1.9",
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Tracing": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Net.Primitives": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.1",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Runtime.Handles": "4.3.0",
-          "System.Runtime.InteropServices": "4.3.0",
-          "System.Security.Principal.Windows": "5.0.0",
-          "System.Threading": "4.3.0",
-          "System.Threading.Tasks": "4.3.0",
-          "runtime.native.System": "4.3.0"
         }
       },
       "System.Net.Primitives/4.3.0": {
@@ -4201,12 +4193,12 @@
       "serviceable": false,
       "sha512": ""
     },
-    "Apache.Avro/1.11.0": {
+    "Apache.Avro/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JpBxUTE/JeVt9yugkIiu0N+FHl+SIihDjs4VZsGFmlZM42nntj2QB8nAdj5yu8LOla54pSAQqdqHcxPa458KWQ==",
-      "path": "apache.avro/1.11.0",
-      "hashPath": "apache.avro.1.11.0.nupkg.sha512"
+      "sha512": "sha512-gFFnQ8j91zdbs5QvGo79139WnLpQB4rPbDx2Bnr664uBMSGhh422QsHd89Vv7WyT0+eT7qPL+6rZlnyor3aATw==",
+      "path": "apache.avro/1.12.0",
+      "hashPath": "apache.avro.1.12.0.nupkg.sha512"
     },
     "Azure.AI.OpenAI/2.1.0": {
       "type": "package",
@@ -4348,33 +4340,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/2.4.0": {
+    "Confluent.Kafka/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
-      "path": "confluent.kafka/2.4.0",
-      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
+      "sha512": "sha512-IV06YJSTsBvl4T282qlUADqQa5OPQOnZ+/+mQ8k0wVJy/GSjfFINamUk4zs/PtZ5+NpRdS5VHuQP7bJaTr9RBQ==",
+      "path": "confluent.kafka/2.11.1",
+      "hashPath": "confluent.kafka.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/2.4.0": {
+    "Confluent.SchemaRegistry/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
-      "path": "confluent.schemaregistry/2.4.0",
-      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
+      "sha512": "sha512-U8+hAp61TLgH0RM/JvvMdQq3x8ScLkmofX9l3I05tuQreT0fk6+iBvs/h2N/IQDgQtq/iNLgpiEFpNjoHjotAA==",
+      "path": "confluent.schemaregistry/2.11.1",
+      "hashPath": "confluent.schemaregistry.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
-      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
+      "sha512": "sha512-JEh6zmdwDanp2DQbAh16rkGp1pI4IyPB9S2BJAAgg/qf3pOeMG/vJR15IR8n7RUa+sP0IuV/vqRFLC4y4hotCQ==",
+      "path": "confluent.schemaregistry.serdes.avro/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
-      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
+      "sha512": "sha512-DXW8zTkhB4KTU1DxVf960RuDzfq+LeX1LW2tjppOENJkvUsEZWWdg3haUYdefQe2pa6O+6YcmRXBhgyNiMV1fQ==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.11.1.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4467,12 +4459,12 @@
       "path": "k4os.hash.xxhash/1.0.8",
       "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
     },
-    "librdkafka.redist/2.4.0": {
+    "librdkafka.redist/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
-      "path": "librdkafka.redist/2.4.0",
-      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+      "sha512": "sha512-fgzBgvnvDPyQ+VbGDs4piz7TYv2Gaz9niYv/ztwMoAQ+uyk0wTYR1NmyIKSN8JsE4hr5JHhDccSSNnbAFZQhBA==",
+      "path": "librdkafka.redist/2.11.1",
+      "hashPath": "librdkafka.redist.2.11.1.nupkg.sha512"
     },
     "MessagePack/2.5.301": {
       "type": "package",
@@ -4817,12 +4809,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
+      "sha512": "sha512-sAgPbq06jZzspaTb+6hF4sBkt+0VtH6gmDAfcupZFwyTdsmQHuICCyxPClQ1GKNNWQcqy5RrBxz5r8ZOfMuu8g==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.6.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.6.0.nupkg.sha512"
     },
     "Microsoft.Azure.Kusto.Cloud.Platform/12.2.8": {
       "type": "package",
@@ -4936,12 +4928,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
+      "sha512": "sha512-Eb1IGJmU5pMXCf/rd626vrUJoP6mqGC+ahuCWTC7jjVdsvaXPBZrtf2+83H4aFBBHpTy0qmkqenVCVXb1m4PCA==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4950,12 +4942,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-ZgraJnaP9nsp+p8H2qiJ6G2MLAjomzd2vzZEj7JkVO8WrTS2XQcmAvtJZ7RS13RhQG08ZNUX9/cAnf0uJjoyFQ==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.10.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4971,12 +4963,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
+      "sha512": "sha512-BiGQ+/fmM7BUX4RPsEa8VT8i7hIFLmpyy54KLl+ws66LBBOjOQIncVbW0UGFvh6o2b+yp03gFOyouM0x4c0eJA==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.110",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.110.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4985,12 +4977,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.1",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aGSnO2BFd2ixPoInj6hp6DLAqolvpxAU4beCqLMOmSxCdGWCl8I9XTB4KSRC3ysatz96kkII9bMH9n/CofwBSw==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.2.nupkg.sha512"
+      "sha512": "sha512-/mFvAcFRwQ2e3latJkhvDcnm0+sIYpq741Q1Bn5IiIVKdIEG7VeBF96pgsoAdXFrysJskJKH5Dq/iiVKIU/7MQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.13-Preview": {
       "type": "package",
@@ -5167,12 +5159,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
+      "sha512": "sha512-Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.9",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.9.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5216,19 +5208,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
+      "sha512": "sha512-0xP9HmD2X4/6muiTNOKCUfc10zPlimqH+hf/rtmb9uEdsbM8CPrKms+GUbH2wdoqRXALLOYr/fOpoMlbvDY48g==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.10.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-REKLGEdLhFPIgljYQxfp/xxpbhoKRu82v9H0zohK97+9kokjZg9l2LqY3W8QNoqBjTCQ1IBHr3pEMHJNjcRGlw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5251,12 +5243,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-tgpXYliHOzrs2/qB5xxy1Cip8BkFl2Qz1mv7WEOoxXIyZVHYkgufFo0V+5YzQFLViIbJzpwSMLVHiM2+4uaCWw==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.10.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -5265,19 +5257,19 @@
       "path": "microsoft.durabletask.grpc/1.24.2",
       "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.6.0": {
+    "Microsoft.DurableTask.SqlServer/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-V6befDIGgScaR1lIFTi3B36NYsQ2crbwNe0E9d4gpojMBd/NfbLdpwqj6b/xI57YBZEbJ9+OtiDIgSSkEjntTg==",
-      "path": "microsoft.durabletask.sqlserver/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.6.0.nupkg.sha512"
+      "sha512": "sha512-Vu7EMVcNOu90eCqnOmjchzWROs6ZsqoL3FObKL9uTWM+bsAq4J/An60BBlrgdZfx+fnqo3NkybLHQL5uRS4wJQ==",
+      "path": "microsoft.durabletask.sqlserver/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-luzyU+wE8AVNI/qeDqS9A4SU+An8aKvdnpvhuV3ohoPrfZcA5jRhj2WoC+BBoajeuCHECuM0Mw1GXHrgpXclTw==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
+      "sha512": "sha512-8pH9G65T/QTg33u+Fn2QCa/g7/zeJ0rSsz2T+kEtiBOy5KWvF8v0KZkxcZf85/JpNP5+jv2tXViPTgzFVSNzcA==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.8.1.nupkg.sha512"
     },
     "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
@@ -5776,6 +5768,20 @@
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
     },
+    "protobuf-net.Core/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-8kpui+OKAr/IzFfdvkqGcIO859riNT1bp5hLKudY55lHd9oS3daHkvA9XyXiC+yGLRpg+XCc+ZUkNA8u8sXJTw==",
+      "path": "protobuf-net.core/3.2.12",
+      "hashPath": "protobuf-net.core.3.2.12.nupkg.sha512"
+    },
+    "protobuf-net.Reflection/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bpNTENWPqP2mx1sJJ5C6qZ2xP+f/E3dQF9MYY+xZ+RHxe3sLg+sPyBSCcJDTCY0e4dVIwQ/02gS8m4tVClDoKQ==",
+      "path": "protobuf-net.reflection/3.2.12",
+      "hashPath": "protobuf-net.reflection.3.2.12.nupkg.sha512"
+    },
     "RabbitMQ.Client/6.8.1": {
       "type": "package",
       "serviceable": true,
@@ -5958,12 +5964,12 @@
       "path": "system.clientmodel/1.8.0",
       "hashPath": "system.clientmodel.1.8.0.nupkg.sha512"
     },
-    "System.CodeDom/4.4.0": {
+    "System.CodeDom/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2sCCb7doXEwtYAbqzbF/8UAeDRMNmPaQbU2q50Psg1J9KzumyVVCgKQY8s53WIPTufNT0DpSe9QRvVjOzfDWBA==",
-      "path": "system.codedom/4.4.0",
-      "hashPath": "system.codedom.4.4.0.nupkg.sha512"
+      "sha512": "sha512-WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q==",
+      "path": "system.codedom/8.0.0",
+      "hashPath": "system.codedom.8.0.0.nupkg.sha512"
     },
     "System.Collections/4.3.0": {
       "type": "package",
@@ -6230,13 +6236,6 @@
       "sha512": "sha512-aOa2d51SEbmM+H+Csw7yJOuNZoHkrP2XnAurye5HWYgGVVU54YZDvsLUYRv6h18X3sPnjNCANmN7ZhIPiqMcjA==",
       "path": "system.net.http/4.3.4",
       "hashPath": "system.net.http.4.3.4.nupkg.sha512"
-    },
-    "System.Net.NameResolution/4.3.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-AFYl08R7MrsrEjqpQWTZWBadqXyTzNDaWpMqyxhb0d6sGhV6xMDKueuBXlLL30gz+DIRY6MpdgnHWlCh5wmq9w==",
-      "path": "system.net.nameresolution/4.3.0",
-      "hashPath": "system.net.nameresolution.4.3.0.nupkg.sha512"
     },
     "System.Net.Primitives/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/linux_x64_extensions.deps.json
@@ -12,17 +12,17 @@
           "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.6.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.10.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.110",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.19.0-alpha",
@@ -41,7 +41,7 @@
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.8.1",
           "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
@@ -50,18 +50,15 @@
           "extensions.dll": {}
         }
       },
-      "Apache.Avro/1.11.0": {
+      "Apache.Avro/1.12.0": {
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
-          "System.CodeDom": "4.4.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0"
+          "System.CodeDom": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/Avro.dll": {
-            "assemblyVersion": "1.11.0.0",
-            "fileVersion": "1.11.0.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         }
       },
@@ -79,7 +76,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -171,7 +168,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -312,58 +309,54 @@
           }
         }
       },
-      "Confluent.Kafka/2.4.0": {
+      "Confluent.Kafka/2.11.1": {
         "dependencies": {
-          "System.Memory": "4.5.5",
-          "librdkafka.redist": "2.4.0"
+          "librdkafka.redist": "2.11.1"
         },
         "runtime": {
-          "lib/net6.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/2.4.0": {
+      "Confluent.SchemaRegistry/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.Http": "4.3.4"
+          "Confluent.Kafka": "2.11.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
         "dependencies": {
-          "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "Apache.Avro": "1.12.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
           "Google.Protobuf": "3.34.1",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "protobuf-net.Reflection": "3.2.12"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
@@ -489,15 +482,12 @@
           }
         }
       },
-      "librdkafka.redist/2.4.0": {
+      "librdkafka.redist/2.11.1": {
         "native": {
           "runtimes/linux-x64/native/alpine-librdkafka.so": {
             "fileVersion": "0.0.0.0"
           },
-          "runtimes/linux-x64/native/centos6-librdkafka.so": {
-            "fileVersion": "0.0.0.0"
-          },
-          "runtimes/linux-x64/native/centos7-librdkafka.so": {
+          "runtimes/linux-x64/native/centos8-librdkafka.so": {
             "fileVersion": "0.0.0.0"
           },
           "runtimes/linux-x64/native/librdkafka.so": {
@@ -894,7 +884,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -929,7 +919,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -944,7 +934,7 @@
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -978,7 +968,7 @@
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -994,7 +984,7 @@
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1039,13 +1029,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1055,8 +1045,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.26227"
+            "assemblyVersion": "1.6.0.0",
+            "fileVersion": "1.6.0.26380"
           }
         }
       },
@@ -1305,7 +1295,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
@@ -1320,12 +1310,12 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.13.1.0"
+            "fileVersion": "3.15.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1333,9 +1323,9 @@
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -1343,8 +1333,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -1376,7 +1366,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1392,12 +1382,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           }
         }
       },
@@ -1417,20 +1407,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.11.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.3.2.0"
+            "assemblyVersion": "4.3.3.0",
+            "fileVersion": "4.3.3.0"
           }
         }
       },
@@ -1454,7 +1444,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1789,11 +1779,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.8",
-            "fileVersion": "10.0.826.23019"
+            "assemblyVersion": "10.0.0.9",
+            "fileVersion": "10.0.926.27113"
           }
         }
       },
@@ -1878,7 +1868,7 @@
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -1891,37 +1881,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.10.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -1970,15 +1960,15 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -1986,8 +1976,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -2003,7 +1993,7 @@
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.6.0": {
+      "Microsoft.DurableTask.SqlServer/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -2011,25 +2001,25 @@
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Text.Json": "8.0.6"
+          "System.Drawing.Common": "4.7.3",
+          "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.DurableTask.SqlServer": "1.6.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.DurableTask.SqlServer": "1.8.1"
         },
         "runtime": {
-          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
@@ -2895,6 +2885,28 @@
           }
         }
       },
+      "protobuf-net.Core/3.2.12": {
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        },
+        "runtime": {
+          "lib/net6.0/protobuf-net.Core.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
+      "protobuf-net.Reflection/3.2.12": {
+        "dependencies": {
+          "protobuf-net.Core": "3.2.12"
+        },
+        "runtime": {
+          "lib/netstandard2.0/protobuf-net.Reflection.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
       "RabbitMQ.Client/6.8.1": {
         "dependencies": {
           "System.Memory": "4.5.5",
@@ -3150,11 +3162,11 @@
           }
         }
       },
-      "System.CodeDom/4.4.0": {
+      "System.CodeDom/8.0.0": {
         "runtime": {
-          "lib/netstandard2.0/System.CodeDom.dll": {
-            "assemblyVersion": "4.0.0.0",
-            "fileVersion": "4.6.25519.3"
+          "lib/net8.0/System.CodeDom.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -3461,7 +3473,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -4085,12 +4097,12 @@
       "serviceable": false,
       "sha512": ""
     },
-    "Apache.Avro/1.11.0": {
+    "Apache.Avro/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JpBxUTE/JeVt9yugkIiu0N+FHl+SIihDjs4VZsGFmlZM42nntj2QB8nAdj5yu8LOla54pSAQqdqHcxPa458KWQ==",
-      "path": "apache.avro/1.11.0",
-      "hashPath": "apache.avro.1.11.0.nupkg.sha512"
+      "sha512": "sha512-gFFnQ8j91zdbs5QvGo79139WnLpQB4rPbDx2Bnr664uBMSGhh422QsHd89Vv7WyT0+eT7qPL+6rZlnyor3aATw==",
+      "path": "apache.avro/1.12.0",
+      "hashPath": "apache.avro.1.12.0.nupkg.sha512"
     },
     "Azure.AI.OpenAI/2.1.0": {
       "type": "package",
@@ -4232,33 +4244,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/2.4.0": {
+    "Confluent.Kafka/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
-      "path": "confluent.kafka/2.4.0",
-      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
+      "sha512": "sha512-IV06YJSTsBvl4T282qlUADqQa5OPQOnZ+/+mQ8k0wVJy/GSjfFINamUk4zs/PtZ5+NpRdS5VHuQP7bJaTr9RBQ==",
+      "path": "confluent.kafka/2.11.1",
+      "hashPath": "confluent.kafka.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/2.4.0": {
+    "Confluent.SchemaRegistry/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
-      "path": "confluent.schemaregistry/2.4.0",
-      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
+      "sha512": "sha512-U8+hAp61TLgH0RM/JvvMdQq3x8ScLkmofX9l3I05tuQreT0fk6+iBvs/h2N/IQDgQtq/iNLgpiEFpNjoHjotAA==",
+      "path": "confluent.schemaregistry/2.11.1",
+      "hashPath": "confluent.schemaregistry.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
-      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
+      "sha512": "sha512-JEh6zmdwDanp2DQbAh16rkGp1pI4IyPB9S2BJAAgg/qf3pOeMG/vJR15IR8n7RUa+sP0IuV/vqRFLC4y4hotCQ==",
+      "path": "confluent.schemaregistry.serdes.avro/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
-      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
+      "sha512": "sha512-DXW8zTkhB4KTU1DxVf960RuDzfq+LeX1LW2tjppOENJkvUsEZWWdg3haUYdefQe2pa6O+6YcmRXBhgyNiMV1fQ==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.11.1.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4351,12 +4363,12 @@
       "path": "k4os.hash.xxhash/1.0.8",
       "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
     },
-    "librdkafka.redist/2.4.0": {
+    "librdkafka.redist/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
-      "path": "librdkafka.redist/2.4.0",
-      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+      "sha512": "sha512-fgzBgvnvDPyQ+VbGDs4piz7TYv2Gaz9niYv/ztwMoAQ+uyk0wTYR1NmyIKSN8JsE4hr5JHhDccSSNnbAFZQhBA==",
+      "path": "librdkafka.redist/2.11.1",
+      "hashPath": "librdkafka.redist.2.11.1.nupkg.sha512"
     },
     "MessagePack/2.5.301": {
       "type": "package",
@@ -4701,12 +4713,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
+      "sha512": "sha512-sAgPbq06jZzspaTb+6hF4sBkt+0VtH6gmDAfcupZFwyTdsmQHuICCyxPClQ1GKNNWQcqy5RrBxz5r8ZOfMuu8g==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.6.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.6.0.nupkg.sha512"
     },
     "Microsoft.Azure.Kusto.Cloud.Platform/12.2.8": {
       "type": "package",
@@ -4820,12 +4832,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
+      "sha512": "sha512-Eb1IGJmU5pMXCf/rd626vrUJoP6mqGC+ahuCWTC7jjVdsvaXPBZrtf2+83H4aFBBHpTy0qmkqenVCVXb1m4PCA==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4834,12 +4846,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-ZgraJnaP9nsp+p8H2qiJ6G2MLAjomzd2vzZEj7JkVO8WrTS2XQcmAvtJZ7RS13RhQG08ZNUX9/cAnf0uJjoyFQ==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.10.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4855,12 +4867,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
+      "sha512": "sha512-BiGQ+/fmM7BUX4RPsEa8VT8i7hIFLmpyy54KLl+ws66LBBOjOQIncVbW0UGFvh6o2b+yp03gFOyouM0x4c0eJA==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.110",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.110.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4869,12 +4881,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.1",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aGSnO2BFd2ixPoInj6hp6DLAqolvpxAU4beCqLMOmSxCdGWCl8I9XTB4KSRC3ysatz96kkII9bMH9n/CofwBSw==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.2.nupkg.sha512"
+      "sha512": "sha512-/mFvAcFRwQ2e3latJkhvDcnm0+sIYpq741Q1Bn5IiIVKdIEG7VeBF96pgsoAdXFrysJskJKH5Dq/iiVKIU/7MQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.13-Preview": {
       "type": "package",
@@ -5051,12 +5063,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
+      "sha512": "sha512-Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.9",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.9.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5100,19 +5112,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
+      "sha512": "sha512-0xP9HmD2X4/6muiTNOKCUfc10zPlimqH+hf/rtmb9uEdsbM8CPrKms+GUbH2wdoqRXALLOYr/fOpoMlbvDY48g==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.10.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-REKLGEdLhFPIgljYQxfp/xxpbhoKRu82v9H0zohK97+9kokjZg9l2LqY3W8QNoqBjTCQ1IBHr3pEMHJNjcRGlw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5135,12 +5147,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-tgpXYliHOzrs2/qB5xxy1Cip8BkFl2Qz1mv7WEOoxXIyZVHYkgufFo0V+5YzQFLViIbJzpwSMLVHiM2+4uaCWw==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.10.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -5149,19 +5161,19 @@
       "path": "microsoft.durabletask.grpc/1.24.2",
       "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.6.0": {
+    "Microsoft.DurableTask.SqlServer/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-V6befDIGgScaR1lIFTi3B36NYsQ2crbwNe0E9d4gpojMBd/NfbLdpwqj6b/xI57YBZEbJ9+OtiDIgSSkEjntTg==",
-      "path": "microsoft.durabletask.sqlserver/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.6.0.nupkg.sha512"
+      "sha512": "sha512-Vu7EMVcNOu90eCqnOmjchzWROs6ZsqoL3FObKL9uTWM+bsAq4J/An60BBlrgdZfx+fnqo3NkybLHQL5uRS4wJQ==",
+      "path": "microsoft.durabletask.sqlserver/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-luzyU+wE8AVNI/qeDqS9A4SU+An8aKvdnpvhuV3ohoPrfZcA5jRhj2WoC+BBoajeuCHECuM0Mw1GXHrgpXclTw==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
+      "sha512": "sha512-8pH9G65T/QTg33u+Fn2QCa/g7/zeJ0rSsz2T+kEtiBOy5KWvF8v0KZkxcZf85/JpNP5+jv2tXViPTgzFVSNzcA==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.8.1.nupkg.sha512"
     },
     "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
@@ -5660,6 +5672,20 @@
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
     },
+    "protobuf-net.Core/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-8kpui+OKAr/IzFfdvkqGcIO859riNT1bp5hLKudY55lHd9oS3daHkvA9XyXiC+yGLRpg+XCc+ZUkNA8u8sXJTw==",
+      "path": "protobuf-net.core/3.2.12",
+      "hashPath": "protobuf-net.core.3.2.12.nupkg.sha512"
+    },
+    "protobuf-net.Reflection/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bpNTENWPqP2mx1sJJ5C6qZ2xP+f/E3dQF9MYY+xZ+RHxe3sLg+sPyBSCcJDTCY0e4dVIwQ/02gS8m4tVClDoKQ==",
+      "path": "protobuf-net.reflection/3.2.12",
+      "hashPath": "protobuf-net.reflection.3.2.12.nupkg.sha512"
+    },
     "RabbitMQ.Client/6.8.1": {
       "type": "package",
       "serviceable": true,
@@ -6017,12 +6043,12 @@
       "path": "system.clientmodel/1.8.0",
       "hashPath": "system.clientmodel.1.8.0.nupkg.sha512"
     },
-    "System.CodeDom/4.4.0": {
+    "System.CodeDom/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2sCCb7doXEwtYAbqzbF/8UAeDRMNmPaQbU2q50Psg1J9KzumyVVCgKQY8s53WIPTufNT0DpSe9QRvVjOzfDWBA==",
-      "path": "system.codedom/4.4.0",
-      "hashPath": "system.codedom.4.4.0.nupkg.sha512"
+      "sha512": "sha512-WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q==",
+      "path": "system.codedom/8.0.0",
+      "hashPath": "system.codedom.8.0.0.nupkg.sha512"
     },
     "System.Collections/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/win_x64_extensions.deps.json
@@ -12,17 +12,17 @@
           "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.6.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.10.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.110",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.19.0-alpha",
@@ -41,7 +41,7 @@
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.8.1",
           "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
@@ -50,18 +50,15 @@
           "extensions.dll": {}
         }
       },
-      "Apache.Avro/1.11.0": {
+      "Apache.Avro/1.12.0": {
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
-          "System.CodeDom": "4.4.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0"
+          "System.CodeDom": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/Avro.dll": {
-            "assemblyVersion": "1.11.0.0",
-            "fileVersion": "1.11.0.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         }
       },
@@ -79,7 +76,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -171,7 +168,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -312,58 +309,54 @@
           }
         }
       },
-      "Confluent.Kafka/2.4.0": {
+      "Confluent.Kafka/2.11.1": {
         "dependencies": {
-          "System.Memory": "4.5.5",
-          "librdkafka.redist": "2.4.0"
+          "librdkafka.redist": "2.11.1"
         },
         "runtime": {
-          "lib/net6.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/2.4.0": {
+      "Confluent.SchemaRegistry/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.Http": "4.3.4"
+          "Confluent.Kafka": "2.11.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
         "dependencies": {
-          "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "Apache.Avro": "1.12.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
           "Google.Protobuf": "3.34.1",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "protobuf-net.Reflection": "3.2.12"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
@@ -489,13 +482,13 @@
           }
         }
       },
-      "librdkafka.redist/2.4.0": {
+      "librdkafka.redist/2.11.1": {
         "native": {
           "runtimes/win-x64/native/libcrypto-3-x64.dll": {
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x64/native/libcurl.dll": {
-            "fileVersion": "7.86.0.0"
+            "fileVersion": "8.10.1.0"
           },
           "runtimes/win-x64/native/librdkafka.dll": {
             "fileVersion": "0.0.0.0"
@@ -504,13 +497,13 @@
             "fileVersion": "0.0.0.0"
           },
           "runtimes/win-x64/native/libssl-3-x64.dll": {
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x64/native/zlib1.dll": {
-            "fileVersion": "1.2.13.0"
+            "fileVersion": "1.3.1.0"
           },
           "runtimes/win-x64/native/zstd.dll": {
-            "fileVersion": "1.5.2.0"
+            "fileVersion": "1.5.6.0"
           }
         }
       },
@@ -903,7 +896,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -955,7 +948,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -970,7 +963,7 @@
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -1004,7 +997,7 @@
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1020,7 +1013,7 @@
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1065,13 +1058,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1081,8 +1074,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.26227"
+            "assemblyVersion": "1.6.0.0",
+            "fileVersion": "1.6.0.26380"
           }
         }
       },
@@ -1331,7 +1324,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
@@ -1346,12 +1339,12 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.13.1.0"
+            "fileVersion": "3.15.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1359,9 +1352,9 @@
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -1369,8 +1362,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -1402,7 +1395,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1418,12 +1411,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           }
         }
       },
@@ -1443,20 +1436,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.11.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.3.2.0"
+            "assemblyVersion": "4.3.3.0",
+            "fileVersion": "4.3.3.0"
           }
         }
       },
@@ -1480,7 +1473,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1815,11 +1808,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.8",
-            "fileVersion": "10.0.826.23019"
+            "assemblyVersion": "10.0.0.9",
+            "fileVersion": "10.0.926.27113"
           }
         }
       },
@@ -1910,7 +1903,7 @@
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -1923,37 +1916,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.10.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -2002,15 +1995,15 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -2018,8 +2011,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -2035,7 +2028,7 @@
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.6.0": {
+      "Microsoft.DurableTask.SqlServer/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -2043,25 +2036,25 @@
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Text.Json": "8.0.6"
+          "System.Drawing.Common": "4.7.3",
+          "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.DurableTask.SqlServer": "1.6.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.DurableTask.SqlServer": "1.8.1"
         },
         "runtime": {
-          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
@@ -2944,6 +2937,28 @@
           }
         }
       },
+      "protobuf-net.Core/3.2.12": {
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        },
+        "runtime": {
+          "lib/net6.0/protobuf-net.Core.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
+      "protobuf-net.Reflection/3.2.12": {
+        "dependencies": {
+          "protobuf-net.Core": "3.2.12"
+        },
+        "runtime": {
+          "lib/netstandard2.0/protobuf-net.Reflection.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
       "RabbitMQ.Client/6.8.1": {
         "dependencies": {
           "System.Memory": "4.5.5",
@@ -3183,11 +3198,11 @@
           }
         }
       },
-      "System.CodeDom/4.4.0": {
+      "System.CodeDom/8.0.0": {
         "runtime": {
-          "lib/netstandard2.0/System.CodeDom.dll": {
-            "assemblyVersion": "4.0.0.0",
-            "fileVersion": "4.6.25519.3"
+          "lib/net8.0/System.CodeDom.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -3494,7 +3509,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -4119,12 +4134,12 @@
       "serviceable": false,
       "sha512": ""
     },
-    "Apache.Avro/1.11.0": {
+    "Apache.Avro/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JpBxUTE/JeVt9yugkIiu0N+FHl+SIihDjs4VZsGFmlZM42nntj2QB8nAdj5yu8LOla54pSAQqdqHcxPa458KWQ==",
-      "path": "apache.avro/1.11.0",
-      "hashPath": "apache.avro.1.11.0.nupkg.sha512"
+      "sha512": "sha512-gFFnQ8j91zdbs5QvGo79139WnLpQB4rPbDx2Bnr664uBMSGhh422QsHd89Vv7WyT0+eT7qPL+6rZlnyor3aATw==",
+      "path": "apache.avro/1.12.0",
+      "hashPath": "apache.avro.1.12.0.nupkg.sha512"
     },
     "Azure.AI.OpenAI/2.1.0": {
       "type": "package",
@@ -4266,33 +4281,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/2.4.0": {
+    "Confluent.Kafka/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
-      "path": "confluent.kafka/2.4.0",
-      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
+      "sha512": "sha512-IV06YJSTsBvl4T282qlUADqQa5OPQOnZ+/+mQ8k0wVJy/GSjfFINamUk4zs/PtZ5+NpRdS5VHuQP7bJaTr9RBQ==",
+      "path": "confluent.kafka/2.11.1",
+      "hashPath": "confluent.kafka.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/2.4.0": {
+    "Confluent.SchemaRegistry/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
-      "path": "confluent.schemaregistry/2.4.0",
-      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
+      "sha512": "sha512-U8+hAp61TLgH0RM/JvvMdQq3x8ScLkmofX9l3I05tuQreT0fk6+iBvs/h2N/IQDgQtq/iNLgpiEFpNjoHjotAA==",
+      "path": "confluent.schemaregistry/2.11.1",
+      "hashPath": "confluent.schemaregistry.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
-      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
+      "sha512": "sha512-JEh6zmdwDanp2DQbAh16rkGp1pI4IyPB9S2BJAAgg/qf3pOeMG/vJR15IR8n7RUa+sP0IuV/vqRFLC4y4hotCQ==",
+      "path": "confluent.schemaregistry.serdes.avro/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
-      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
+      "sha512": "sha512-DXW8zTkhB4KTU1DxVf960RuDzfq+LeX1LW2tjppOENJkvUsEZWWdg3haUYdefQe2pa6O+6YcmRXBhgyNiMV1fQ==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.11.1.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4385,12 +4400,12 @@
       "path": "k4os.hash.xxhash/1.0.8",
       "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
     },
-    "librdkafka.redist/2.4.0": {
+    "librdkafka.redist/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
-      "path": "librdkafka.redist/2.4.0",
-      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+      "sha512": "sha512-fgzBgvnvDPyQ+VbGDs4piz7TYv2Gaz9niYv/ztwMoAQ+uyk0wTYR1NmyIKSN8JsE4hr5JHhDccSSNnbAFZQhBA==",
+      "path": "librdkafka.redist/2.11.1",
+      "hashPath": "librdkafka.redist.2.11.1.nupkg.sha512"
     },
     "MessagePack/2.5.301": {
       "type": "package",
@@ -4735,12 +4750,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
+      "sha512": "sha512-sAgPbq06jZzspaTb+6hF4sBkt+0VtH6gmDAfcupZFwyTdsmQHuICCyxPClQ1GKNNWQcqy5RrBxz5r8ZOfMuu8g==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.6.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.6.0.nupkg.sha512"
     },
     "Microsoft.Azure.Kusto.Cloud.Platform/12.2.8": {
       "type": "package",
@@ -4854,12 +4869,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
+      "sha512": "sha512-Eb1IGJmU5pMXCf/rd626vrUJoP6mqGC+ahuCWTC7jjVdsvaXPBZrtf2+83H4aFBBHpTy0qmkqenVCVXb1m4PCA==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4868,12 +4883,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-ZgraJnaP9nsp+p8H2qiJ6G2MLAjomzd2vzZEj7JkVO8WrTS2XQcmAvtJZ7RS13RhQG08ZNUX9/cAnf0uJjoyFQ==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.10.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4889,12 +4904,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
+      "sha512": "sha512-BiGQ+/fmM7BUX4RPsEa8VT8i7hIFLmpyy54KLl+ws66LBBOjOQIncVbW0UGFvh6o2b+yp03gFOyouM0x4c0eJA==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.110",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.110.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4903,12 +4918,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.1",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aGSnO2BFd2ixPoInj6hp6DLAqolvpxAU4beCqLMOmSxCdGWCl8I9XTB4KSRC3ysatz96kkII9bMH9n/CofwBSw==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.2.nupkg.sha512"
+      "sha512": "sha512-/mFvAcFRwQ2e3latJkhvDcnm0+sIYpq741Q1Bn5IiIVKdIEG7VeBF96pgsoAdXFrysJskJKH5Dq/iiVKIU/7MQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.13-Preview": {
       "type": "package",
@@ -5085,12 +5100,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
+      "sha512": "sha512-Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.9",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.9.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5134,19 +5149,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
+      "sha512": "sha512-0xP9HmD2X4/6muiTNOKCUfc10zPlimqH+hf/rtmb9uEdsbM8CPrKms+GUbH2wdoqRXALLOYr/fOpoMlbvDY48g==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.10.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-REKLGEdLhFPIgljYQxfp/xxpbhoKRu82v9H0zohK97+9kokjZg9l2LqY3W8QNoqBjTCQ1IBHr3pEMHJNjcRGlw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5169,12 +5184,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-tgpXYliHOzrs2/qB5xxy1Cip8BkFl2Qz1mv7WEOoxXIyZVHYkgufFo0V+5YzQFLViIbJzpwSMLVHiM2+4uaCWw==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.10.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -5183,19 +5198,19 @@
       "path": "microsoft.durabletask.grpc/1.24.2",
       "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.6.0": {
+    "Microsoft.DurableTask.SqlServer/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-V6befDIGgScaR1lIFTi3B36NYsQ2crbwNe0E9d4gpojMBd/NfbLdpwqj6b/xI57YBZEbJ9+OtiDIgSSkEjntTg==",
-      "path": "microsoft.durabletask.sqlserver/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.6.0.nupkg.sha512"
+      "sha512": "sha512-Vu7EMVcNOu90eCqnOmjchzWROs6ZsqoL3FObKL9uTWM+bsAq4J/An60BBlrgdZfx+fnqo3NkybLHQL5uRS4wJQ==",
+      "path": "microsoft.durabletask.sqlserver/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-luzyU+wE8AVNI/qeDqS9A4SU+An8aKvdnpvhuV3ohoPrfZcA5jRhj2WoC+BBoajeuCHECuM0Mw1GXHrgpXclTw==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
+      "sha512": "sha512-8pH9G65T/QTg33u+Fn2QCa/g7/zeJ0rSsz2T+kEtiBOy5KWvF8v0KZkxcZf85/JpNP5+jv2tXViPTgzFVSNzcA==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.8.1.nupkg.sha512"
     },
     "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
@@ -5694,6 +5709,20 @@
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
     },
+    "protobuf-net.Core/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-8kpui+OKAr/IzFfdvkqGcIO859riNT1bp5hLKudY55lHd9oS3daHkvA9XyXiC+yGLRpg+XCc+ZUkNA8u8sXJTw==",
+      "path": "protobuf-net.core/3.2.12",
+      "hashPath": "protobuf-net.core.3.2.12.nupkg.sha512"
+    },
+    "protobuf-net.Reflection/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bpNTENWPqP2mx1sJJ5C6qZ2xP+f/E3dQF9MYY+xZ+RHxe3sLg+sPyBSCcJDTCY0e4dVIwQ/02gS8m4tVClDoKQ==",
+      "path": "protobuf-net.reflection/3.2.12",
+      "hashPath": "protobuf-net.reflection.3.2.12.nupkg.sha512"
+    },
     "RabbitMQ.Client/6.8.1": {
       "type": "package",
       "serviceable": true,
@@ -6044,12 +6073,12 @@
       "path": "system.clientmodel/1.8.0",
       "hashPath": "system.clientmodel.1.8.0.nupkg.sha512"
     },
-    "System.CodeDom/4.4.0": {
+    "System.CodeDom/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2sCCb7doXEwtYAbqzbF/8UAeDRMNmPaQbU2q50Psg1J9KzumyVVCgKQY8s53WIPTufNT0DpSe9QRvVjOzfDWBA==",
-      "path": "system.codedom/4.4.0",
-      "hashPath": "system.codedom.4.4.0.nupkg.sha512"
+      "sha512": "sha512-WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q==",
+      "path": "system.codedom/8.0.0",
+      "hashPath": "system.codedom.8.0.0.nupkg.sha512"
     },
     "System.Collections/4.3.0": {
       "type": "package",

--- a/tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
+++ b/tests/ExtensionBundle.Tests/TestData/win_x86_extensions.deps.json
@@ -12,17 +12,17 @@
           "MessagePack": "2.5.301",
           "Microsoft.Azure.DurableTask.Netherite.AzureFunctions": "3.1.1",
           "Microsoft.Azure.Functions.Extensions.Connector": "0.2.0-alpha",
-          "Microsoft.Azure.Functions.Extensions.Mcp": "1.5.0",
+          "Microsoft.Azure.Functions.Extensions.Mcp": "1.6.0",
           "Microsoft.Azure.WebJobs.Extensions.AuthenticationEvents": "1.1.0",
           "Microsoft.Azure.WebJobs.Extensions.AzureCosmosDb.Mongo": "1.2.5-preview",
           "Microsoft.Azure.WebJobs.Extensions.CosmosDB": "4.16.1",
           "Microsoft.Azure.WebJobs.Extensions.Dapr": "0.17.0-preview01",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged": "1.10.0",
           "Microsoft.Azure.WebJobs.Extensions.EventGrid": "3.5.0",
           "Microsoft.Azure.WebJobs.Extensions.EventHubs": "6.5.3",
-          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.100",
-          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.2",
+          "Microsoft.Azure.WebJobs.Extensions.Fabric": "1.0.110",
+          "Microsoft.Azure.WebJobs.Extensions.Kafka": "4.3.3",
           "Microsoft.Azure.WebJobs.Extensions.Kusto": "1.0.13-Preview",
           "Microsoft.Azure.WebJobs.Extensions.MySql": "1.0.129",
           "Microsoft.Azure.WebJobs.Extensions.OpenAI": "0.19.0-alpha",
@@ -41,7 +41,7 @@
           "Microsoft.Azure.WebJobs.Extensions.Storage.Queues": "5.3.7",
           "Microsoft.Azure.WebJobs.Extensions.Twilio": "3.0.2",
           "Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO": "1.0.0",
-          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.6.0",
+          "Microsoft.DurableTask.SqlServer.AzureFunctions": "1.8.1",
           "Microsoft.NET.Sdk.Functions": "4.6.0",
           "System.Formats.Asn1": "6.0.1",
           "System.Reactive.Reference": "4.4.0.0"
@@ -50,18 +50,15 @@
           "extensions.dll": {}
         }
       },
-      "Apache.Avro/1.11.0": {
+      "Apache.Avro/1.12.0": {
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
-          "System.CodeDom": "4.4.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0"
+          "System.CodeDom": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.1/Avro.dll": {
-            "assemblyVersion": "1.11.0.0",
-            "fileVersion": "1.11.0.0"
+            "assemblyVersion": "1.12.0.0",
+            "fileVersion": "1.12.0.0"
           }
         }
       },
@@ -79,7 +76,7 @@
       },
       "Azure.Core/1.50.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.ClientModel": "1.8.0",
           "System.Memory.Data": "8.0.1"
         },
@@ -171,7 +168,7 @@
           "Azure.Messaging.EventHubs": "5.12.2",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.Amqp": "2.7.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.TypeExtensions": "4.7.0",
           "System.Threading.Channels": "8.0.0",
@@ -312,58 +309,54 @@
           }
         }
       },
-      "Confluent.Kafka/2.4.0": {
+      "Confluent.Kafka/2.11.1": {
         "dependencies": {
-          "System.Memory": "4.5.5",
-          "librdkafka.redist": "2.4.0"
+          "librdkafka.redist": "2.11.1"
         },
         "runtime": {
-          "lib/net6.0/Confluent.Kafka.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.Kafka.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry/2.4.0": {
+      "Confluent.SchemaRegistry/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Newtonsoft.Json": "13.0.3",
-          "System.Net.Http": "4.3.4"
+          "Confluent.Kafka": "2.11.1",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
         "dependencies": {
-          "Apache.Avro": "1.11.0",
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "Apache.Avro": "1.12.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Avro.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
-      "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+      "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
           "Google.Protobuf": "3.34.1",
-          "System.Net.NameResolution": "4.3.0",
-          "System.Net.Sockets": "4.3.0"
+          "protobuf-net.Reflection": "3.2.12"
         },
         "runtime": {
-          "lib/netstandard2.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
-            "assemblyVersion": "2.4.0.0",
-            "fileVersion": "2.4.0.0"
+          "lib/net8.0/Confluent.SchemaRegistry.Serdes.Protobuf.dll": {
+            "assemblyVersion": "2.11.1.0",
+            "fileVersion": "2.11.1.0"
           }
         }
       },
@@ -489,13 +482,13 @@
           }
         }
       },
-      "librdkafka.redist/2.4.0": {
+      "librdkafka.redist/2.11.1": {
         "native": {
           "runtimes/win-x86/native/libcrypto-3.dll": {
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x86/native/libcurl.dll": {
-            "fileVersion": "7.86.0.0"
+            "fileVersion": "8.10.1.0"
           },
           "runtimes/win-x86/native/librdkafka.dll": {
             "fileVersion": "0.0.0.0"
@@ -504,19 +497,19 @@
             "fileVersion": "0.0.0.0"
           },
           "runtimes/win-x86/native/libssl-3.dll": {
-            "fileVersion": "3.0.8.0"
+            "fileVersion": "3.3.2.0"
           },
           "runtimes/win-x86/native/msvcp140.dll": {
-            "fileVersion": "14.29.30040.0"
+            "fileVersion": "14.40.33816.0"
           },
           "runtimes/win-x86/native/vcruntime140.dll": {
-            "fileVersion": "14.29.30040.0"
+            "fileVersion": "14.40.33816.0"
           },
           "runtimes/win-x86/native/zlib1.dll": {
-            "fileVersion": "1.2.13.0"
+            "fileVersion": "1.3.1.0"
           },
           "runtimes/win-x86/native/zstd.dll": {
-            "fileVersion": "1.5.2.0"
+            "fileVersion": "1.5.6.0"
           }
         }
       },
@@ -909,7 +902,7 @@
       "Microsoft.Azure.Cosmos/3.60.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Bcl.HashCode": "1.1.0",
           "System.Buffers": "4.6.0",
           "System.Collections.Immutable": "8.0.0",
@@ -944,7 +937,7 @@
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/netstandard2.0/DurableTask.ApplicationInsights.dll": {
@@ -959,7 +952,7 @@
           "Azure.Storage.Blobs": "12.27.0",
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "System.Linq.Async": "6.0.1"
         },
         "runtime": {
@@ -993,7 +986,7 @@
           "Azure.Messaging.EventHubs.Processor": "5.11.5",
           "Azure.Storage.Blobs": "12.27.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.FASTER.Core": "2.6.5",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.6"
@@ -1009,7 +1002,7 @@
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
           "Microsoft.Azure.DurableTask.Netherite": "3.1.1",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
           "System.Text.Json": "8.0.6"
         },
         "runtime": {
@@ -1054,13 +1047,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+      "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
         "dependencies": {
           "Azure.Storage.Queues": "12.24.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.1",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.Azure": "1.13.1",
           "ModelContextProtocol": "0.4.0-preview.3",
           "System.Drawing.Common": "4.7.3",
@@ -1070,8 +1063,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.Functions.Extensions.Mcp.dll": {
-            "assemblyVersion": "1.5.0.0",
-            "fileVersion": "1.5.0.26227"
+            "assemblyVersion": "1.6.0.0",
+            "fileVersion": "1.6.0.26380"
           }
         }
       },
@@ -1320,7 +1313,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
         "dependencies": {
           "Azure.Identity": "1.17.1",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.3.0",
@@ -1335,12 +1328,12 @@
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.dll": {
             "assemblyVersion": "3.0.0.0",
-            "fileVersion": "3.13.1.0"
+            "fileVersion": "3.15.0.0"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {},
-      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+      "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1348,9 +1341,9 @@
           "Grpc.Net.Client": "2.76.0",
           "Grpc.Tools": "2.78.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend": "1.9.0",
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -1358,8 +1351,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -1391,7 +1384,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+      "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -1407,12 +1400,12 @@
         },
         "runtime": {
           "lib/netstandard2.1/Microsoft.Azure.Extensions.Fabric.Shared.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           },
           "lib/netstandard2.1/Microsoft.Azure.WebJobs.Extensions.Fabric.dll": {
-            "assemblyVersion": "1.0.100.0",
-            "fileVersion": "1.0.100.0"
+            "assemblyVersion": "1.0.110.0",
+            "fileVersion": "1.0.110.0"
           }
         }
       },
@@ -1432,20 +1425,20 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+      "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
         "dependencies": {
-          "Confluent.Kafka": "2.4.0",
-          "Confluent.SchemaRegistry": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Avro": "2.4.0",
-          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.4.0",
+          "Confluent.Kafka": "2.11.1",
+          "Confluent.SchemaRegistry": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.11.1",
+          "Confluent.SchemaRegistry.Serdes.Protobuf": "2.11.1",
           "Microsoft.Azure.WebJobs": "3.0.45",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Kafka.dll": {
-            "assemblyVersion": "4.3.2.0",
-            "fileVersion": "4.3.2.0"
+            "assemblyVersion": "4.3.3.0",
+            "fileVersion": "4.3.3.0"
           }
         }
       },
@@ -1469,7 +1462,7 @@
           "Microsoft.ApplicationInsights": "2.23.0",
           "Microsoft.AspNetCore.Http": "2.3.0",
           "Microsoft.Azure.WebJobs": "3.0.45",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.SqlServer.TransactSql.ScriptDom": "161.9135.0",
           "MySql.Data": "9.0.0",
           "Newtonsoft.Json": "13.0.3",
@@ -1804,11 +1797,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+      "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
-            "assemblyVersion": "10.0.0.8",
-            "fileVersion": "10.0.826.23019"
+            "assemblyVersion": "10.0.0.9",
+            "fileVersion": "10.0.926.27113"
           }
         }
       },
@@ -1899,7 +1892,7 @@
       "Microsoft.DurableTask.Abstractions/1.24.2": {
         "dependencies": {
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "System.Collections.Immutable": "8.0.0",
@@ -1912,37 +1905,37 @@
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
-          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.9.0",
+          "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged": "1.10.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
-      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+      "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
         "dependencies": {
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0"
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.AzureManagedBackend.Protobuf.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -1991,15 +1984,15 @@
           }
         }
       },
-      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+      "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
           "Google.Protobuf": "3.34.1",
           "Grpc.Net.Client": "2.76.0",
           "Microsoft.Azure.DurableTask.Core": "3.9.0",
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8",
-          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.9.0",
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9",
+          "Microsoft.DurableTask.AzureManagedBackend.Protobuf": "1.10.0",
           "Microsoft.DurableTask.Extensions.AzureBlobPayloads": "1.24.2",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
           "System.Text.Json": "8.0.6",
@@ -2007,8 +2000,8 @@
         },
         "runtime": {
           "lib/net8.0/Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged.dll": {
-            "assemblyVersion": "1.9.0.0",
-            "fileVersion": "1.9.0.26961"
+            "assemblyVersion": "1.10.0.0",
+            "fileVersion": "1.10.0.19286"
           }
         }
       },
@@ -2024,7 +2017,7 @@
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer/1.6.0": {
+      "Microsoft.DurableTask.SqlServer/1.8.1": {
         "dependencies": {
           "Azure.Core": "1.50.0",
           "Azure.Identity": "1.17.1",
@@ -2032,25 +2025,25 @@
           "Microsoft.Data.SqlClient": "5.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "7.5.1",
           "SemanticVersion": "2.1.0",
-          "System.IdentityModel.Tokens.Jwt": "7.5.1",
-          "System.Text.Json": "8.0.6"
+          "System.Drawing.Common": "4.7.3",
+          "System.IdentityModel.Tokens.Jwt": "7.5.1"
         },
         "runtime": {
-          "lib/netstandard2.0/DurableTask.SqlServer.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
-      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+      "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.13.1",
-          "Microsoft.DurableTask.SqlServer": "1.6.0"
+          "Microsoft.Azure.WebJobs.Extensions.DurableTask": "3.15.0",
+          "Microsoft.DurableTask.SqlServer": "1.8.1"
         },
         "runtime": {
-          "lib/net6.0/DurableTask.SqlServer.AzureFunctions.dll": {
-            "assemblyVersion": "1.6.0.0",
-            "fileVersion": "1.6.0.4247"
+          "lib/net8.0/DurableTask.SqlServer.AzureFunctions.dll": {
+            "assemblyVersion": "1.8.0.0",
+            "fileVersion": "1.8.1.34310"
           }
         }
       },
@@ -2916,6 +2909,28 @@
           }
         }
       },
+      "protobuf-net.Core/3.2.12": {
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        },
+        "runtime": {
+          "lib/net6.0/protobuf-net.Core.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
+      "protobuf-net.Reflection/3.2.12": {
+        "dependencies": {
+          "protobuf-net.Core": "3.2.12"
+        },
+        "runtime": {
+          "lib/netstandard2.0/protobuf-net.Reflection.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.2.12.9385"
+          }
+        }
+      },
       "RabbitMQ.Client/6.8.1": {
         "dependencies": {
           "System.Memory": "4.5.5",
@@ -3155,11 +3170,11 @@
           }
         }
       },
-      "System.CodeDom/4.4.0": {
+      "System.CodeDom/8.0.0": {
         "runtime": {
-          "lib/netstandard2.0/System.CodeDom.dll": {
-            "assemblyVersion": "4.0.0.0",
-            "fileVersion": "4.6.25519.3"
+          "lib/net8.0/System.CodeDom.dll": {
+            "assemblyVersion": "8.0.0.0",
+            "fileVersion": "8.0.23.53103"
           }
         }
       },
@@ -3466,7 +3481,7 @@
       },
       "System.Linq.Async/6.0.1": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "10.0.8"
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.9"
         },
         "runtime": {
           "lib/net6.0/System.Linq.Async.dll": {
@@ -4091,12 +4106,12 @@
       "serviceable": false,
       "sha512": ""
     },
-    "Apache.Avro/1.11.0": {
+    "Apache.Avro/1.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-JpBxUTE/JeVt9yugkIiu0N+FHl+SIihDjs4VZsGFmlZM42nntj2QB8nAdj5yu8LOla54pSAQqdqHcxPa458KWQ==",
-      "path": "apache.avro/1.11.0",
-      "hashPath": "apache.avro.1.11.0.nupkg.sha512"
+      "sha512": "sha512-gFFnQ8j91zdbs5QvGo79139WnLpQB4rPbDx2Bnr664uBMSGhh422QsHd89Vv7WyT0+eT7qPL+6rZlnyor3aATw==",
+      "path": "apache.avro/1.12.0",
+      "hashPath": "apache.avro.1.12.0.nupkg.sha512"
     },
     "Azure.AI.OpenAI/2.1.0": {
       "type": "package",
@@ -4238,33 +4253,33 @@
       "path": "cloudnative.cloudevents.systemtextjson/2.6.0",
       "hashPath": "cloudnative.cloudevents.systemtextjson.2.6.0.nupkg.sha512"
     },
-    "Confluent.Kafka/2.4.0": {
+    "Confluent.Kafka/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3xrE8SUSLN10klkDaXFBAiXxTc+2wMffvjcZ3RUyvOo2ckaRJZ3dY7yjs6R7at7+tjUiuq2OlyTiEaV6G9zFHA==",
-      "path": "confluent.kafka/2.4.0",
-      "hashPath": "confluent.kafka.2.4.0.nupkg.sha512"
+      "sha512": "sha512-IV06YJSTsBvl4T282qlUADqQa5OPQOnZ+/+mQ8k0wVJy/GSjfFINamUk4zs/PtZ5+NpRdS5VHuQP7bJaTr9RBQ==",
+      "path": "confluent.kafka/2.11.1",
+      "hashPath": "confluent.kafka.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry/2.4.0": {
+    "Confluent.SchemaRegistry/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-NBIPOvVjvmaSdWUf+J8igmtGRJmsVRiI5CwHdmuz+zATawLFgxDNJxJPhpYYLJnLk504wrjAy8JmeWjkHbiqNA==",
-      "path": "confluent.schemaregistry/2.4.0",
-      "hashPath": "confluent.schemaregistry.2.4.0.nupkg.sha512"
+      "sha512": "sha512-U8+hAp61TLgH0RM/JvvMdQq3x8ScLkmofX9l3I05tuQreT0fk6+iBvs/h2N/IQDgQtq/iNLgpiEFpNjoHjotAA==",
+      "path": "confluent.schemaregistry/2.11.1",
+      "hashPath": "confluent.schemaregistry.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Avro/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Avro/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-89xbRmZhmxl7JdXeeAIkv8AwQsun7koARMHIgiWIMDMfVgmyNYpWlQK41XEyZ/8kIV/HUQuEtZZLYh23glbpdA==",
-      "path": "confluent.schemaregistry.serdes.avro/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.avro.2.4.0.nupkg.sha512"
+      "sha512": "sha512-JEh6zmdwDanp2DQbAh16rkGp1pI4IyPB9S2BJAAgg/qf3pOeMG/vJR15IR8n7RUa+sP0IuV/vqRFLC4y4hotCQ==",
+      "path": "confluent.schemaregistry.serdes.avro/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.avro.2.11.1.nupkg.sha512"
     },
-    "Confluent.SchemaRegistry.Serdes.Protobuf/2.4.0": {
+    "Confluent.SchemaRegistry.Serdes.Protobuf/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-RC128zwUo081k+BQeIVA7CMBrsjhZ6lIOsyY8dL2IuXlekhZF5zsUSo32vgjrxUJvC1i2eY2ZZRfBYz82tJN4g==",
-      "path": "confluent.schemaregistry.serdes.protobuf/2.4.0",
-      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.4.0.nupkg.sha512"
+      "sha512": "sha512-DXW8zTkhB4KTU1DxVf960RuDzfq+LeX1LW2tjppOENJkvUsEZWWdg3haUYdefQe2pa6O+6YcmRXBhgyNiMV1fQ==",
+      "path": "confluent.schemaregistry.serdes.protobuf/2.11.1",
+      "hashPath": "confluent.schemaregistry.serdes.protobuf.2.11.1.nupkg.sha512"
     },
     "DnsClient/1.6.1": {
       "type": "package",
@@ -4357,12 +4372,12 @@
       "path": "k4os.hash.xxhash/1.0.8",
       "hashPath": "k4os.hash.xxhash.1.0.8.nupkg.sha512"
     },
-    "librdkafka.redist/2.4.0": {
+    "librdkafka.redist/2.11.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uqi1sNe0LEV50pYXZ3mYNJfZFF1VmsZ6m8wbpWugAAPOzOcX8FJP5FOhLMoUKVFiuenBH2v8zVBht7f1RCs3rA==",
-      "path": "librdkafka.redist/2.4.0",
-      "hashPath": "librdkafka.redist.2.4.0.nupkg.sha512"
+      "sha512": "sha512-fgzBgvnvDPyQ+VbGDs4piz7TYv2Gaz9niYv/ztwMoAQ+uyk0wTYR1NmyIKSN8JsE4hr5JHhDccSSNnbAFZQhBA==",
+      "path": "librdkafka.redist/2.11.1",
+      "hashPath": "librdkafka.redist.2.11.1.nupkg.sha512"
     },
     "MessagePack/2.5.301": {
       "type": "package",
@@ -4707,12 +4722,12 @@
       "path": "microsoft.azure.functions.extensions.dapr.core/0.17.0-preview01",
       "hashPath": "microsoft.azure.functions.extensions.dapr.core.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.Extensions.Mcp/1.5.0": {
+    "Microsoft.Azure.Functions.Extensions.Mcp/1.6.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OzglE9PYAB09b9n5IZZMtyMh0BUkHeRuxXocsOlbGk/6v/hBvJIK7i1WsGXhk3pyPGP7YCNQnuFi0YWxCeQ+Pw==",
-      "path": "microsoft.azure.functions.extensions.mcp/1.5.0",
-      "hashPath": "microsoft.azure.functions.extensions.mcp.1.5.0.nupkg.sha512"
+      "sha512": "sha512-sAgPbq06jZzspaTb+6hF4sBkt+0VtH6gmDAfcupZFwyTdsmQHuICCyxPClQ1GKNNWQcqy5RrBxz5r8ZOfMuu8g==",
+      "path": "microsoft.azure.functions.extensions.mcp/1.6.0",
+      "hashPath": "microsoft.azure.functions.extensions.mcp.1.6.0.nupkg.sha512"
     },
     "Microsoft.Azure.Kusto.Cloud.Platform/12.2.8": {
       "type": "package",
@@ -4826,12 +4841,12 @@
       "path": "microsoft.azure.webjobs.extensions.dapr/0.17.0-preview01",
       "hashPath": "microsoft.azure.webjobs.extensions.dapr.0.17.0-preview01.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.13.1": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask/3.15.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lIdzf5eluOoD6numPn7EKO9mic5Oct4pgd4Pcds+XRMc/BehqNg6RqGo3yKBBxIx+6U9YmMpbGdZOeX0jhSD7Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask/3.13.1",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.13.1.nupkg.sha512"
+      "sha512": "sha512-Eb1IGJmU5pMXCf/rd626vrUJoP6mqGC+ahuCWTC7jjVdsvaXPBZrtf2+83H4aFBBHpTy0qmkqenVCVXb1m4PCA==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask/3.15.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.3.15.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.DurableTask.Analyzers/0.5.0": {
       "type": "package",
@@ -4840,12 +4855,12 @@
       "path": "microsoft.azure.webjobs.extensions.durabletask.analyzers/0.5.0",
       "hashPath": "microsoft.azure.webjobs.extensions.durabletask.analyzers.0.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.9.0": {
+    "Microsoft.Azure.WebJobs.Extensions.DurableTask.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-LU4r9UFJuaHzy/JuE18jUGFCHmlHfXYGUoiegus1fFYYhHF55I+gPK5mWJfUSip4EjkG/Z9ygx6znqe04+cp9Q==",
-      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.9.0",
-      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-ZgraJnaP9nsp+p8H2qiJ6G2MLAjomzd2vzZEj7JkVO8WrTS2XQcmAvtJZ7RS13RhQG08ZNUX9/cAnf0uJjoyFQ==",
+      "path": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged/1.10.0",
+      "hashPath": "microsoft.azure.webjobs.extensions.durabletask.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.EventGrid/3.5.0": {
       "type": "package",
@@ -4861,12 +4876,12 @@
       "path": "microsoft.azure.webjobs.extensions.eventhubs/6.5.3",
       "hashPath": "microsoft.azure.webjobs.extensions.eventhubs.6.5.3.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.100": {
+    "Microsoft.Azure.WebJobs.Extensions.Fabric/1.0.110": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-oEVfZaQWHPzK2kep+NWBeaAAXPxF8wTeU8YXD5w9jS51BU5gxkiGmzgO+CVsr2KteMkI2913ZnY9f2tULqEygw==",
-      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.100",
-      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.100.nupkg.sha512"
+      "sha512": "sha512-BiGQ+/fmM7BUX4RPsEa8VT8i7hIFLmpyy54KLl+ws66LBBOjOQIncVbW0UGFvh6o2b+yp03gFOyouM0x4c0eJA==",
+      "path": "microsoft.azure.webjobs.extensions.fabric/1.0.110",
+      "hashPath": "microsoft.azure.webjobs.extensions.fabric.1.0.110.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.1": {
       "type": "package",
@@ -4875,12 +4890,12 @@
       "path": "microsoft.azure.webjobs.extensions.http/3.2.1",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.2": {
+    "Microsoft.Azure.WebJobs.Extensions.Kafka/4.3.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aGSnO2BFd2ixPoInj6hp6DLAqolvpxAU4beCqLMOmSxCdGWCl8I9XTB4KSRC3ysatz96kkII9bMH9n/CofwBSw==",
-      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.2",
-      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.2.nupkg.sha512"
+      "sha512": "sha512-/mFvAcFRwQ2e3latJkhvDcnm0+sIYpq741Q1Bn5IiIVKdIEG7VeBF96pgsoAdXFrysJskJKH5Dq/iiVKIU/7MQ==",
+      "path": "microsoft.azure.webjobs.extensions.kafka/4.3.3",
+      "hashPath": "microsoft.azure.webjobs.extensions.kafka.4.3.3.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Kusto/1.0.13-Preview": {
       "type": "package",
@@ -5057,12 +5072,12 @@
       "path": "microsoft.azure.webpubsub.common/1.5.0",
       "hashPath": "microsoft.azure.webpubsub.common.1.5.0.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/10.0.8": {
+    "Microsoft.Bcl.AsyncInterfaces/10.0.9": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-e+kYYRb0HmNo5FTOcjXkP0mIEFHEyygm4ea/iLWpdumsACzCH078nZMfnk6RQFmtSrnNbh654c8nNtmUSwQoow==",
-      "path": "microsoft.bcl.asyncinterfaces/10.0.8",
-      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.8.nupkg.sha512"
+      "sha512": "sha512-Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow==",
+      "path": "microsoft.bcl.asyncinterfaces/10.0.9",
+      "hashPath": "microsoft.bcl.asyncinterfaces.10.0.9.nupkg.sha512"
     },
     "Microsoft.Bcl.HashCode/1.1.0": {
       "type": "package",
@@ -5106,19 +5121,19 @@
       "path": "microsoft.durabletask.abstractions/1.24.2",
       "hashPath": "microsoft.durabletask.abstractions.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2C0xLirYzWLC7PHkuSCXiKHhJGwvzN0sUVLjILP5PbRNWRk06pUTy/4Q2H9gMYU49UradHfrkW6EE4q9xyAuvg==",
-      "path": "microsoft.durabletask.azuremanagedbackend/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.9.0.nupkg.sha512"
+      "sha512": "sha512-0xP9HmD2X4/6muiTNOKCUfc10zPlimqH+hf/rtmb9uEdsbM8CPrKms+GUbH2wdoqRXALLOYr/fOpoMlbvDY48g==",
+      "path": "microsoft.durabletask.azuremanagedbackend/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.1.10.0.nupkg.sha512"
     },
-    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.9.0": {
+    "Microsoft.DurableTask.AzureManagedBackend.Protobuf/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-aaNCASJqkIkcfBhqe+T9QsiGo+XRD6mu8aSLfA7QzwUB7vsnEYJXyxLukgES+bdBTLYEf/V7saZ9GynYjyj6/A==",
-      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.9.0",
-      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.9.0.nupkg.sha512"
+      "sha512": "sha512-REKLGEdLhFPIgljYQxfp/xxpbhoKRu82v9H0zohK97+9kokjZg9l2LqY3W8QNoqBjTCQ1IBHr3pEMHJNjcRGlw==",
+      "path": "microsoft.durabletask.azuremanagedbackend.protobuf/1.10.0",
+      "hashPath": "microsoft.durabletask.azuremanagedbackend.protobuf.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Client/1.24.2": {
       "type": "package",
@@ -5141,12 +5156,12 @@
       "path": "microsoft.durabletask.extensions.azureblobpayloads/1.24.2",
       "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.9.0": {
+    "Microsoft.DurableTask.Extensions.AzureBlobPayloads.AzureManaged/1.10.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-bp+lVqj4B1CQBkFr205/ej2GU9ibTWGhkGxaVxpfc77Y4ONSIV/53GBKZTP4ruPAGyu+2H6T/ggWsaV4JhQzSA==",
-      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.9.0",
-      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.9.0.nupkg.sha512"
+      "sha512": "sha512-tgpXYliHOzrs2/qB5xxy1Cip8BkFl2Qz1mv7WEOoxXIyZVHYkgufFo0V+5YzQFLViIbJzpwSMLVHiM2+4uaCWw==",
+      "path": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged/1.10.0",
+      "hashPath": "microsoft.durabletask.extensions.azureblobpayloads.azuremanaged.1.10.0.nupkg.sha512"
     },
     "Microsoft.DurableTask.Grpc/1.24.2": {
       "type": "package",
@@ -5155,19 +5170,19 @@
       "path": "microsoft.durabletask.grpc/1.24.2",
       "hashPath": "microsoft.durabletask.grpc.1.24.2.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer/1.6.0": {
+    "Microsoft.DurableTask.SqlServer/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-V6befDIGgScaR1lIFTi3B36NYsQ2crbwNe0E9d4gpojMBd/NfbLdpwqj6b/xI57YBZEbJ9+OtiDIgSSkEjntTg==",
-      "path": "microsoft.durabletask.sqlserver/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.1.6.0.nupkg.sha512"
+      "sha512": "sha512-Vu7EMVcNOu90eCqnOmjchzWROs6ZsqoL3FObKL9uTWM+bsAq4J/An60BBlrgdZfx+fnqo3NkybLHQL5uRS4wJQ==",
+      "path": "microsoft.durabletask.sqlserver/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.1.8.1.nupkg.sha512"
     },
-    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.6.0": {
+    "Microsoft.DurableTask.SqlServer.AzureFunctions/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-luzyU+wE8AVNI/qeDqS9A4SU+An8aKvdnpvhuV3ohoPrfZcA5jRhj2WoC+BBoajeuCHECuM0Mw1GXHrgpXclTw==",
-      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.6.0",
-      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.6.0.nupkg.sha512"
+      "sha512": "sha512-8pH9G65T/QTg33u+Fn2QCa/g7/zeJ0rSsz2T+kEtiBOy5KWvF8v0KZkxcZf85/JpNP5+jv2tXViPTgzFVSNzcA==",
+      "path": "microsoft.durabletask.sqlserver.azurefunctions/1.8.1",
+      "hashPath": "microsoft.durabletask.sqlserver.azurefunctions.1.8.1.nupkg.sha512"
     },
     "Microsoft.DurableTask.Worker/1.24.2": {
       "type": "package",
@@ -5666,6 +5681,20 @@
       "path": "pipelines.sockets.unofficial/2.2.8",
       "hashPath": "pipelines.sockets.unofficial.2.2.8.nupkg.sha512"
     },
+    "protobuf-net.Core/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-8kpui+OKAr/IzFfdvkqGcIO859riNT1bp5hLKudY55lHd9oS3daHkvA9XyXiC+yGLRpg+XCc+ZUkNA8u8sXJTw==",
+      "path": "protobuf-net.core/3.2.12",
+      "hashPath": "protobuf-net.core.3.2.12.nupkg.sha512"
+    },
+    "protobuf-net.Reflection/3.2.12": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bpNTENWPqP2mx1sJJ5C6qZ2xP+f/E3dQF9MYY+xZ+RHxe3sLg+sPyBSCcJDTCY0e4dVIwQ/02gS8m4tVClDoKQ==",
+      "path": "protobuf-net.reflection/3.2.12",
+      "hashPath": "protobuf-net.reflection.3.2.12.nupkg.sha512"
+    },
     "RabbitMQ.Client/6.8.1": {
       "type": "package",
       "serviceable": true,
@@ -6016,12 +6045,12 @@
       "path": "system.clientmodel/1.8.0",
       "hashPath": "system.clientmodel.1.8.0.nupkg.sha512"
     },
-    "System.CodeDom/4.4.0": {
+    "System.CodeDom/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2sCCb7doXEwtYAbqzbF/8UAeDRMNmPaQbU2q50Psg1J9KzumyVVCgKQY8s53WIPTufNT0DpSe9QRvVjOzfDWBA==",
-      "path": "system.codedom/4.4.0",
-      "hashPath": "system.codedom.4.4.0.nupkg.sha512"
+      "sha512": "sha512-WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q==",
+      "path": "system.codedom/8.0.0",
+      "hashPath": "system.codedom.8.0.0.nupkg.sha512"
     },
     "System.Collections/4.3.0": {
       "type": "package",


### PR DESCRIPTION
# Pull Request

## Description

Prepare the Preview extension bundle for 4.47.0 and refresh dependency baselines for the reviewed Kafka 4.3.3 update. Add a repository skill documenting the repeatable dependency-bump review workflow.

The dependency update is safe because Kafka is the only extension consuming the changed `System.CodeDom` dependency path, and `System.CodeDom` is not listed in the Functions host runtime assembly manifest.

## Issue Link

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring
- [x] Testing

## Branch Propagation

- [ ] main
- [x] main-preview
- [ ] main-experimental
- [ ] main-v2
- [ ] main-v3

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added/updated emulator tests that prove my fix or feature works
- [x] I have updated relevant documentation
- [x] I have verified my changes in a local environment or internal build artifact
- [ ] I have added appropriate comments to complex code

## Documentation Updates

Added `.github/skills/extension-bundle-dependency-review/SKILL.md`.

## Additional Information

- Public scheduled build `300560` succeeded and the immediately following build `300826` failed on the same commit.
- Kafka 4.3.3 was published to the repository-configured `upstream-public` feed between those builds.
- Dependency path: Kafka -> Confluent Schema Registry Avro serializer -> Apache.Avro -> System.CodeDom.
- Kafka is the only extension consumer found in `function.deps.json`.
- `System.CodeDom` is absent from the Functions host `runtimeassemblies.json`.
- Linux data came from internal build `300812`; its Build stage succeeded, and the `linux-x64` ZIP contains the same reviewed dependency update.
- Updated `any_any`, `win_x64`, `win_x86`, and `linux_x64` dependency baselines.
- Local unit tests: 4 passed, 0 failed.
